### PR TITLE
Performance: N+1-Queries beheben (Ride-Liste, Profil, City-Tracks)

### DIFF
--- a/src/Criticalmass/MassTrackImport/ProposalPersister/ProposalPersister.php
+++ b/src/Criticalmass/MassTrackImport/ProposalPersister/ProposalPersister.php
@@ -5,7 +5,6 @@ namespace App\Criticalmass\MassTrackImport\ProposalPersister;
 use App\Criticalmass\MassTrackImport\TrackDecider\RideResult;
 use App\Entity\Track;
 use App\Entity\TrackImportCandidate;
-use App\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
 
 class ProposalPersister implements ProposalPersisterInterface
@@ -31,54 +30,33 @@ class ProposalPersister implements ProposalPersisterInterface
     private function isDuplicate(TrackImportCandidate $candidate): bool
     {
         $user = $candidate->getUser();
+        $candidateRepository = $this->registry->getRepository(TrackImportCandidate::class);
 
+        // Gezielte Existenz-Abfrage statt die gesamte Track-/Candidate-Collection
+        // des Users zu hydratisieren und per in_array zu prüfen.
         if ($candidate->getSource() === TrackImportCandidate::CANDIDATE_SOURCE_UPLOAD) {
             $fileHash = $candidate->getFileHash();
 
-            return $fileHash !== null && in_array($fileHash, $this->loadExistingFileHashes($user), true);
+            return $fileHash !== null && null !== $candidateRepository->findOneBy([
+                'user' => $user,
+                'source' => TrackImportCandidate::CANDIDATE_SOURCE_UPLOAD,
+                'fileHash' => $fileHash,
+            ]);
         }
 
-        return in_array($candidate->getActivityId(), $this->loadExistingStravaActivityIds($user), true);
-    }
+        $activityId = $candidate->getActivityId();
 
-    /**
-     * @return list<int>
-     */
-    private function loadExistingStravaActivityIds(User $user): array
-    {
-        $activityIds = [];
-
-        /** @var Track $track */
-        foreach ($this->registry->getRepository(Track::class)->findBy(['user' => $user]) as $track) {
-            if ($track->getStravaActivityId()) {
-                $activityIds[] = (int) $track->getStravaActivityId();
-            }
+        if ($activityId === null) {
+            return false;
         }
 
-        /** @var TrackImportCandidate $candidate */
-        foreach ($this->registry->getRepository(TrackImportCandidate::class)->findBy(['user' => $user]) as $candidate) {
-            if ($candidate->getActivityId() !== null) {
-                $activityIds[] = $candidate->getActivityId();
-            }
-        }
-
-        return $activityIds;
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function loadExistingFileHashes(User $user): array
-    {
-        $hashes = [];
-
-        /** @var TrackImportCandidate $candidate */
-        foreach ($this->registry->getRepository(TrackImportCandidate::class)->findBy(['user' => $user]) as $candidate) {
-            if ($candidate->getSource() === TrackImportCandidate::CANDIDATE_SOURCE_UPLOAD && $candidate->getFileHash() !== null) {
-                $hashes[] = $candidate->getFileHash();
-            }
-        }
-
-        return $hashes;
+        // 'stravaActitityId' ist der (verschriebene) Property-/Feldname in Track.
+        return null !== $this->registry->getRepository(Track::class)->findOneBy([
+            'user' => $user,
+            'stravaActitityId' => $activityId,
+        ]) || null !== $candidateRepository->findOneBy([
+            'user' => $user,
+            'activityId' => $activityId,
+        ]);
     }
 }

--- a/src/Repository/ParticipationRepository.php
+++ b/src/Repository/ParticipationRepository.php
@@ -92,6 +92,11 @@ class ParticipationRepository extends ServiceEntityRepository
 
         $builder
             ->join('p.ride', 'r')
+            // Ride + Stadt (+ Haupt-Slug) eager laden: die Profilseite rendert je
+            // Teilnahme participation.ride.city.city / object_path → sonst N+1.
+            ->addSelect('r', 'c', 'mainSlug')
+            ->leftJoin('r.city', 'c')
+            ->leftJoin('c.mainSlug', 'mainSlug')
             ->where($builder->expr()->eq('p.user', ':user'))
             ->setParameter('user', $user)
             ->orderBy('r.dateTime', 'DESC');

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -282,6 +282,11 @@ class RideRepository extends ServiceEntityRepository
 
         $builder
             ->select('ride')
+            // Stadt (+ Haupt-Slug für object_path) eager laden: die Kalenderliste
+            // rendert je Zeile ride.city.city und object_path(ride.city) → sonst N+1.
+            ->addSelect('city', 'mainSlug')
+            ->leftJoin('ride.city', 'city')
+            ->leftJoin('city.mainSlug', 'mainSlug')
             ->where($builder->expr()->gt('ride.dateTime', ':startDateTime'))
             ->andWhere($builder->expr()->lt('ride.dateTime', ':endDateTime'))
             ->addOrderBy('ride.dateTime', 'ASC')

--- a/src/Repository/TrackRepository.php
+++ b/src/Repository/TrackRepository.php
@@ -200,6 +200,11 @@ class TrackRepository extends ServiceEntityRepository
 
         $builder->select('t')
             ->join('t.ride', 'r')
+            // Ride + Stadt eager laden: Templates dereferenzieren track.ride.city
+            // → sonst N+1 je Track.
+            ->addSelect('r', 'c', 'mainSlug')
+            ->leftJoin('r.city', 'c')
+            ->leftJoin('c.mainSlug', 'mainSlug')
             ->where($builder->expr()->eq('r.city', ':city'))
             ->setParameter('city', $city)
             ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))

--- a/tests/Repository/RideRepositoryEagerLoadTest.php
+++ b/tests/Repository/RideRepositoryEagerLoadTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\Proxy;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Regression für #1399: findRidesInInterval muss die Stadt (für die Kalender-
+ * liste: ride.city.city + object_path(ride.city)) eager laden — sonst N+1.
+ * Eine eager geladene Assoziation ist kein (uninitialisierter) Doctrine-Proxy.
+ */
+final class RideRepositoryEagerLoadTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine')->getManager();
+        $this->em->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->em->getConnection();
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+        parent::tearDown();
+    }
+
+    public function testFindRidesInIntervalEagerLoadsCity(): void
+    {
+        $city = new City();
+        $city->setCity('Teststadt ' . substr(md5(uniqid('', true)), 0, 8));
+        $city->setTitle('Critical Mass Test');
+        $city->setCreatedAt(new \DateTime());
+        $this->em->persist($city);
+
+        $slug = new CitySlug();
+        $slug->setSlug('eager-' . substr(md5(uniqid('', true)), 0, 10));
+        $slug->setCity($city);
+        $this->em->persist($slug);
+        $city->setMainSlug($slug);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setTitle('Eager-Test-Ride');
+        $ride->setDateTime((new \DateTime())->add(new \DateInterval('P2D')));
+        $this->em->persist($ride);
+        $this->em->flush();
+
+        // Identity Map leeren, damit die Abfrage frisch hydratisiert.
+        $this->em->clear();
+
+        /** @var RideRepository $repository */
+        $repository = $this->em->getRepository(Ride::class);
+        $rides = $repository->findRidesInInterval();
+
+        $match = null;
+        foreach ($rides as $candidate) {
+            if ($candidate->getTitle() === 'Eager-Test-Ride') {
+                $match = $candidate;
+                break;
+            }
+        }
+
+        self::assertNotNull($match, 'Der angelegte Ride muss im Intervall gefunden werden.');
+        self::assertNotInstanceOf(
+            Proxy::class,
+            $match->getCity(),
+            'Die Stadt muss eager geladen sein (kein Lazy-Proxy) — sonst N+1.',
+        );
+        self::assertSame($city->getCity(), $match->getCity()?->getCity());
+    }
+}


### PR DESCRIPTION
## Summary
Mehrere häufige/öffentliche Seiten lösten je Zeile eine Extra-Query aus:
- `RideRepository::findRidesInInterval` selektierte nur den Ride; die öffentliche Kalenderliste rendert je Zeile `ride.city.city` + `object_path(ride.city)`.
- `ParticipationRepository::findByUser` jointe `p.ride` nur zum Sortieren; die Profilseite liest `participation.ride.city.city` je Zeile.
- `TrackRepository::findByCityQuery` jointe `t.ride` ohne Select; Templates dereferenzieren `track.ride.city`.

→ Stadt (und den von `object_path` genutzten City-**mainSlug**) per `leftJoin` + `addSelect` eager laden. Alle Joins sind **ToOne** → kein Row-Fan-out, **Ergebnismengen unverändert** (`leftJoin` behält Zeilen mit null-City/-Slug).

Zusätzlich: `ProposalPersister::isDuplicate` hydratisierte die **gesamte** Track-/Candidate-Collection des Users nur für einen `in_array`-Check → ersetzt durch gezielte `findOneBy`-Existenz-Abfragen.

## Test Plan
- Volle Test-Suite grün (1169 Tests) — Korrektheit/Ergebnismengen unverändert.
- Neuer Regressionstest: `findRidesInInterval` lädt die Stadt eager (eine eager geladene Assoziation ist **kein** Lazy-Doctrine-Proxy).
- PHPStan Level 6 sauber.

Closes #1399

🤖 Generated with [Claude Code](https://claude.com/claude-code)