### PR TITLE
Fix: Verschluckte Exceptions loggen (Photo-GPS, Strava-Token)

### DIFF
--- a/src/Controller/Track/StravaMassImportController.php
+++ b/src/Controller/Track/StravaMassImportController.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\Attribute\Route;
@@ -50,12 +51,14 @@ class StravaMassImportController extends AbstractController
 
     #[IsGranted('ROLE_USER')]
     #[Route('/trackimport/stravatoken', name: 'caldera_criticalmass_trackmassimport_token', priority: 310)]
-    public function tokenAction(Request $request, SessionInterface $session, RouterInterface $router): Response
+    public function tokenAction(Request $request, SessionInterface $session, RouterInterface $router, LoggerInterface $logger): Response
     {
         $error = $request->get('error');
         $year = $request->query->getInt('year', (new \DateTime())->format('Y'));
 
         if ($error) {
+            $logger->warning('Strava authorization returned an error', ['error' => $error]);
+
             return $this->redirect($router->generate('caldera_criticalmass_trackmassimport_auth'));
         }
 
@@ -72,6 +75,8 @@ class StravaMassImportController extends AbstractController
                 'year' => $year,
             ]));
         } catch (\Exception $e) {
+            $logger->error('Strava token exchange failed', ['exception' => $e]);
+
             return $this->redirect($router->generate('caldera_criticalmass_trackmassimport_auth'));
         }
     }

--- a/src/EventSubscriber/PhotoEventSubscriber.php
+++ b/src/EventSubscriber/PhotoEventSubscriber.php
@@ -10,6 +10,8 @@ use App\Event\Photo\PhotoDeletedEvent;
 use App\Event\Photo\PhotoUpdatedEvent;
 use App\Event\Photo\PhotoUploadedEvent;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PhotoEventSubscriber implements EventSubscriberInterface
@@ -17,12 +19,14 @@ class PhotoEventSubscriber implements EventSubscriberInterface
     protected ManagerRegistry $registry;
     protected PhotoGpsInterface $photoGps;
     protected ExifHandlerInterface $exifHandler;
+    protected LoggerInterface $logger;
 
-    public function __construct(ManagerRegistry $registry, PhotoGpsInterface $photoGps, ExifHandlerInterface $exifHandler)
+    public function __construct(ManagerRegistry $registry, PhotoGpsInterface $photoGps, ExifHandlerInterface $exifHandler, ?LoggerInterface $logger = null)
     {
         $this->registry = $registry;
         $this->photoGps = $photoGps;
         $this->exifHandler = $exifHandler;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public static function getSubscribedEvents(): array
@@ -70,7 +74,12 @@ class PhotoEventSubscriber implements EventSubscriberInterface
                     ->execute()
                     ->getPhoto();
             } catch (\Exception $exception) {
-
+                // Geolokalisierung ist best-effort; Fehler dürfen den Upload nicht
+                // abbrechen, sollen aber nicht spurlos verschwinden.
+                $this->logger->error('Photo geolocation failed', [
+                    'photo' => $photo->getId(),
+                    'exception' => $exception,
+                ]);
             }
         }
     }

--- a/tests/EventSubscriber/PhotoEventSubscriberTest.php
+++ b/tests/EventSubscriber/PhotoEventSubscriberTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Image\ExifHandler\ExifHandlerInterface;
+use App\Criticalmass\Image\PhotoGps\PhotoGpsInterface;
+use App\Entity\Photo;
+use App\Entity\Ride;
+use App\Entity\Track;
+use App\Entity\User;
+use App\Event\Photo\PhotoUploadedEvent;
+use App\EventSubscriber\PhotoEventSubscriber;
+use App\Repository\TrackRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Stellt sicher, dass eine fehlgeschlagene Foto-Geolokalisierung den Upload
+ * nicht abbricht, aber nicht mehr stillschweigend verschluckt wird (#1400).
+ */
+final class PhotoEventSubscriberTest extends TestCase
+{
+    public function testFailedGeolocationIsLoggedAndDoesNotThrow(): void
+    {
+        $photo = new Photo();
+        $photo->setRide(new Ride());
+        $photo->setUser(new User());
+
+        $trackRepository = $this->createMock(TrackRepository::class);
+        $trackRepository->method('findByUserAndRide')->willReturn(new Track());
+
+        $manager = $this->createMock(ObjectManager::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+        $registry->method('getRepository')->with(Track::class)->willReturn($trackRepository);
+
+        $exifHandler = $this->createMock(ExifHandlerInterface::class);
+        $exifHandler->method('readExifDataFromPhotoFile')->willReturn(null);
+
+        $photoGps = $this->createMock(PhotoGpsInterface::class);
+        $photoGps->method('setPhoto')->willReturnSelf();
+        $photoGps->method('setTrack')->willReturnSelf();
+        $photoGps->method('execute')->willThrowException(new \RuntimeException('GPS service down'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(self::stringContains('geolocation failed'), self::anything());
+
+        $subscriber = new PhotoEventSubscriber($registry, $photoGps, $exifHandler, $logger);
+
+        // Darf nicht werfen.
+        $subscriber->onPhotoUploaded(new PhotoUploadedEvent($photo));
+    }
+}


### PR DESCRIPTION
## Summary
- `PhotoEventSubscriber::locate()` fing `\Exception` um `photoGps->execute()` mit **leerem** Body — Fehler verschwanden spurlos.
- `StravaMassImportController::tokenAction()` verschluckte Token-Exchange-Fehler still per Redirect.
- Beide loggen jetzt (`->error()` mit Kontext), bevor weitergemacht wird. Geolokalisierung bleibt best-effort und bricht den Upload nicht ab; Logger im Subscriber ist nullable (DI-frei nutzbar).

## Test Plan
- Neuer Unit-Test: fehlgeschlagene Geolokalisierung wird geloggt und wirft nicht.
- PHPStan Level 6 sauber, `lint:container` OK.

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)