### PR TITLE
Add migration to convert rideType ENUM to VARCHAR

### DIFF
--- a/migrations/Version20260314120000.php
+++ b/migrations/Version20260314120000.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260314120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Convert rideType column from ENUM to VARCHAR(255)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE ride MODIFY rideType VARCHAR(255) DEFAULT NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- Add migration to convert the `rideType` column from ENUM to VARCHAR(255)
- Same issue as `disabledReason` (fixed in #1342): column is ENUM in DB but mapped as VARCHAR in entity, causing DBAL 4 compatibility issues

## Test plan
- [ ] PHPStan passes
- [ ] PHPUnit passes
- [ ] Migration runs without errors on production database

🤖 Generated with [Claude Code](https://claude.com/claude-code)