### PR TITLE
Fix ride map not displaying track polylines

### DIFF
--- a/assets/controllers/map/ride_map_controller.js
+++ b/assets/controllers/map/ride_map_controller.js
@@ -73,7 +73,7 @@ export default class extends BaseMapController {
             const trackLayer = L.featureGroup();
 
             for (const track of trackList) {
-                const polylineString = track.polylineString || track.polyline;
+                const polylineString = this.getPolylineFromTrack(track);
                 if (!polylineString || !track.user) continue;
 
                 const { color_red, color_green, color_blue } = track.user;
@@ -147,6 +147,18 @@ export default class extends BaseMapController {
         } catch (err) {
             console.warn('Ride photos load failed', err);
         }
+    }
+
+    getPolylineFromTrack(track) {
+        if (track.track_polylines && track.track_polylines.length) {
+            const preferred = track.track_polylines.find(p => p.resolution && p.resolution.value === 10)
+                || track.track_polylines.find(p => p.resolution && p.resolution.value === 2)
+                || track.track_polylines[0];
+
+            return preferred.polyline;
+        }
+
+        return track.polylineString || track.polyline || null;
     }
 
     getPhotoIcon() {


### PR DESCRIPTION
## Summary

- Fix track polylines not rendering on ride detail pages (e.g. `/potsdam/2026-01-01`)
- The `ride_map_controller.js` was looking for `track.polylineString` or `track.polyline`, but since the TrackPolyline entity migration these properties no longer exist on the serialized track object
- The polyline data is now in `track.track_polylines[].polyline` — added `getPolylineFromTrack()` method that reads from this array, preferring MEDIUM resolution (value=10) for map display, falling back to FINE or the first available polyline

## Test plan

- [ ] Open a ride page with tracks (e.g. `/potsdam/2026-01-01`) — track polyline should now be visible on the map
- [ ] Verify the map auto-zooms to fit the track extent
- [ ] Check browser console for no JS errors
- [ ] Build frontend assets with `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)