### PR TITLE
Change email sender to configurable noreply address

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,6 +2,7 @@ APP_ENV=dev
 APP_SECRET=change-me
 
 MAILER_DSN=null://null
+MAILER_SENDER=noreply@criticalmass.in
 
 FB_ID=
 FB_SECRET=

--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -2,4 +2,4 @@ framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'
         envelope:
-            sender: 'malte@criticalmass.in'
+            sender: 'noreply@criticalmass.in'

--- a/config/packages/mailer.yaml
+++ b/config/packages/mailer.yaml
@@ -2,4 +2,4 @@ framework:
     mailer:
         dsn: '%env(MAILER_DSN)%'
         envelope:
-            sender: 'noreply@criticalmass.in'
+            sender: '%env(MAILER_SENDER)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,7 +22,7 @@ parameters:
     facebook.default_token: '%env(FACEBOOK_DEFAULT_TOKEN)%'
     photo_tsv.access_key: '%env(PHOTO_TSV_ACCESS_KEY)%'
     timeline.ttl: 60
-    notification.mail.sender_address: noreply@criticalmass.in
+    notification.mail.sender_address: '%env(MAILER_SENDER)%'
     request_listener.http_port: 80
     request_listener.https_port: 443
     upload_destination.track: '%kernel.project_dir%/public/tracks'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,7 +22,7 @@ parameters:
     facebook.default_token: '%env(FACEBOOK_DEFAULT_TOKEN)%'
     photo_tsv.access_key: '%env(PHOTO_TSV_ACCESS_KEY)%'
     timeline.ttl: 60
-    notification.mail.sender_address: malte@criticalmass.in
+    notification.mail.sender_address: noreply@criticalmass.in
     request_listener.http_port: 80
     request_listener.https_port: 443
     upload_destination.track: '%kernel.project_dir%/public/tracks'

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Notifier\NotifierInterface;
 use Symfony\Component\Notifier\Recipient\Recipient;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 
 class LoginController extends AbstractController
@@ -46,7 +47,8 @@ class LoginController extends AbstractController
         LoginLinkHandlerInterface $loginLinkHandler,
         UserRepository $userRepository,
         Request $request,
-        RateLimiterFactory $loginLimiter
+        RateLimiterFactory $loginLimiter,
+        #[Autowire('%notification.mail.sender_address%')] string $senderAddress
     ): Response {
         $limiter = $loginLimiter->create($request->getClientIp());
 
@@ -80,7 +82,8 @@ class LoginController extends AbstractController
             // create a notification based on the login link details
             $notification = new CriticalMassLoginLinkNotification(
                 $loginLinkDetails,
-                'Dein Login auf criticalmass.in'
+                'Dein Login auf criticalmass.in',
+                senderAddress: $senderAddress
             );
             // create a recipient for this user
             $recipient = new Recipient($user->getEmail());

--- a/src/Notifier/CriticalMassLoginLinkNotification.php
+++ b/src/Notifier/CriticalMassLoginLinkNotification.php
@@ -11,7 +11,7 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkNotification;
 
 class CriticalMassLoginLinkNotification extends LoginLinkNotification
 {
-    public function __construct(private LoginLinkDetails $loginLinkDetails, string $subject, array $channels = [])
+    public function __construct(private LoginLinkDetails $loginLinkDetails, string $subject, array $channels = [], private string $senderAddress = 'noreply@criticalmass.in')
     {
         parent::__construct($loginLinkDetails, $subject, $channels);
     }
@@ -19,7 +19,7 @@ class CriticalMassLoginLinkNotification extends LoginLinkNotification
     public function asEmailMessage(EmailRecipientInterface $recipient, ?string $transport = null): ?EmailMessage
     {
         $email = (new TemplatedEmail())
-            ->from(new Address('noreply@criticalmass.in', 'criticalmass.in'))
+            ->from(new Address($this->senderAddress, 'criticalmass.in'))
             ->to($recipient->getEmail())
             ->subject($this->getSubject())
             ->htmlTemplate('email/login_link.html.twig')

--- a/src/Notifier/CriticalMassLoginLinkNotification.php
+++ b/src/Notifier/CriticalMassLoginLinkNotification.php
@@ -19,7 +19,7 @@ class CriticalMassLoginLinkNotification extends LoginLinkNotification
     public function asEmailMessage(EmailRecipientInterface $recipient, ?string $transport = null): ?EmailMessage
     {
         $email = (new TemplatedEmail())
-            ->from(new Address('malte@criticalmass.in', 'criticalmass.in'))
+            ->from(new Address('noreply@criticalmass.in', 'criticalmass.in'))
             ->to($recipient->getEmail())
             ->subject($this->getSubject())
             ->htmlTemplate('email/login_link.html.twig')


### PR DESCRIPTION
## Summary
- Ändert die E-Mail-Absenderadresse von `malte@criticalmass.in` auf `noreply@criticalmass.in`
- Macht die Absenderadresse über die Umgebungsvariable `MAILER_SENDER` konfigurierbar
- Betrifft Mailer-Envelope, Service-Parameter und Login-Link-Notification

## Test plan
- [ ] Prüfen, dass Login-Link-E-Mails mit der neuen Absenderadresse versendet werden
- [ ] Prüfen, dass `MAILER_SENDER` in `.env` überschrieben werden kann

🤖 Generated with [Claude Code](https://claude.com/claude-code)