### PR TITLE
Update dataquery-bundle to 0.11.2: 404 statt 500 bei unbekanntem citySlug

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3543,16 +3543,16 @@
         },
         {
             "name": "maltehuebner/dataquery-bundle",
-            "version": "0.11.1",
+            "version": "0.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maltehuebner/dataquery-bundle.git",
-                "reference": "3be287efb7599efd0c9c7009bc9413d3c8904071"
+                "reference": "2cffbe4480cdd43fbbf48a0e22ca2a72f16d511f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maltehuebner/dataquery-bundle/zipball/3be287efb7599efd0c9c7009bc9413d3c8904071",
-                "reference": "3be287efb7599efd0c9c7009bc9413d3c8904071",
+                "url": "https://api.github.com/repos/maltehuebner/dataquery-bundle/zipball/2cffbe4480cdd43fbbf48a0e22ca2a72f16d511f",
+                "reference": "2cffbe4480cdd43fbbf48a0e22ca2a72f16d511f",
                 "shasum": ""
             },
             "require": {
@@ -3588,9 +3588,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maltehuebner/dataquery-bundle/issues",
-                "source": "https://github.com/maltehuebner/dataquery-bundle/tree/0.11.1"
+                "source": "https://github.com/maltehuebner/dataquery-bundle/tree/0.11.2"
             },
-            "time": "2026-03-14T10:53:56+00:00"
+            "time": "2026-06-12T15:15:16+00:00"
         },
         {
             "name": "maltehuebner/ordered-entities-bundle",

--- a/src/Criticalmass/DataQuery/Query/RegionQuery.php
+++ b/src/Criticalmass/DataQuery/Query/RegionQuery.php
@@ -19,7 +19,10 @@ class RegionQuery extends AbstractQuery implements OrmQueryInterface, ElasticQue
     #[Constraints\Type(Region::class)]
     protected Region $region;
 
-    #[DataQuery\RequiredQueryParameter(parameterName: 'regionSlug')]
+    #[DataQuery\RequiredQueryParameter(
+        parameterName: 'regionSlug',
+        repositoryMethod: 'findOneBySlug'
+    )]
     public function setRegion(Region $region): RegionQuery
     {
         $this->region = $region;

--- a/src/Criticalmass/DataQuery/Query/RideQuery.php
+++ b/src/Criticalmass/DataQuery/Query/RideQuery.php
@@ -39,9 +39,16 @@ class RideQuery extends AbstractQuery implements OrmQueryInterface, ElasticQuery
         $expr = $queryBuilder->expr();
         $alias = $queryBuilder->getRootAliases()[0];
 
-        $queryBuilder
-            ->andWhere($expr->eq(sprintf('%s.id', $alias), ':rideId'))
-            ->setParameter('rideId', $this->ride->getId());
+        if (Ride::class === $this->entityFqcn) {
+            $queryBuilder
+                ->andWhere($expr->eq(sprintf('%s.id', $alias), ':rideId'))
+                ->setParameter('rideId', $this->ride->getId());
+        } else {
+            // Photo, Track and Post carry a direct ride relation
+            $queryBuilder
+                ->andWhere($expr->eq(sprintf('%s.ride', $alias), ':ride'))
+                ->setParameter('ride', $this->ride);
+        }
 
         return $queryBuilder;
     }

--- a/tests/Controller/Api/CityApi/CityApiQueryTest.php
+++ b/tests/Controller/Api/CityApi/CityApiQueryTest.php
@@ -28,12 +28,20 @@ class CityApiQueryTest extends AbstractApiControllerTestCase
         $this->assertResponseIsSuccessful();
         $data = json_decode($this->client->getResponse()->getContent(), true);
 
-        // Region may not exist in test fixtures - just verify API returns valid response
         $this->assertIsArray($data);
+        $this->assertNotEmpty($data, 'Should return cities in Schleswig-Holstein');
 
-        // Note: Region filter requires proper region fixtures setup.
-        // If regions are not configured, all cities may be returned or empty array.
-        // We only verify that the API call succeeds.
+        // Kiel is the only Schleswig-Holstein city in the fixtures
+        foreach ($data as $city) {
+            $this->assertStringContainsStringIgnoringCase('kiel', $city['name']);
+        }
+    }
+
+    public function testFilterByNonExistentRegionReturnsNotFound(): void
+    {
+        $this->client->request('GET', '/api/city?regionSlug=atlantis');
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 
     public function testLimitSize(): void

--- a/tests/Controller/Api/PhotoApi/CityQueryTest.php
+++ b/tests/Controller/Api/PhotoApi/CityQueryTest.php
@@ -46,14 +46,11 @@ class CityQueryTest extends AbstractApiControllerTestCase
         }
     }
 
-    #[TestDox('Expect an error when providing a non existent slug.')]
+    #[TestDox('Querying for a non existent slug returns 404 not found.')]
     public function testPhotoListWithCityQueryForNonExistentCity(): void
     {
-        $this->client->catchExceptions(false);
-
-        // Non-existent city slug causes an exception in CityQuery
-        // when trying to access getCity() on null result
-        $this->expectException(\Error::class);
         $this->client->request('GET', '/api/photo?citySlug=foobarcity');
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Controller/Api/PhotoApi/RideQueryTest.php
+++ b/tests/Controller/Api/PhotoApi/RideQueryTest.php
@@ -7,11 +7,12 @@ use Tests\Controller\Api\AbstractApiControllerTestCase;
 
 class RideQueryTest extends AbstractApiControllerTestCase
 {
-    #[TestDox('Querying for Hamburg with past ride date will only return Hamburg photos.')]
+    #[TestDox('Querying for the past Hamburg ride will only return its photos.')]
     public function testPhotoListWithRideQueryForHamburg(): void
     {
-        $rideDate = (new \DateTime('-1 month last friday'))->format('Y-m-d');
-        $this->client->request('GET', '/api/photo?citySlug=hamburg&rideIdentifier=' . $rideDate);
+        $rideId = $this->queryMostRecentPastRideId('hamburg');
+
+        $this->client->request('GET', sprintf('/api/photo?citySlug=hamburg&rideIdentifier=%d', $rideId));
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
@@ -27,11 +28,12 @@ class RideQueryTest extends AbstractApiControllerTestCase
         }
     }
 
-    #[TestDox('Querying for Berlin with past ride date will only return Berlin photos.')]
+    #[TestDox('Querying for the past Berlin ride will only return its photos.')]
     public function testPhotoListWithRideQueryForBerlin(): void
     {
-        $rideDate = (new \DateTime('-1 month last friday'))->format('Y-m-d');
-        $this->client->request('GET', '/api/photo?citySlug=berlin&rideIdentifier=' . $rideDate);
+        $rideId = $this->queryMostRecentPastRideId('berlin');
+
+        $this->client->request('GET', sprintf('/api/photo?citySlug=berlin&rideIdentifier=%d', $rideId));
 
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
@@ -47,13 +49,30 @@ class RideQueryTest extends AbstractApiControllerTestCase
         }
     }
 
-    #[TestDox('Expect an error when providing a non existent slug for city and ride.')]
+    #[TestDox('Querying for a non existent slug for city and ride returns 404 not found.')]
     public function testPhotoListWithCityQueryForNonExistentCity(): void
     {
-        $this->client->catchExceptions(false);
-
-        // Non-existent city slug causes an exception in CityQuery
-        $this->expectException(\Error::class);
         $this->client->request('GET', '/api/photo?citySlug=foobarcity&rideIdentifier=1245');
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * The photo fixtures are attached to the most recent past ride of a city.
+     */
+    private function queryMostRecentPastRideId(string $citySlug): int
+    {
+        $this->client->request('GET', '/api/ride?citySlug=' . $citySlug);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $rideList = $this->getJsonResponse();
+
+        $pastRideList = array_filter($rideList, fn(array $ride): bool => $ride['date_time'] < time());
+        $this->assertNotEmpty($pastRideList, sprintf('Should have a past ride for %s', $citySlug));
+
+        usort($pastRideList, fn(array $a, array $b): int => $b['date_time'] <=> $a['date_time']);
+
+        return $pastRideList[0]['id'];
     }
 }

--- a/tests/Controller/Api/RideApi/CityQueryTest.php
+++ b/tests/Controller/Api/RideApi/CityQueryTest.php
@@ -51,13 +51,11 @@ class CityQueryTest extends AbstractApiControllerTestCase
         }
     }
 
-    #[TestDox('Expect an error when providing a non existent slug.')]
+    #[TestDox('Querying for a non existent slug returns 404 not found.')]
     public function testRideListWithCityQueryForNonExistentCity(): void
     {
-        $this->client->catchExceptions(false);
-
-        // Non-existent city slug causes an exception in CityQuery
-        $this->expectException(\Error::class);
         $this->client->request('GET', '/api/ride?citySlug=foobarcity');
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary

- Hebt `maltehuebner/dataquery-bundle` von 0.11.1 auf [0.11.2](https://github.com/maltehuebner/dataquery-bundle/pull/30) an
- Bisher crashte jeder API-Request mit unbekanntem `citySlug` (z.B. `GET /api/ride?citySlug=rellingen`) im `ValueAssigner` des Bundles mit *"Call to a member function getCity() on null"* → **500 Internal Server Error**
- Das Bundle wirft jetzt eine `EntityNotFoundException` (implementiert `HttpExceptionInterface`, Status 404) — Symfony rendert automatisch **404 Not Found**, ohne App-Code-Änderung

### Vom strikteren Lookup aufgedeckte Filter-Bugs (mitgefixt)

Bisher wurde ein nicht auflösbarer Query-Parameter **still ignoriert** — die API lieferte dann die ungefilterte Liste. Dadurch sind zwei nie funktionierende Filter unbemerkt geblieben, deren Tests nur gegen die ungefilterte Liste "grün" waren:

- **`RegionQuery`**: `regionSlug` wurde per Default-`find()` (Primärschlüssel!) aufgelöst — ein Slug wie `schleswig-holstein` konnte nie matchen. Jetzt via `findOneBySlug()`, wie es die API-Doku verspricht.
- **`RideQuery`**: filterte Photo-Listen mit `photo.id = :rideId` (Root-Alias statt Ride-Relation). Für Nicht-Ride-Entities (Photo, Track, Post) wird jetzt über die `ride`-Relation gefiltert.

### Test-Updates

- `CityQueryTest` (Ride + Photo API): unbekannter Slug → 404 statt `\Error`-Crash
- `CityApiQueryTest::testFilterByRegion`: prüft jetzt echtes Filtern (nur Kiel liegt in den Fixtures in Schleswig-Holstein) + neuer 404-Test für unbekannte Region
- `PhotoApi\RideQueryTest`: nutzt echte Ride-IDs (via Ride-API aufgelöst) statt des nie matchenden Datums-Identifiers; unbekannte Slugs → 404

## Test Plan

- [x] `vendor/bin/phpunit tests/Controller/Api/PhotoApi/ tests/Controller/Api/CityApi/CityApiQueryTest.php tests/Controller/Api/RideApi/CityQueryTest.php` — 83 Tests, 440 Assertions, grün
- [x] `vendor/bin/phpstan analyse` über geänderte Dateien — keine Fehler
- [ ] Nach Deployment: `GET https://criticalmass.in/api/ride?citySlug=gibtesnicht123` liefert 404 statt 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)