### PR TITLE
Fix: Fataler getTmpFilename()-Aufruf in onPhotoUpdated

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3245,12 +3245,6 @@ parameters:
 			path: src/Enum/RideTypeEnum.php
 
 		-
-			message: '#^Call to an undefined method App\\Event\\Photo\\PhotoUpdatedEvent\:\:getTmpFilename\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/EventSubscriber/PhotoEventSubscriber.php
-
-		-
 			message: '#^Call to an undefined method Doctrine\\Persistence\\ObjectRepository\<App\\Entity\\Track\>\:\:findByUserAndRide\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/EventSubscriber/PhotoEventSubscriber.php
+++ b/src/EventSubscriber/PhotoEventSubscriber.php
@@ -48,7 +48,10 @@ class PhotoEventSubscriber implements EventSubscriberInterface
 
     public function onPhotoUpdated(PhotoUpdatedEvent $photoUpdatedEvent): void
     {
-        $this->handleExifData($photoUpdatedEvent->getPhoto(), $photoUpdatedEvent->getTmpFilename());
+        // PhotoUpdatedEvent trägt keine temporäre Upload-Datei (anders als
+        // PhotoUploadedEvent) — die EXIF-Daten werden aus der bereits
+        // persistierten Foto-Datei gelesen.
+        $this->handleExifData($photoUpdatedEvent->getPhoto());
         $this->locate($photoUpdatedEvent->getPhoto());
 
         $this->registry->getManager()->flush();

--- a/tests/EventSubscriber/PhotoUpdatedHandlingTest.php
+++ b/tests/EventSubscriber/PhotoUpdatedHandlingTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Image\ExifHandler\ExifHandlerInterface;
+use App\Criticalmass\Image\PhotoGps\PhotoGpsInterface;
+use App\Entity\Photo;
+use App\Entity\Ride;
+use App\Entity\Track;
+use App\Entity\User;
+use App\Event\Photo\PhotoUpdatedEvent;
+use App\EventSubscriber\PhotoEventSubscriber;
+use App\Repository\TrackRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression für #1422: onPhotoUpdated() rief `getTmpFilename()` auf, das es auf
+ * PhotoUpdatedEvent nicht gibt — jeder Dispatch wäre fatal gescheitert.
+ */
+final class PhotoUpdatedHandlingTest extends TestCase
+{
+    public function testOnPhotoUpdatedReadsExifWithoutThrowing(): void
+    {
+        $photo = new Photo();
+        $photo->setRide(new Ride());
+        $photo->setUser(new User());
+
+        $trackRepository = $this->createMock(TrackRepository::class);
+        $trackRepository->method('findByUserAndRide')->willReturn(null);
+
+        $manager = $this->createMock(ObjectManager::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+        $registry->method('getRepository')->with(Track::class)->willReturn($trackRepository);
+
+        $exifHandler = $this->createMock(ExifHandlerInterface::class);
+        // Die EXIF-Daten werden aus der persistierten Datei gelesen (kein tmpFile).
+        $exifHandler->expects(self::once())
+            ->method('readExifDataFromPhotoFile')
+            ->with($photo)
+            ->willReturn(null);
+
+        $subscriber = new PhotoEventSubscriber($registry, $this->createMock(PhotoGpsInterface::class), $exifHandler);
+
+        // Darf nicht werfen.
+        $subscriber->onPhotoUpdated(new PhotoUpdatedEvent($photo));
+    }
+}


### PR DESCRIPTION
## Summary
- `PhotoEventSubscriber::onPhotoUpdated()` rief `getTmpFilename()` auf, das nur auf `PhotoUploadedEvent` existiert (nicht auf `PhotoUpdatedEvent`) → jeder Dispatch scheiterte mit `Call to undefined method`.
- Ein `PhotoUpdatedEvent` trägt keine temporäre Upload-Datei → EXIF-Daten aus der bereits persistierten Foto-Datei lesen (`handleExifData` ohne tmpFilename).

## Test Plan
- Neuer Regressionstest: `onPhotoUpdated` läuft ohne Exception und liest EXIF aus der Datei.
- PHPStan Level 6 sauber.

Closes #1422
(entdeckt beim Testen rund um #1400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)