### PR TITLE
Fix: flaky TrackImporterIntegrationTest (Token-Gültigkeits-Boundary)

### DIFF
--- a/tests/Strava/Importer/TrackImporterIntegrationTest.php
+++ b/tests/Strava/Importer/TrackImporterIntegrationTest.php
@@ -73,8 +73,11 @@ class TrackImporterIntegrationTest extends TestCase
         $this->session = $this->createMock(SessionInterface::class);
         $this->entityManager = $this->createMock(EntityManager::class);
 
-        // Setup session with token
-        $token = new StravaTokenStorage('test-access-token', 'test-refresh-token', time() + 3600);
+        // Setup session with token. Die Gültigkeit muss deutlich über
+        // StravaApi::ACCESS_TOKEN_MINIMUM_VALIDITY (3600s) liegen: bei exakt
+        // time()+3600 wirft setAccessToken() "needs to be refreshed", sobald
+        // zwischen setUp und Konstruktion eine Sekundengrenze tickt (Flake).
+        $token = new StravaTokenStorage('test-access-token', 'test-refresh-token', time() + 86400);
         $this->session->method('get')
             ->with('strava_token')
             ->willReturn($token);


### PR DESCRIPTION
## Summary
`TrackImporterIntegrationTest` setzte das Strava-Token auf exakt `time() + 3600` — genau `StravaApi::ACCESS_TOKEN_MINIMUM_VALIDITY`. `setAccessToken()` wirft `"Strava access token needs to be refreshed"`, wenn `expiresAt - time() < 3600`. Tickte zwischen `setUp()` (Token-Erzeugung) und der Importer-Konstruktion eine **Sekundengrenze**, fiel die Differenz unter 3600 → Test-Error. Ein intermittierender Fehler, der **jeden** PR-CI-Lauf zufällig rot machen konnte (z. B. zuletzt #1428).

## Fix
Token-Gültigkeit deutlich über die Schwelle setzen (`time() + 86400`).

## Test Plan
- Test-Datei 5× hintereinander grün (DB-frei, 6 Tests/38 Assertions). PHPStan sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)