### PR TITLE
Fix: FIT-Zeitstempel als UTC interpretieren

### DIFF
--- a/src/Criticalmass/Geo/FitService/FitToGpxConverter.php
+++ b/src/Criticalmass/Geo/FitService/FitToGpxConverter.php
@@ -50,7 +50,10 @@ class FitToGpxConverter implements FitToGpxConverterInterface
             $point->latitude = (float) $latitude;
             $point->longitude = (float) $longitudes[$timestamp];
             $point->elevation = isset($altitudes[$timestamp]) ? (float) $altitudes[$timestamp] : null;
-            $point->time = (new \DateTime())->setTimestamp((int) $timestamp);
+            // FIT-Zeitstempel sind Unix/UTC. `@<timestamp>` erzeugt eine DateTime
+            // in UTC (unabhängig von der Server-Zeitzone), damit die minutengenaue
+            // Ride-Auto-Zuordnung (DateTimeVoter) korrekt matcht.
+            $point->time = new \DateTime('@' . (int) $timestamp);
 
             $points[] = $point;
         }

--- a/tests/Criticalmass/Geo/FitService/FitToGpxConverterTest.php
+++ b/tests/Criticalmass/Geo/FitService/FitToGpxConverterTest.php
@@ -45,6 +45,23 @@ class FitToGpxConverterTest extends TestCase
         }
     }
 
+    public function testTrackPointTimesAreInterpretedAsUtc(): void
+    {
+        // Auf einem nicht-UTC-Server würde eine zeitzonenlose Interpretation die
+        // Zeitstempel verschieben. Default-TZ temporär umstellen und prüfen, dass
+        // die Punktzeit trotzdem UTC (+00:00) trägt.
+        $originalTimezone = date_default_timezone_get();
+        date_default_timezone_set('America/New_York');
+
+        try {
+            $points = (new FitToGpxConverter())->convertFileToGpxFile(self::FIXTURE)->tracks[0]->getPoints();
+
+            self::assertSame('+00:00', $points[0]->time->format('P'), 'FIT timestamps must be interpreted as UTC.');
+        } finally {
+            date_default_timezone_set($originalTimezone);
+        }
+    }
+
     public function testConvertFileToXmlStringProducesGpxTrackpoints(): void
     {
         $xml = (new FitToGpxConverter())->convertFileToXmlString(self::FIXTURE);


### PR DESCRIPTION
## Summary
- `FitToGpxConverter` baute FIT-Zeitstempel (Unix/UTC) mit `(new \DateTime())->setTimestamp()` — ohne UTC, das Ergebnis trug die Server-Default-Zeitzone.
- Auf nicht-UTC-Servern verschob das die minutengenaue Ride-Auto-Zuordnung (`DateTimeVoter`) und senkte die Confidence.
- Fix: `new \DateTime('@'.$timestamp)` (immer UTC).

## Test Plan
- Neuer zeitzonenunabhängiger Regressionstest: Default-TZ temporär auf `America/New_York`, dann `format('P') === '+00:00'` geprüft.
- `FitToGpxConverterTest` grün (6/6), PHPStan Level 6 sauber.

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)