### PR TITLE
Sicherheit: Rate-Limiting, trusted_proxies, Captcha fail-closed

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -58,3 +58,7 @@ LOGGLY_TOKEN=placeholder
 # postgresql+advisory://db_user:db_password@localhost/db_name
 LOCK_DSN=flock
 ###< symfony/lock ###
+
+# Reverse-Proxy-IPs/-Ranges, denen X-Forwarded-* vertraut werden darf.
+# Leer = keinem Proxy vertrauen. Beispiel hinter Proxy: "127.0.0.1,10.0.0.0/8"
+TRUSTED_PROXIES=

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -4,6 +4,13 @@ framework:
     #csrf_protection: true
     #http_method_override: true
 
+    # Hinter einem Reverse-Proxy: damit Request::getClientIp() die echte IP
+    # liefert (statt der Proxy-IP) und X-Forwarded-* nicht spoofbar ist.
+    # Default leer = keinem Proxy vertrauen; echte Proxy-IPs/-Ranges per ENV
+    # TRUSTED_PROXIES je Deployment setzen (z. B. "127.0.0.1,10.0.0.0/8").
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+    trusted_headers: [ 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port' ]
+
     #esi: true
     #fragments: true
     php_errors:

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -1,6 +1,26 @@
 framework:
     rate_limiter:
+        # Login pro Client-IP (bestehend).
         login:
             policy: sliding_window
             limit: 5
+            interval: '15 minutes'
+
+        # Login zusätzlich pro E-Mail (gegen Magic-Link-Spam/Mailbomb).
+        login_email:
+            policy: sliding_window
+            limit: 5
+            interval: '15 minutes'
+
+        # Track-Uploads pro User (Bulk = eine Anfrage je Datei). Großzügig, damit
+        # legitime Bulk-Importe durchgehen, aber Missbrauch gedrosselt wird.
+        upload:
+            policy: token_bucket
+            limit: 150
+            rate: { interval: '1 minute', amount: 10 }
+
+        # Schreibende API-Endpunkte pro Client-IP (die /api-Firewall ist anonym).
+        api_write:
+            policy: sliding_window
+            limit: 120
             interval: '15 minutes'

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -48,6 +48,7 @@ class LoginController extends AbstractController
         UserRepository $userRepository,
         Request $request,
         RateLimiterFactory $loginLimiter,
+        RateLimiterFactory $loginEmailLimiter,
         #[Autowire('%notification.mail.sender_address%')] string $senderAddress
     ): Response {
         $limiter = $loginLimiter->create($request->getClientIp());
@@ -70,6 +71,13 @@ class LoginController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $email = $data['email'];
+
+            // Pro-E-Mail-Drosselung gegen Magic-Link-Spam/Mailbomb auf fremde Adressen.
+            if (false === $loginEmailLimiter->create($email)->consume()->isAccepted()) {
+                $this->addFlash('error', 'Zu viele Anmeldelinks für diese E-Mail. Bitte versuche es später erneut.');
+
+                return $this->redirectToRoute('login');
+            }
 
             $user = $userRepository->findOneBy(['email' => $email]);
 

--- a/src/Controller/Track/BulkTrackUploadController.php
+++ b/src/Controller/Track/BulkTrackUploadController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -41,6 +42,7 @@ class BulkTrackUploadController extends AbstractController
         TrackDeciderInterface $trackDecider,
         ProposalPersisterInterface $proposalPersister,
         FilesystemOperator $trackFilesystem,
+        RateLimiterFactory $uploadLimiter,
         #[CurrentUser] ?User $user = null,
     ): JsonResponse {
         if (!$this->isCsrfTokenValid('bulk_track_upload', (string) $request->request->get('_token'))) {
@@ -49,6 +51,10 @@ class BulkTrackUploadController extends AbstractController
 
         if (!$user instanceof User) {
             return $this->statusResponse('error', 'Bitte melde dich an, um Tracks hochzuladen.', Response::HTTP_FORBIDDEN);
+        }
+
+        if (false === $uploadLimiter->create('user-' . $user->getId())->consume()->isAccepted()) {
+            return $this->statusResponse('error', 'Zu viele Uploads in kurzer Zeit. Bitte warte einen Moment.', Response::HTTP_TOO_MANY_REQUESTS);
         }
 
         $uploadedFile = $request->files->get('file');

--- a/src/Criticalmass/FriendlyCaptcha/FriendlyCaptcha.php
+++ b/src/Criticalmass/FriendlyCaptcha/FriendlyCaptcha.php
@@ -3,9 +3,10 @@
 namespace App\Criticalmass\FriendlyCaptcha;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
-use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class FriendlyCaptcha implements FriendlyCaptchaInterface
 {
@@ -15,7 +16,8 @@ class FriendlyCaptcha implements FriendlyCaptchaInterface
 
     public function __construct(
         private readonly SerializerInterface $serializer,
-        ContainerBagInterface $containerBag
+        private readonly HttpClientInterface $httpClient,
+        ContainerBagInterface $containerBag,
     ) {
         $this->apiKey = $containerBag->get('friendlycaptcha_api_key');
         $this->siteKey = $containerBag->get('friendlycaptcha_site_key');
@@ -25,23 +27,28 @@ class FriendlyCaptcha implements FriendlyCaptchaInterface
     {
         $captchaSolution = $request->request->get('frc-captcha-solution');
 
-        $client = HttpClient::create();
+        try {
+            $response = $this->httpClient->request('POST', self::API_URL, [
+                'json' => [
+                    'solution' => $captchaSolution,
+                    'secret' => $this->apiKey,
+                    'sitekey' => $this->siteKey,
+                ],
+            ]);
 
-        $payload = [
-            'solution' => $captchaSolution,
-            'secret' => $this->apiKey,
-            'sitekey' => $this->siteKey,
-        ];
+            // Fail-closed: bei einem nicht erfolgreichen Verify-Aufruf gilt das
+            // Captcha als NICHT bestanden (vorher wurde hier `true` zurückgegeben).
+            if ($response->getStatusCode() !== 200) {
+                return false;
+            }
 
-        $response = $client->request('POST', self::API_URL, [
-            'json' => $payload,
-        ]);
-
-        if ($response->getStatusCode() !== 200) {
-            return true;
+            $content = $response->getContent();
+        } catch (HttpClientExceptionInterface) {
+            return false;
         }
 
-        $result = $this->serializer->deserialize($response->getContent(), Response::class, 'json');
+        /** @var Response $result */
+        $result = $this->serializer->deserialize($content, Response::class, 'json');
 
         return $result->isSuccess();
     }

--- a/src/EventSubscriber/ApiRateLimitSubscriber.php
+++ b/src/EventSubscriber/ApiRateLimitSubscriber.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Drosselt schreibende Zugriffe (POST/PUT/PATCH/DELETE) auf die anonyme
+ * /api-Firewall pro Client-IP (#1392). Die echte IP setzt trusted_proxies voraus.
+ */
+final class ApiRateLimitSubscriber implements EventSubscriberInterface
+{
+    private const WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
+
+    public function __construct(
+        private readonly RateLimiterFactory $apiWriteLimiter,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 16],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!str_starts_with($request->getPathInfo(), '/api/')) {
+            return;
+        }
+
+        if (!\in_array($request->getMethod(), self::WRITE_METHODS, true)) {
+            return;
+        }
+
+        $limit = $this->apiWriteLimiter->create($request->getClientIp())->consume();
+
+        if (false === $limit->isAccepted()) {
+            throw new TooManyRequestsHttpException(
+                max(0, $limit->getRetryAfter()->getTimestamp() - time()),
+                'API rate limit exceeded.',
+            );
+        }
+    }
+}

--- a/tests/Criticalmass/FriendlyCaptcha/FriendlyCaptchaTest.php
+++ b/tests/Criticalmass/FriendlyCaptcha/FriendlyCaptchaTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\FriendlyCaptcha;
+
+use App\Criticalmass\FriendlyCaptcha\FriendlyCaptcha;
+use App\Criticalmass\FriendlyCaptcha\Response as CaptchaResponse;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * #1392: Der Captcha-Check muss fail-closed sein — bei einem nicht erfolgreichen
+ * Verify-Aufruf (≠200 oder Transportfehler) gilt das Captcha als NICHT bestanden.
+ */
+final class FriendlyCaptchaTest extends TestCase
+{
+    private function captcha(HttpClientInterface $httpClient, ?SerializerInterface $serializer = null): FriendlyCaptcha
+    {
+        $containerBag = $this->createMock(ContainerBagInterface::class);
+        $containerBag->method('get')->willReturnMap([
+            ['friendlycaptcha_api_key', 'test-api-key'],
+            ['friendlycaptcha_site_key', 'test-site-key'],
+        ]);
+
+        return new FriendlyCaptcha($serializer ?? $this->createMock(SerializerInterface::class), $httpClient, $containerBag);
+    }
+
+    private function request(): Request
+    {
+        return Request::create('/login', 'POST', ['frc-captcha-solution' => 'solved']);
+    }
+
+    public function testNonSuccessStatusFailsClosed(): void
+    {
+        $captcha = $this->captcha(new MockHttpClient(new MockResponse('error', ['http_code' => 500])));
+
+        self::assertFalse($captcha->checkCaptcha($this->request()));
+    }
+
+    public function testTransportExceptionFailsClosed(): void
+    {
+        $client = new MockHttpClient(static function (): MockResponse {
+            throw new \Symfony\Component\HttpClient\Exception\TransportException('network down');
+        });
+
+        self::assertFalse($this->captcha($client)->checkCaptcha($this->request()));
+    }
+
+    public function testValidSolutionPasses(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('deserialize')->willReturn((new CaptchaResponse())->setSuccess(true)->setErrors(null));
+
+        $captcha = $this->captcha(
+            new MockHttpClient(new MockResponse('{"success":true}', ['http_code' => 200])),
+            $serializer,
+        );
+
+        self::assertTrue($captcha->checkCaptcha($this->request()));
+    }
+
+    public function testRejectedSolutionFails(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->method('deserialize')->willReturn((new CaptchaResponse())->setSuccess(false)->setErrors(['bad']));
+
+        $captcha = $this->captcha(
+            new MockHttpClient(new MockResponse('{"success":false}', ['http_code' => 200])),
+            $serializer,
+        );
+
+        self::assertFalse($captcha->checkCaptcha($this->request()));
+    }
+}

--- a/tests/EventSubscriber/ApiRateLimitSubscriberTest.php
+++ b/tests/EventSubscriber/ApiRateLimitSubscriberTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\ApiRateLimitSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+/**
+ * Echte RateLimiterFactory (final) mit In-Memory-Storage, limit 1: durch
+ * gezieltes Vor-Erschöpfen des IP-Buckets lässt sich sowohl die Drosselung als
+ * auch das Überspringen (Reads / Nicht-API) ohne Mocking nachweisen.
+ */
+final class ApiRateLimitSubscriberTest extends TestCase
+{
+    private const CLIENT_IP = '127.0.0.1';
+
+    private function factory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'api_write_test', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'],
+            new InMemoryStorage(),
+        );
+    }
+
+    private function event(string $method, string $path): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create($path, $method),
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+
+    public function testThrottlesApiWriteWhenLimitExceeded(): void
+    {
+        $factory = $this->factory();
+        // Bucket der Client-IP vorab erschöpfen.
+        $factory->create(self::CLIENT_IP)->consume();
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('POST', '/api/estimate'));
+    }
+
+    public function testAllowsApiWriteWithinLimit(): void
+    {
+        (new ApiRateLimitSubscriber($this->factory()))->onKernelRequest($this->event('POST', '/api/estimate'));
+        $this->addToAssertionCount(1);
+    }
+
+    public function testIgnoresApiReadRequests(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        // Bucket ist erschöpft — würde der Subscriber Reads verarbeiten, gäbe es 429.
+        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('GET', '/api/ride'));
+        $this->addToAssertionCount(1);
+    }
+
+    public function testIgnoresNonApiPaths(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('POST', '/login'));
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
Behebt #1392 (Abuse-Schutz).

- **Captcha fail-closed**: `FriendlyCaptcha` gab bei nicht erfolgreichem Verify-Aufruf (≠200) `true` zurück (Captcha bestanden) → jetzt `false`, auch bei Transportfehlern. HTTP-Client wird injiziert (testbar).
- **Dedizierte Rate-Limiter**: `upload` (pro User, token_bucket — großzügig für legitime Bulk-Importe), `api_write` (pro Client-IP), `login_email` (pro E-Mail, gegen Magic-Link-Spam/Mailbomb).
- **Angewandt**: Bulk-Track-Upload (pro User), Login (IP bestand, jetzt zusätzlich pro E-Mail), und ein `kernel.request`-Subscriber, der schreibende Methoden auf der anonymen `^/api`-Firewall pro IP drosselt.
- **`trusted_proxies`** via `%env(TRUSTED_PROXIES)%` (+ trusted_headers): korrekte `getClientIp()`, `X-Forwarded-*` nicht spoofbar. Default leer (nichts vertrauen); echte Proxy-Ranges per ENV je Deployment.

## Test Plan
- Neue Unit-Tests: `FriendlyCaptchaTest` (fail-closed-Pfade), `ApiRateLimitSubscriberTest` (Drosselung vs. Überspringen von Reads/Nicht-API).
- Volle Suite grün (1177 Tests); PHPStan Level 6 sauber.

## Hinweise
- `RateLimiterFactory` (konkret) verwendet — `RateLimiterFactoryInterface` gibt es erst ab Symfony 7.3; main ist 7.2.
- Schwellen sind bewusst großzügig und in `config/packages/rate_limiter.yaml` zentral anpassbar.
- Single-Upload-Endpoint bewusst ausgelassen (Bulk ist der im Issue genannte Abuse-Vektor).

Closes #1392

🤖 Generated with [Claude Code](https://claude.com/claude-code)