### PR TITLE
Sicherheit: HSTS und Report-Only-CSP ergänzen

### DIFF
--- a/src/EventSubscriber/SecurityHeadersEventSubscriber.php
+++ b/src/EventSubscriber/SecurityHeadersEventSubscriber.php
@@ -15,6 +15,22 @@ class SecurityHeadersEventSubscriber implements EventSubscriberInterface
         ];
     }
 
+    /**
+     * Content-Security-Policy zunächst nur als Report-Only ausrollen: bricht
+     * nichts, sammelt aber Verstöße (z. B. Inline-Skripte), bevor auf eine
+     * erzwingende Policy umgestellt wird. `script-src` bewusst ohne
+     * `unsafe-inline`, damit Inline-Skripte sichtbar werden.
+     */
+    private const CONTENT_SECURITY_POLICY = "default-src 'self'; "
+        . "base-uri 'self'; "
+        . "object-src 'none'; "
+        . "frame-ancestors 'self'; "
+        . "img-src 'self' data: https:; "
+        . "font-src 'self' data: https:; "
+        . "style-src 'self' 'unsafe-inline'; "
+        . "script-src 'self'; "
+        . "connect-src 'self' https:";
+
     public function onResponse(ResponseEvent $event): void
     {
         $response = $event->getResponse();
@@ -23,5 +39,15 @@ class SecurityHeadersEventSubscriber implements EventSubscriberInterface
         $response->headers->set('X-Content-Type-Options', 'nosniff');
         $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(self)');
+
+        if (!$response->headers->has('Content-Security-Policy-Report-Only')
+            && !$response->headers->has('Content-Security-Policy')) {
+            $response->headers->set('Content-Security-Policy-Report-Only', self::CONTENT_SECURITY_POLICY);
+        }
+
+        // HSTS nur über HTTPS senden (Browser ignorieren es sonst ohnehin).
+        if ($event->getRequest()->isSecure() && !$response->headers->has('Strict-Transport-Security')) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
     }
 }

--- a/tests/EventSubscriber/SecurityHeadersEventSubscriberTest.php
+++ b/tests/EventSubscriber/SecurityHeadersEventSubscriberTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\SecurityHeadersEventSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class SecurityHeadersEventSubscriberTest extends TestCase
+{
+    private function dispatch(Request $request, ?Response $response = null): Response
+    {
+        $response ??= new Response();
+
+        $event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        (new SecurityHeadersEventSubscriber())->onResponse($event);
+
+        return $response;
+    }
+
+    public function testSetsBaselineAndReportOnlyCsp(): void
+    {
+        $response = $this->dispatch(Request::create('http://example.org/'));
+
+        self::assertSame('SAMEORIGIN', $response->headers->get('X-Frame-Options'));
+        self::assertSame('nosniff', $response->headers->get('X-Content-Type-Options'));
+        self::assertStringContainsString("default-src 'self'", (string) $response->headers->get('Content-Security-Policy-Report-Only'));
+        self::assertStringContainsString("object-src 'none'", (string) $response->headers->get('Content-Security-Policy-Report-Only'));
+    }
+
+    public function testHstsOnlyOnSecureRequest(): void
+    {
+        $insecure = $this->dispatch(Request::create('http://example.org/'));
+        self::assertFalse($insecure->headers->has('Strict-Transport-Security'));
+
+        $secure = $this->dispatch(Request::create('https://example.org/'));
+        self::assertStringContainsString('max-age=', (string) $secure->headers->get('Strict-Transport-Security'));
+        self::assertStringContainsString('includeSubDomains', (string) $secure->headers->get('Strict-Transport-Security'));
+    }
+
+    public function testDoesNotOverrideExistingEnforcingCsp(): void
+    {
+        $response = new Response();
+        $response->headers->set('Content-Security-Policy', "default-src 'none'");
+
+        $result = $this->dispatch(Request::create('http://example.org/'), $response);
+
+        self::assertFalse($result->headers->has('Content-Security-Policy-Report-Only'));
+        self::assertSame("default-src 'none'", $result->headers->get('Content-Security-Policy'));
+    }
+}


### PR DESCRIPTION
## Summary
- `SecurityHeadersEventSubscriber` setzte bisher kein **CSP** und kein **HSTS**.
- **HSTS** nur über HTTPS (`max-age=31536000; includeSubDomains`).
- **Content-Security-Policy-Report-Only** als nicht-brechender erster Schritt: `default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'self'`, `script-src 'self'` (bewusst **ohne** `unsafe-inline`, damit Inline-Skripte als Report sichtbar werden, bevor auf eine erzwingende Policy umgestellt wird). Vorhandene CSP-Header werden nicht überschrieben.

## Test Plan
- DB-freie Unit-Tests: Baseline-Header + Report-Only-CSP gesetzt; HSTS nur bei `isSecure()`; bestehende erzwingende CSP wird nicht überschrieben.
- PHPStan Level 6 sauber.

## Hinweis
Report-Only bricht nichts. Nächster Schritt (separat): Reports auswerten, Inline-Skripte (z. B. Captcha) per Nonce/Refactor entschärfen, dann auf erzwingende `Content-Security-Policy` umstellen. HSTS ggf. zusätzlich auf Webserver-Ebene.

Closes #1394

🤖 Generated with [Claude Code](https://claude.com/claude-code)