### PR TITLE
Fix: Ride-Vor/Zurück-Navigation bleibt in derselben Stadt (#1353)

### DIFF
--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -367,6 +367,46 @@ class RideRepository extends ServiceEntityRepository
         return $query->getOneOrNullResult();
     }
 
+    /**
+     * Vorheriger Ride DERSELBEN Stadt (#1353): das generische
+     * ordered-entities-Bundle scopt die City nicht zuverlässig und navigiert
+     * stadtübergreifend, daher hier eine explizit stadt-gescopte Abfrage.
+     */
+    public function getPreviousRide(Ride $ride): ?Ride
+    {
+        $builder = $this->createQueryBuilder('r');
+
+        $builder
+            ->select('r')
+            ->where($builder->expr()->lt('r.dateTime', ':dateTime'))
+            ->andWhere($builder->expr()->eq('r.city', ':city'))
+            ->addOrderBy('r.dateTime', 'DESC')
+            ->setMaxResults(1)
+            ->setParameter('city', $ride->getCity())
+            ->setParameter('dateTime', $ride->getDateTime());
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
+    /**
+     * Nächster Ride DERSELBEN Stadt (#1353).
+     */
+    public function getNextRide(Ride $ride): ?Ride
+    {
+        $builder = $this->createQueryBuilder('r');
+
+        $builder
+            ->select('r')
+            ->where($builder->expr()->gt('r.dateTime', ':dateTime'))
+            ->andWhere($builder->expr()->eq('r.city', ':city'))
+            ->addOrderBy('r.dateTime', 'ASC')
+            ->setMaxResults(1)
+            ->setParameter('city', $ride->getCity())
+            ->setParameter('dateTime', $ride->getDateTime());
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
     public function getLocationsForCity(City $city): array
     {
         $builder = $this->createQueryBuilder('r');

--- a/src/Twig/Extension/RideNavigationTwigExtension.php
+++ b/src/Twig/Extension/RideNavigationTwigExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Stadt-gescopte Vor-/Zurück-Navigation zwischen Rides (#1353). Ersetzt die
+ * generischen ordered-entities-Funktionen, die die City nicht zuverlässig
+ * scopen und stadtübergreifend navigieren.
+ */
+class RideNavigationTwigExtension extends AbstractExtension
+{
+    public function __construct(private readonly RideRepository $rideRepository)
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('previous_ride', [$this, 'previousRide']),
+            new TwigFunction('next_ride', [$this, 'nextRide']),
+        ];
+    }
+
+    public function previousRide(Ride $ride): ?Ride
+    {
+        return $this->rideRepository->getPreviousRide($ride);
+    }
+
+    public function nextRide(Ride $ride): ?Ride
+    {
+        return $this->rideRepository->getNextRide($ride);
+    }
+
+    public function getName(): string
+    {
+        return 'ride_navigation_extension';
+    }
+}

--- a/templates/Ride/Includes/_pagination.html.twig
+++ b/templates/Ride/Includes/_pagination.html.twig
@@ -1,21 +1,21 @@
-{% set previous_ride = previous_entity(ride) %}
-{% set next_ride = next_entity(ride) %}
+{% set previousRide = previous_ride(ride) %}
+{% set nextRide = next_ride(ride) %}
 
 <nav aria-label="Tour Navigation" class="mt-4">
     <div class="d-flex justify-content-between">
-        {% if previous_ride %}
-            <a href="{{ object_path(previous_ride) }}" class="btn btn-outline-secondary">
+        {% if previousRide %}
+            <a href="{{ object_path(previousRide) }}" class="btn btn-outline-secondary">
                 <i class="far fa-chevron-left me-2"></i>
-                <span class="d-none d-sm-inline">{{ previous_ride.dateTime|date('d.m.Y') }}</span>
+                <span class="d-none d-sm-inline">{{ previousRide.dateTime|date('d.m.Y') }}</span>
                 <span class="d-sm-none">Vorige</span>
             </a>
         {% else %}
             <span></span>
         {% endif %}
 
-        {% if next_ride %}
-            <a href="{{ object_path(next_ride) }}" class="btn btn-outline-secondary">
-                <span class="d-none d-sm-inline">{{ next_ride.dateTime|date('d.m.Y') }}</span>
+        {% if nextRide %}
+            <a href="{{ object_path(nextRide) }}" class="btn btn-outline-secondary">
+                <span class="d-none d-sm-inline">{{ nextRide.dateTime|date('d.m.Y') }}</span>
                 <span class="d-sm-none">Nächste</span>
                 <i class="far fa-chevron-right ms-2"></i>
             </a>

--- a/tests/Repository/RideRepositoryNavigationTest.php
+++ b/tests/Repository/RideRepositoryNavigationTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Regression für #1353: Vor-/Zurück-Navigation muss innerhalb DERSELBEN Stadt
+ * bleiben (nicht stadtübergreifend springen).
+ */
+final class RideRepositoryNavigationTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private RideRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::getContainer()->get('doctrine')->getManager();
+        $this->repository = self::getContainer()->get(RideRepository::class);
+        $this->em->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->em->getConnection();
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+        parent::tearDown();
+    }
+
+    private function city(string $name): City
+    {
+        $city = new City();
+        $city->setCity($name);
+        $city->setTitle('Critical Mass ' . $name);
+        $city->setCreatedAt(new \DateTime());
+        $this->em->persist($city);
+
+        $slug = new CitySlug();
+        $slug->setSlug('nav-' . substr(md5(uniqid('', true)), 0, 10));
+        $slug->setCity($city);
+        $this->em->persist($slug);
+        $city->setMainSlug($slug);
+
+        return $city;
+    }
+
+    private function ride(City $city, string $date): Ride
+    {
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime($date));
+        $ride->setTitle('Ride ' . $date);
+        $this->em->persist($ride);
+
+        return $ride;
+    }
+
+    public function testNavigationStaysWithinSameCity(): void
+    {
+        $cityA = $this->city('Stadt A');
+        $cityB = $this->city('Stadt B');
+
+        $a1 = $this->ride($cityA, '2026-03-01 19:00:00');
+        $a2 = $this->ride($cityA, '2026-04-01 19:00:00');
+        $a3 = $this->ride($cityA, '2026-05-01 19:00:00');
+        // Stadt B hat einen Ride zwischen und nach den A-Rides — darf NICHT auftauchen.
+        $this->ride($cityB, '2026-04-15 19:00:00');
+        $this->ride($cityB, '2026-09-01 19:00:00');
+
+        $this->em->flush();
+
+        self::assertSame($a1->getId(), $this->repository->getPreviousRide($a2)?->getId());
+        self::assertSame($a3->getId(), $this->repository->getNextRide($a2)?->getId());
+    }
+
+    public function testNoNeighbourAcrossCityBoundary(): void
+    {
+        $cityA = $this->city('Stadt A');
+        $cityB = $this->city('Stadt B');
+
+        $a1 = $this->ride($cityA, '2026-03-01 19:00:00');
+        // Späterer Ride NUR in Stadt B → getNextRide für den letzten A-Ride muss null sein.
+        $this->ride($cityB, '2026-12-01 19:00:00');
+
+        $this->em->flush();
+
+        self::assertNull($this->repository->getNextRide($a1), 'Kein nächster Ride in derselben Stadt');
+        self::assertNull($this->repository->getPreviousRide($a1), 'Kein vorheriger Ride in derselben Stadt');
+    }
+}


### PR DESCRIPTION
## Summary
Auf der Ride-Detailseite zeigten **beide** Navigations-Buttons denselben Ride einer **anderen Stadt** (z. B. von `/hamburg/...` verlinkten beide auf einen Stuttgart-Ride). Die Buttons nutzten die generischen `ordered-entities`-Funktionen (`previous_entity`/`next_entity`); deren Doctrine-Criteria-Vergleich auf der `city`-Assoziation scopt nicht zuverlässig → stadtübergreifende Navigation.

- Stadt-gescopte `RideRepository::getPreviousRide()` / `getNextRide()` (gleiche Stadt, nach `dateTime` sortiert, `LIMIT 1`) — analog zur bereits korrekt scopenden `getPreviousRideWithSubrides()`.
- Kleine Twig-Extension `previous_ride()` / `next_ride()`, in `Ride/Includes/_pagination.html.twig` verwendet.

## Test Plan
- Neuer Repository-Test: Navigation bleibt in derselben Stadt und überspringt keine Stadtgrenze (auch: kein Nachbar in anderer Stadt).
- `lint:twig` ok, PHPStan Level 6 sauber.

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)