### PR TITLE
Sicherheit: /api/doc in Produktion nicht ausliefern

### DIFF
--- a/config/routes/nelmio_api_doc.yaml
+++ b/config/routes/nelmio_api_doc.yaml
@@ -1,15 +1,33 @@
-# Expose your documentation as JSON swagger compliant
-app.swagger:
-    path: /api/doc.json
-    methods: GET
-    defaults: { _controller: nelmio_api_doc.controller.swagger }
-    options:
-        priority: 200
+# Die Swagger-Doku (/api/doc, /api/doc.json) wird nur in dev und test
+# registriert. In Produktion liegt sie unter der `^/api`-Firewall
+# (security: false) und wäre anonym erreichbar — sie dokumentiert alle
+# Endpunkte inkl. der Schreiboperationen und erleichtert Recon (#1393).
+when@dev:
+    app.swagger:
+        path: /api/doc.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger }
+        options:
+            priority: 200
 
-# Requires the Asset component and the Twig bundle
-app.swagger_ui:
-    path: /api/doc
-    methods: GET
-    defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
-    options:
-        priority: 200
+    app.swagger_ui:
+        path: /api/doc
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+        options:
+            priority: 200
+
+when@test:
+    app.swagger:
+        path: /api/doc.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger }
+        options:
+            priority: 200
+
+    app.swagger_ui:
+        path: /api/doc
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+        options:
+            priority: 200


### PR DESCRIPTION
## Summary
- `/api/doc` (Swagger-UI) und `/api/doc.json` waren in **allen** Umgebungen registriert und liegen unter der `^/api`-Firewall (`security: false`) → in Produktion anonym erreichbar, dokumentieren alle Endpunkte inkl. Schreiboperationen.
- Die Doc-Routen werden jetzt nur noch in **dev** und **test** registriert.

## Test Plan
- `debug:router`: dev=2, test=2, **prod=0** Doc-Routen.
- Bestehender `ApiControllerTest::testApiDocVisible` (läuft im test-Env) bleibt grün.

Closes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)