### PR TITLE
Fix crash on trailing hyphen in ride URL

### DIFF
--- a/src/ValueResolver/RideValueResolver.php
+++ b/src/ValueResolver/RideValueResolver.php
@@ -40,11 +40,15 @@ class RideValueResolver implements ValueResolverInterface
     {
         $parts = explode('-', $rideDate);
 
-        return match (count($parts)) {
-            2 => new \DateTime("{$parts[0]}-{$parts[1]}-01"),
-            3 => new \DateTime("{$parts[0]}-{$parts[1]}-{$parts[2]}"),
-            default => null,
-        };
+        try {
+            return match (count($parts)) {
+                2 => new \DateTime("{$parts[0]}-{$parts[1]}-01"),
+                3 => new \DateTime("{$parts[0]}-{$parts[1]}-{$parts[2]}"),
+                default => null,
+            };
+        } catch (\Exception) {
+            return null;
+        }
     }
 
     private function findRideById(Request $request): ?Ride

--- a/src/ValueResolver/RideValueResolver.php
+++ b/src/ValueResolver/RideValueResolver.php
@@ -56,7 +56,7 @@ class RideValueResolver implements ValueResolverInterface
     private function findRideBySlugs(Request $request): ?Ride
     {
         $citySlug = $request->get('citySlug');
-        $rideIdentifier = $request->get('rideIdentifier');
+        $rideIdentifier = rtrim($request->get('rideIdentifier'), '-');
 
         if (!$citySlug || !$rideIdentifier) {
             return null;


### PR DESCRIPTION
## Summary
- Strip trailing hyphens from `rideIdentifier` so URLs like `/berlin/2026-02-` resolve correctly instead of crashing
- Wrap `guessDateTime()` in try-catch to handle invalid dates (e.g. `2026-13-45`) gracefully with a 404

## Test plan
- [ ] Visit `/berlin/2026-02-` — should resolve to the February ride (same as `/berlin/2026-02`)
- [ ] Visit `/berlin/2026-13-45` — should return 404
- [ ] Visit `/berlin/2026-02-28` — should still work as before
- [ ] `vendor/bin/phpstan analyse src/ValueResolver/RideValueResolver.php` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)