### PR TITLE
MCP + API: Schätzungen ändern, löschen, auflisten

### DIFF
--- a/src/Controller/Api/EstimateController.php
+++ b/src/Controller/Api/EstimateController.php
@@ -8,7 +8,10 @@ use MalteHuebner\DataQueryBundle\RequestParameterList\RequestParameterList;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Event\RideEstimate\RideEstimateCreatedEvent;
+use App\Event\RideEstimate\RideEstimateDeletedEvent;
+use App\Event\RideEstimate\RideEstimateUpdatedEvent;
 use App\Model\CreateEstimateModel;
+use App\Repository\RideEstimateRepository;
 use App\Serializer\CriticalSerializerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -116,6 +119,104 @@ class EstimateController extends BaseController
         $this->eventDispatcher->dispatch(new RideEstimateCreatedEvent($rideEstimation), RideEstimateCreatedEvent::NAME);
 
         return $this->createStandardResponse($rideEstimation);
+    }
+
+    /**
+     * Lists all participant estimates of a ride, including their ids.
+     */
+    #[Route(path: '/api/{citySlug}/{rideIdentifier}/estimates', name: 'caldera_criticalmass_rest_estimate_list', methods: ['GET'], priority: 190)]
+    #[OA\Tag(name: 'Estimate')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the ride\'s city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    public function listRideEstimatesAction(Ride $ride, RideEstimateRepository $repository): JsonResponse
+    {
+        $estimates = [];
+
+        foreach ($repository->findEstimatesByRide($ride) as $estimate) {
+            $estimates[] = [
+                'id' => $estimate->getId(),
+                'estimation' => $estimate->getEstimatedParticipants(),
+                'latitude' => $estimate->getLatitude(),
+                'longitude' => $estimate->getLongitude(),
+                'dateTime' => $estimate->getDateTime()->format(\DateTimeInterface::ATOM),
+                'source' => $estimate->getSource(),
+                'user' => $estimate->getUser()?->getUsername(),
+            ];
+        }
+
+        return new JsonResponse(['estimates' => $estimates]);
+    }
+
+    /**
+     * Updates an existing participant estimate identified by its id.
+     */
+    #[Route(path: '/api/estimate/{id}', name: 'caldera_criticalmass_rest_estimate_update', methods: ['POST'], priority: 200, requirements: ['id' => '\d+'])]
+    #[OA\Tag(name: 'Estimate')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the estimate to update', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\RequestBody(description: 'JSON representation of the estimate data', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the submitted data is invalid')]
+    public function updateRideEstimateAction(Request $request, RideEstimate $rideEstimate): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (array_key_exists('estimation', $payload)) {
+            if (!is_numeric($payload['estimation']) || (int) $payload['estimation'] < 0) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['estimation' => 'estimation must be a non-negative number.']);
+            }
+            $rideEstimate->setEstimatedParticipants((int) $payload['estimation']);
+        }
+
+        if (array_key_exists('latitude', $payload)) {
+            $rideEstimate->setLatitude(null === $payload['latitude'] ? null : (float) $payload['latitude']);
+        }
+
+        if (array_key_exists('longitude', $payload)) {
+            $rideEstimate->setLongitude(null === $payload['longitude'] ? null : (float) $payload['longitude']);
+        }
+
+        if (array_key_exists('date_time', $payload)) {
+            try {
+                $rideEstimate->setDateTime(new \DateTime((string) $payload['date_time']));
+            } catch (\Exception) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['date_time' => 'date_time is not a valid datetime.']);
+            }
+        }
+
+        if (array_key_exists('source', $payload)) {
+            $rideEstimate->setSource(null === $payload['source'] ? null : (string) $payload['source']);
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        $this->eventDispatcher->dispatch(new RideEstimateUpdatedEvent($rideEstimate), RideEstimateUpdatedEvent::NAME);
+
+        return $this->createStandardResponse($rideEstimate);
+    }
+
+    /**
+     * Deletes a participant estimate identified by its id.
+     */
+    #[Route(path: '/api/estimate/{id}', name: 'caldera_criticalmass_rest_estimate_delete', methods: ['DELETE'], priority: 200, requirements: ['id' => '\d+'])]
+    #[OA\Tag(name: 'Estimate')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the estimate to delete', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    public function deleteRideEstimateAction(RideEstimate $rideEstimate): JsonResponse
+    {
+        $id = $rideEstimate->getId();
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->remove($rideEstimate);
+        $manager->flush();
+
+        $this->eventDispatcher->dispatch(new RideEstimateDeletedEvent($rideEstimate), RideEstimateDeletedEvent::NAME);
+
+        return new JsonResponse(['status' => 'ok', 'deletedId' => $id]);
     }
 
     protected function createRideEstimate(CreateEstimateModel $model, ?Ride $ride = null): ?RideEstimate

--- a/src/Mcp/Support/EntityResolver.php
+++ b/src/Mcp/Support/EntityResolver.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Support;
 use App\Entity\City;
 use App\Entity\CitySlug;
 use App\Entity\Ride;
+use App\Entity\RideEstimate;
 use App\Mcp\Tool\McpToolException;
 use App\Repository\RideRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -66,5 +67,16 @@ final class EntityResolver
         }
 
         return $ride;
+    }
+
+    public function rideEstimate(int $id): RideEstimate
+    {
+        $estimate = $this->registry->getRepository(RideEstimate::class)->find($id);
+
+        if (null === $estimate) {
+            throw new McpToolException(sprintf('Keine Schätzung mit der ID %d gefunden.', $id));
+        }
+
+        return $estimate;
     }
 }

--- a/src/Mcp/Tool/DeleteRideEstimateTool.php
+++ b/src/Mcp/Tool/DeleteRideEstimateTool.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Event\RideEstimate\RideEstimateDeletedEvent;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Write-Tool: löscht eine Teilnehmerzahl-Schätzung (per ID). Feuert
+ * RideEstimateDeletedEvent, damit die aggregierten Ride-Schätzungen neu
+ * berechnet werden. IDs liefert list_ride_estimates.
+ */
+final class DeleteRideEstimateTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_ride_estimate';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht eine Teilnehmerzahl-Schätzung (per ID).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'estimateId' => ['type' => 'integer', 'description' => 'ID der Schätzung (siehe list_ride_estimates).'],
+            ],
+            'required' => ['estimateId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::EstimateWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['estimateId']) || !is_numeric($arguments['estimateId'])) {
+            throw new McpToolException('estimateId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $estimate = $this->resolver->rideEstimate((int) $arguments['estimateId']);
+        $id = $estimate->getId();
+
+        $manager = $this->registry->getManager();
+        $manager->remove($estimate);
+        $manager->flush();
+
+        // Nach dem Löschen feuern: der Handler berechnet die verbleibenden
+        // Schätzungen des Rides neu (der Estimate hält die Ride-Referenz weiter).
+        $this->eventDispatcher->dispatch(new RideEstimateDeletedEvent($estimate), RideEstimateDeletedEvent::NAME);
+
+        return json_encode(['status' => 'ok', 'deletedId' => $id], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/ListRideEstimatesTool.php
+++ b/src/Mcp/Tool/ListRideEstimatesTool.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Repository\RideEstimateRepository;
+
+/**
+ * Read-Tool: listet die Teilnehmerzahl-Schätzungen eines Rides inkl. ihrer IDs.
+ * Die IDs werden von update_ride_estimate / delete_ride_estimate benötigt.
+ */
+final class ListRideEstimatesTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly RideEstimateRepository $repository,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'list_ride_estimates';
+    }
+
+    public function description(): string
+    {
+        return 'Listet alle Teilnehmerzahl-Schätzungen eines Rides mit ihren IDs.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+            ],
+            'required' => ['citySlug', 'rideIdentifier'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::RideRead;
+    }
+
+    public function call(array $arguments): string
+    {
+        $ride = $this->resolver->ride((string) ($arguments['citySlug'] ?? ''), (string) ($arguments['rideIdentifier'] ?? ''));
+
+        $estimates = [];
+        foreach ($this->repository->findEstimatesByRide($ride) as $estimate) {
+            $estimates[] = [
+                'id' => $estimate->getId(),
+                'estimation' => $estimate->getEstimatedParticipants(),
+                'latitude' => $estimate->getLatitude(),
+                'longitude' => $estimate->getLongitude(),
+                'dateTime' => $estimate->getDateTime()->format(\DateTimeInterface::ATOM),
+                'source' => $estimate->getSource(),
+                'user' => $estimate->getUser()?->getUsername(),
+            ];
+        }
+
+        return json_encode(['estimates' => $estimates], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/UpdateRideEstimateTool.php
+++ b/src/Mcp/Tool/UpdateRideEstimateTool.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Event\RideEstimate\RideEstimateUpdatedEvent;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Write-Tool: aktualisiert eine bestehende Teilnehmerzahl-Schätzung (per ID).
+ * Feuert RideEstimateUpdatedEvent, damit die aggregierten Ride-Schätzungen
+ * neu berechnet werden. IDs liefert list_ride_estimates.
+ */
+final class UpdateRideEstimateTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'update_ride_estimate';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert eine bestehende Teilnehmerzahl-Schätzung (per ID).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'estimateId' => ['type' => 'integer', 'description' => 'ID der Schätzung (siehe list_ride_estimates).'],
+                'estimation' => ['type' => 'integer', 'description' => 'Neue geschätzte Teilnehmerzahl.', 'minimum' => 0],
+                'latitude' => ['type' => 'number', 'description' => 'Neuer Breitengrad der Schätzung.'],
+                'longitude' => ['type' => 'number', 'description' => 'Neuer Längengrad der Schätzung.'],
+                'dateTime' => ['type' => 'string', 'description' => 'Neuer Zeitpunkt der Schätzung (ISO 8601).'],
+                'source' => ['type' => 'string', 'description' => 'Neue Quelle der Schätzung.'],
+            ],
+            'required' => ['estimateId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::EstimateWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['estimateId']) || !is_numeric($arguments['estimateId'])) {
+            throw new McpToolException('estimateId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $estimate = $this->resolver->rideEstimate((int) $arguments['estimateId']);
+
+        if (array_key_exists('estimation', $arguments)) {
+            if ((int) $arguments['estimation'] < 0) {
+                throw new McpToolException('estimation muss eine nichtnegative Zahl sein.');
+            }
+            $estimate->setEstimatedParticipants((int) $arguments['estimation']);
+        }
+
+        if (array_key_exists('latitude', $arguments)) {
+            $estimate->setLatitude(null === $arguments['latitude'] ? null : (float) $arguments['latitude']);
+        }
+
+        if (array_key_exists('longitude', $arguments)) {
+            $estimate->setLongitude(null === $arguments['longitude'] ? null : (float) $arguments['longitude']);
+        }
+
+        if (array_key_exists('dateTime', $arguments)) {
+            try {
+                $estimate->setDateTime(new \DateTime((string) $arguments['dateTime']));
+            } catch (\Exception) {
+                throw new McpToolException('dateTime ist kein gültiger Zeitpunkt.');
+            }
+        }
+
+        if (array_key_exists('source', $arguments)) {
+            $estimate->setSource(null === $arguments['source'] ? null : (string) $arguments['source']);
+        }
+
+        $this->registry->getManager()->flush();
+
+        $this->eventDispatcher->dispatch(new RideEstimateUpdatedEvent($estimate), RideEstimateUpdatedEvent::NAME);
+
+        return json_encode([
+            'status' => 'ok',
+            'id' => $estimate->getId(),
+            'estimation' => $estimate->getEstimatedParticipants(),
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/Api/EstimateApi/EstimateApiWriteTest.php
+++ b/tests/Controller/Api/EstimateApi/EstimateApiWriteTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\EstimateApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Entity\RideEstimate;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests der schreibenden Estimate-Endpunkte (Liste, Update, Delete). Jede
+ * Testmethode läuft in einer zurückgerollten Transaktion.
+ */
+class EstimateApiWriteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createRideWithEstimate(int $participants = 100): array
+    {
+        $slug = 'estimate-api-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Schätzstadt');
+        $city->setTitle('Critical Mass Schätzstadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime('2026-09-01 19:00:00'));
+        $ride->setTitle('Critical Mass');
+        $this->entityManager->persist($ride);
+
+        $estimate = new RideEstimate();
+        $estimate->setRide($ride);
+        $estimate->setEstimatedParticipants($participants);
+        $estimate->setDateTime(new \DateTime('2026-09-01 19:30:00'));
+        $estimate->setSource('api-test');
+        $this->entityManager->persist($estimate);
+
+        $this->entityManager->flush();
+
+        return [$city, $ride, $estimate];
+    }
+
+    public function testListEstimatesReturnsId(): void
+    {
+        [$city, , $estimate] = $this->createRideWithEstimate();
+
+        $this->client->request('GET', '/api/' . $city->getMainSlugString() . '/2026-09-01/estimates');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+        $ids = array_column($data['estimates'], 'id');
+        $this->assertContains($estimate->getId(), $ids);
+    }
+
+    public function testUpdateEstimateChangesParticipants(): void
+    {
+        [, , $estimate] = $this->createRideWithEstimate(100);
+        $estimateId = $estimate->getId();
+
+        $this->client->request('POST', '/api/estimate/' . $estimateId, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['estimation' => 777]));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(RideEstimate::class)->find($estimateId);
+        $this->assertSame(777, $updated?->getEstimatedParticipants());
+    }
+
+    public function testDeleteEstimateRemovesIt(): void
+    {
+        [, , $estimate] = $this->createRideWithEstimate();
+        $estimateId = $estimate->getId();
+
+        $this->client->request('DELETE', '/api/estimate/' . $estimateId);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(RideEstimate::class)->find($estimateId));
+    }
+
+    public function testUpdateEstimateRejectsNegative(): void
+    {
+        [, , $estimate] = $this->createRideWithEstimate();
+
+        $this->client->request('POST', '/api/estimate/' . $estimate->getId(), [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['estimation' => -5]));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Mcp/AbstractMcpTestCase.php
+++ b/tests/Mcp/AbstractMcpTestCase.php
@@ -8,6 +8,7 @@ use App\Entity\CitySlug;
 use App\Entity\Location;
 use App\Entity\Photo;
 use App\Entity\Ride;
+use App\Entity\RideEstimate;
 use App\Entity\Subride;
 use App\Entity\Track;
 use App\Entity\User;
@@ -256,6 +257,19 @@ abstract class AbstractMcpTestCase extends WebTestCase
         $this->em()->flush();
 
         return $subride;
+    }
+
+    protected function createRideEstimate(Ride $ride, int $participants = 100): RideEstimate
+    {
+        $estimate = new RideEstimate();
+        $estimate->setRide($ride);
+        $estimate->setEstimatedParticipants($participants);
+        $estimate->setDateTime(new \DateTime('2026-09-01 19:30:00'));
+        $estimate->setSource('test');
+        $this->em()->persist($estimate);
+        $this->em()->flush();
+
+        return $estimate;
     }
 
     protected function createCityCycle(City $city): CityCycle

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -190,6 +190,75 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertCount(1, $this->em()->getRepository(RideEstimate::class)->findBy(['ride' => $ride]));
     }
 
+    public function testListRideEstimatesReturnsIds(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $estimate = $this->createRideEstimate($ride, 123);
+        $token = $this->obtainAccessToken('ride:read');
+
+        $result = $this->callTool($token, 'list_ride_estimates', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        $ids = array_column($result['json']['estimates'], 'id');
+        self::assertContains($estimate->getId(), $ids);
+    }
+
+    public function testUpdateRideEstimateChangesEstimation(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $estimate = $this->createRideEstimate($ride, 100);
+        $token = $this->obtainAccessToken('estimate:write');
+
+        $result = $this->callTool($token, 'update_ride_estimate', [
+            'estimateId' => $estimate->getId(),
+            'estimation' => 555,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $estimateId = $estimate->getId();
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(RideEstimate::class)->find($estimateId);
+        self::assertSame(555, $updated?->getEstimatedParticipants());
+    }
+
+    public function testDeleteRideEstimateRemovesIt(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $estimate = $this->createRideEstimate($ride, 100);
+        $token = $this->obtainAccessToken('estimate:write');
+
+        $estimateId = $estimate->getId();
+
+        $result = $this->callTool($token, 'delete_ride_estimate', [
+            'estimateId' => $estimateId,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        self::assertNull($this->em()->getRepository(RideEstimate::class)->find($estimateId));
+    }
+
+    public function testUpdateRideEstimateRejectsUnknownId(): void
+    {
+        $token = $this->obtainAccessToken('estimate:write');
+
+        $result = $this->callTool($token, 'update_ride_estimate', [
+            'estimateId' => 999999999,
+            'estimation' => 10,
+        ]);
+
+        self::assertTrue($result['isError']);
+        self::assertStringContainsString('ID', $result['text']);
+    }
+
     public function testSetWeatherPersists(): void
     {
         $city = $this->createCity();


### PR DESCRIPTION
## Summary

Macht Teilnehmerzahl-Schätzungen voll editierbar (bisher nur *create*). Teil der Initiative „alle CRUD-Operationen via MCP" (PR 2 von 8).

> **Stacked auf #1439** (Basis `feature/mcp-city-crud`). Bitte nach PR 1 mergen; GitHub retargetet automatisch auf `main`.

- **MCP `list_ride_estimates`** (`ride:read`) — Schätzungen eines Rides inkl. IDs.
- **MCP `update_ride_estimate`** (`estimate:write`) — Schätzung per ID ändern; feuert `RideEstimateUpdatedEvent` → Ride-Aggregate werden neu berechnet.
- **MCP `delete_ride_estimate`** (`estimate:write`) — Schätzung per ID löschen; feuert `RideEstimateDeletedEvent`.
- **REST `GET /api/{citySlug}/{rideIdentifier}/estimates`** — Liste mit IDs.
- **REST `POST /api/estimate/{id}`** — Update; **`DELETE /api/estimate/{id}`** — Delete.

`EntityResolver` bekommt `rideEstimate(id)`. Die Events sorgen dafür, dass geänderte/gelöschte Schätzungen korrekt in die aggregierten Ride-Zahlen einfließen.

## Test Plan

- [x] MCP-Integrationstests: Liste (IDs), Update (Zahl ändert sich), Delete (weg), unbekannte ID
- [x] EstimateApi-Write-Tests: Liste, Update, Delete, negative Zahl → 400
- [x] `tests/Mcp` + `tests/Controller/Api/EstimateApi`: 109/109 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)