### PR TITLE
MCP + API: Städte bearbeiten und deaktivieren

### DIFF
--- a/src/Controller/Api/CityController.php
+++ b/src/Controller/Api/CityController.php
@@ -11,6 +11,8 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CityController extends BaseController
 {
@@ -145,6 +147,60 @@ class CityController extends BaseController
 
         $manager->persist($city);
         $manager->flush();
+
+        return $this->createStandardResponse($city, ['groups' => ['ride-list']]);
+    }
+
+    /**
+     * Updates an existing city.
+     */
+    #[Route(path: '/api/{citySlug}', name: 'caldera_criticalmass_rest_city_update', methods: ['POST'], priority: 170, requirements: ['citySlug' => '(?!doc$|doc\.json$)[^/]+'])]
+    #[OA\Tag(name: 'City')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city to be updated', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON representation of city', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the submitted city is invalid')]
+    public function updateCityAction(Request $request, City $city, ValidatorInterface $validator): JsonResponse
+    {
+        $this->deserializeRequestInto($request, $city);
+
+        $constraintViolationList = $validator->validate($city);
+
+        $errorList = [];
+
+        /** @var ConstraintViolation $constraintViolation */
+        foreach ($constraintViolationList as $constraintViolation) {
+            $errorList[$constraintViolation->getPropertyPath()] = $constraintViolation->getMessage();
+        }
+
+        if (0 < count($errorList)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, $errorList);
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($city, ['groups' => ['ride-list']]);
+    }
+
+    /**
+     * Enables or disables a city. A disabled city is kept but hidden.
+     */
+    #[Route(path: '/api/{citySlug}/enabled', name: 'caldera_criticalmass_rest_city_set_enabled', methods: ['POST'], priority: 190)]
+    #[OA\Tag(name: 'City')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON object with an "enabled" boolean', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the "enabled" flag is missing or not a boolean')]
+    public function setCityEnabledAction(Request $request, City $city): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload) || !array_key_exists('enabled', $payload) || !is_bool($payload['enabled'])) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['enabled' => 'A boolean "enabled" flag is required.']);
+        }
+
+        $city->setEnabled($payload['enabled']);
+        $this->managerRegistry->getManager()->flush();
 
         return $this->createStandardResponse($city, ['groups' => ['ride-list']]);
     }

--- a/src/Mcp/Tool/SetCityEnabledTool.php
+++ b/src/Mcp/Tool/SetCityEnabledTool.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: aktiviert bzw. deaktiviert eine Stadt über das enabled-Flag.
+ * Deaktivierte Städte bleiben erhalten, werden aber ausgeblendet.
+ */
+final class SetCityEnabledTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'set_city_enabled';
+    }
+
+    public function description(): string
+    {
+        return 'Aktiviert oder deaktiviert eine Stadt (enabled-Flag). enabled=false blendet die Stadt aus.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'enabled' => ['type' => 'boolean', 'description' => 'true = aktivieren, false = deaktivieren.'],
+            ],
+            'required' => ['citySlug', 'enabled'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::CityWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!array_key_exists('enabled', $arguments) || !\is_bool($arguments['enabled'])) {
+            throw new McpToolException('enabled muss ein Boolean sein (true oder false).');
+        }
+
+        $city = $this->resolver->city((string) ($arguments['citySlug'] ?? ''));
+        $city->setEnabled($arguments['enabled']);
+
+        $this->registry->getManager()->flush();
+
+        return json_encode([
+            'status' => 'ok',
+            'city' => $city->getMainSlugString(),
+            'enabled' => $city->isEnabled(),
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/UpdateCityTool.php
+++ b/src/Mcp/Tool/UpdateCityTool.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Write-Tool: spiegelt POST /api/{citySlug} (Stadt bearbeiten).
+ */
+final class UpdateCityTool extends AbstractWriteTool
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        CriticalSerializerInterface $serializer,
+        ValidatorInterface $validator,
+        private readonly EntityResolver $resolver,
+    ) {
+        parent::__construct($registry, $serializer, $validator);
+    }
+
+    public function name(): string
+    {
+        return 'update_city';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert eine bestehende Stadt (Name, Titel, Beschreibung, Koordinaten, Zeitzone).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'city' => [
+                    'type' => 'object',
+                    'description' => 'Zu ändernde Stadt-Felder (api-write), z. B. city, title, description, latitude, longitude, timezone.',
+                ],
+            ],
+            'required' => ['citySlug', 'city'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::CityWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $city = $this->resolver->city((string) ($arguments['citySlug'] ?? ''));
+
+        $this->deserializeInto(\is_array($arguments['city'] ?? null) ? $arguments['city'] : [], $city);
+
+        $this->validateEntity($city);
+        $this->flush();
+
+        return $this->serializer->serialize($city, 'json', ['groups' => ['ride-list']]);
+    }
+}

--- a/tests/Controller/Api/CityApi/CityApiWriteTest.php
+++ b/tests/Controller/Api/CityApi/CityApiWriteTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\CityApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests der schreibenden City-Endpunkte (Edit, Aktivieren/Deaktivieren).
+ * Jede Testmethode läuft in einer zurückgerollten Transaktion, damit die
+ * angelegte Test-Stadt die Fixtures nicht verunreinigt.
+ */
+class CityApiWriteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createCity(): City
+    {
+        $slug = 'api-write-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Schreibstadt');
+        $city->setTitle('Critical Mass Schreibstadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+
+        $city->setMainSlug($citySlug);
+        $this->entityManager->flush();
+
+        return $city;
+    }
+
+    public function testUpdateCityChangesTitle(): void
+    {
+        $city = $this->createCity();
+        $slug = $city->getMainSlugString();
+
+        $this->client->request('POST', '/api/' . $slug, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Geänderter Titel']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $cityId = $city->getId();
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(City::class)->find($cityId);
+        $this->assertSame('Geänderter Titel', $updated?->getTitle());
+    }
+
+    public function testUpdateCityRejectsBlankName(): void
+    {
+        $city = $this->createCity();
+        $slug = $city->getMainSlugString();
+
+        $this->client->request('POST', '/api/' . $slug, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['name' => '']));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testDeactivateCity(): void
+    {
+        $city = $this->createCity();
+        $slug = $city->getMainSlugString();
+
+        $this->client->request('POST', '/api/' . $slug . '/enabled', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['enabled' => false]));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $cityId = $city->getId();
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(City::class)->find($cityId);
+        $this->assertFalse($reloaded?->isEnabled());
+    }
+
+    public function testSetCityEnabledRejectsMissingFlag(): void
+    {
+        $city = $this->createCity();
+        $slug = $city->getMainSlugString();
+
+        $this->client->request('POST', '/api/' . $slug . '/enabled', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['foo' => 'bar']));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -53,6 +53,57 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertStringContainsString('existiert bereits', $result['text']);
     }
 
+    public function testUpdateCityChangesTitle(): void
+    {
+        $city = $this->createCity('Alt-Stadt');
+        $token = $this->obtainAccessToken('city:write');
+
+        $result = $this->callTool($token, 'update_city', [
+            'citySlug' => $city->getMainSlugString(),
+            'city' => ['title' => 'Neuer Titel'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $cityId = $city->getId();
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(\App\Entity\City::class)->find($cityId);
+        self::assertSame('Neuer Titel', $updated?->getTitle());
+    }
+
+    public function testSetCityEnabledDisablesCity(): void
+    {
+        $city = $this->createCity();
+        $token = $this->obtainAccessToken('city:write');
+
+        $result = $this->callTool($token, 'set_city_enabled', [
+            'citySlug' => $city->getMainSlugString(),
+            'enabled' => false,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertFalse($result['json']['enabled']);
+
+        $cityId = $city->getId();
+        $this->em()->clear();
+        $reloaded = $this->em()->getRepository(\App\Entity\City::class)->find($cityId);
+        self::assertFalse($reloaded?->isEnabled());
+    }
+
+    public function testSetCityEnabledRejectsNonBoolean(): void
+    {
+        $city = $this->createCity();
+        $token = $this->obtainAccessToken('city:write');
+
+        $result = $this->callTool($token, 'set_city_enabled', [
+            'citySlug' => $city->getMainSlugString(),
+            'enabled' => 'nein',
+        ]);
+
+        self::assertTrue($result['isError']);
+        self::assertStringContainsString('Boolean', $result['text']);
+    }
+
     public function testCreateRidePersistsRide(): void
     {
         $city = $this->createCity();


### PR DESCRIPTION
## Summary

Erweitert MCP-Server **und** REST-API um volles Admin-CRUD für Städte über das bisherige *create* hinaus (Teil der Initiative „alle CRUD-Operationen via MCP", PR 1 von 8).

- **MCP-Tool `update_city`** (`city:write`) — bestehende Stadt bearbeiten (api-write-Felder: name, title, description, latitude, longitude, timezone).
- **MCP-Tool `set_city_enabled`** (`city:write`) — Stadt aktivieren/deaktivieren über das `enabled`-Flag (Soft-Hide, Entity bleibt erhalten).
- **REST `POST /api/{citySlug}`** — Stadt editieren (validiert, 400 bei Fehlern).
- **REST `POST /api/{citySlug}/enabled`** — `enabled`-Flag umschalten.

Gating unverändert scope-basiert (kein zusätzlicher Rollen-Check, wie im MCP-Server etabliert).

## Test Plan

- [x] Neue MCP-Integrationstests: `update_city`, `set_city_enabled` (inkl. Boolean-Validierung)
- [x] Neue CityApi-Write-Tests: Edit, Blank-Name-Ablehnung, Deaktivieren, fehlendes Flag
- [x] `tests/Mcp` + `tests/OAuth2`: 108/108 grün
- [x] `tests/Controller/Api/CityApi`: 68/68 grün
- [x] PHPStan (Level 6) auf `src/Mcp` + `CityController`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)