### PR TITLE
Sicherheit: Upload-Verzeichnisse in public/.htaccess härten

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -66,3 +66,24 @@ DirectoryIndex index.php
         # RedirectTemp cannot be used instead
     </IfModule>
 </IfModule>
+
+# Härtung der Upload-Verzeichnisse (#1395). Diese liegen im Web-Root; als
+# Defense-in-Depth wird hier für sie die Ausführung von Skripten unterbunden und
+# MIME-Sniffing abgeschaltet. Greift zusätzlich zum content-basierten Vich-Namer.
+<IfModule mod_authz_core.c>
+    <If "%{REQUEST_URI} =~ m#^/(tracks|photos|cities|rides|teaser|users)/.+\.(?i:php[0-9]?|phtml|phar|pl|py|cgi|asp|sh)$#">
+        Require all denied
+    </If>
+</IfModule>
+
+<IfModule mod_headers.c>
+    # nosniff für alle Upload-Pfade (bricht Inline-Bilder nicht).
+    <If "%{REQUEST_URI} =~ m#^/(tracks|photos|cities|rides|teaser|users)/#">
+        Header always set X-Content-Type-Options "nosniff"
+    </If>
+
+    # GPX/FIT-Tracks als Download ausliefern, nicht im Browser rendern lassen.
+    <If "%{REQUEST_URI} =~ m#^/tracks/#">
+        Header always set Content-Disposition "attachment"
+    </If>
+</IfModule>


### PR DESCRIPTION
## Summary
Storage-Härtung aus #1395. Die Upload-Ordner liegen im Web-Root und werden von Apache direkt ausgeliefert. Als Defense-in-Depth (zusätzlich zum content-basierten Vich-Namer) werden in der getrackten `public/.htaccess` pfad-gescopte Regeln ergänzt:
- **Skript-Ausführung sperren** (php/phtml/phar/pl/py/cgi/asp/sh) unter den Upload-Pfaden (`index.php` im Root bleibt unberührt).
- **`X-Content-Type-Options: nosniff`** für alle Upload-Pfade (bricht Inline-Bilder nicht).
- **`Content-Disposition: attachment`** nur für `/tracks/` (GPX/FIT als Download; bewusst NICHT auf Bild-Verzeichnisse, sonst würde Inline-Anzeige brechen).

Per-Verzeichnis-`.htaccess` ist nicht möglich, da die Upload-Ordner gitignored sind → zentrale, pfad-gescopte Regeln.

## Bewusst NICHT in diesem PR (separat/mit Sorgfalt)
- **Validieren vor Persistieren / Datei bei Fehler löschen**: `TrackValidator` liest die bereits gespeicherte Datei (Vich/Flysystem), Umstellung ist kein sicherer Quick-Change — sollte mit Upload-Testabdeckung (#1403) als Sicherheitsnetz erfolgen.
- **MIME-Allowlist verschärfen / FIT-per-Signatur**: `application/octet-stream` zu entfernen riskiert legitime FIT-Uploads; braucht einen Signatur-Validator + Tests. Aktuell mitigiert: Inhalt wird als GPX/FIT geparst und sonst abgelehnt.
- **Parsing-Limits / Foto-Dimension / ImageMagick `policy.xml`**: teils server-/deployment-seitig.

## Test Plan
- Reine Apache-Config; keine PHP-Änderung. Bestehende Suite unverändert grün.
- Verifizierbar im Deployment: `.php` unter `/tracks/` → 403; Track-Download trägt `Content-Disposition: attachment`.

Refs #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)