### PR TITLE
MCP + API: Rides deaktivieren, Cycles löschen

### DIFF
--- a/src/Controller/Api/CycleController.php
+++ b/src/Controller/Api/CycleController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Api;
 use App\Entity\City;
 use App\Entity\CityCycle;
 use App\Entity\Region;
+use App\Entity\Ride;
 use App\Repository\CityCycleRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -139,5 +140,38 @@ class CycleController extends BaseController
         $manager->flush();
 
         return $this->createStandardResponse($cycle);
+    }
+
+    /**
+     * Deletes a cycle. Rides created from the cycle are kept (detached).
+     */
+    #[Route(path: '/api/{citySlug}/cycles/{cycleId}', name: 'caldera_criticalmass_rest_cycles_delete', methods: ['DELETE'], priority: 190)]
+    #[OA\Tag(name: 'Cycles')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'cycleId', in: 'path', description: 'Id of the cycle to delete', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successfully deleted')]
+    #[OA\Response(response: 404, description: 'Returned when the cycle does not belong to the city')]
+    public function deleteCycleAction(City $city, int $cycleId, CityCycleRepository $cityCycleRepository): JsonResponse
+    {
+        $cycle = $cityCycleRepository->find($cycleId);
+
+        if (!$cycle || $cycle->getCity()->getId() !== $city->getId()) {
+            return new JsonResponse(['error' => 'Cycle not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $manager = $this->managerRegistry->getManager();
+
+        // Detach rides explicitly (null the cycle_id FK) so the association's
+        // cascade-remove does not delete them.
+        $rides = $manager->getRepository(Ride::class)->findBy(['cycle' => $cycle]);
+        foreach ($rides as $ride) {
+            $ride->setCycle(null);
+        }
+        $manager->flush();
+
+        $manager->remove($cycle);
+        $manager->flush();
+
+        return new JsonResponse(['status' => 'ok', 'deletedCycleId' => $cycleId]);
     }
 }

--- a/src/Controller/Api/RideController.php
+++ b/src/Controller/Api/RideController.php
@@ -256,4 +256,28 @@ class RideController extends BaseController
 
         return $this->createStandardResponse($ride, ['groups' => ['ride-list']]);
     }
+
+    /**
+     * Enables or disables a ride. A disabled ride is kept but hidden (soft delete).
+     */
+    #[Route(path: '/api/{citySlug}/{rideIdentifier}/enabled', name: 'caldera_criticalmass_rest_ride_set_enabled', methods: ['POST'], priority: 190)]
+    #[OA\Tag(name: 'Ride')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON object with an "enabled" boolean', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the "enabled" flag is missing or not a boolean')]
+    public function setRideEnabledAction(Request $request, Ride $ride): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload) || !array_key_exists('enabled', $payload) || !is_bool($payload['enabled'])) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['enabled' => 'A boolean "enabled" flag is required.']);
+        }
+
+        $ride->setEnabled($payload['enabled']);
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($ride, ['groups' => ['ride-list']]);
+    }
 }

--- a/src/Mcp/Tool/DeleteCycleTool.php
+++ b/src/Mcp/Tool/DeleteCycleTool.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Ride;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Repository\CityCycleRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: löscht einen Termin-Zyklus einer Stadt. Bereits aus dem Zyklus
+ * erzeugte Rides werden vorher entkoppelt (cycle = null), damit sie NICHT durch
+ * das cascade-remove der Zuordnung mitgelöscht werden.
+ */
+final class DeleteCycleTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly CityCycleRepository $cityCycleRepository,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_cycle';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht einen Termin-Zyklus einer Stadt. Zugehörige Rides bleiben erhalten (werden entkoppelt).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'cycleId' => ['type' => 'integer', 'description' => 'ID des Cycles.'],
+            ],
+            'required' => ['citySlug', 'cycleId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::CycleWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $city = $this->resolver->city((string) ($arguments['citySlug'] ?? ''));
+        $cycle = $this->cityCycleRepository->find((int) ($arguments['cycleId'] ?? 0));
+
+        if (null === $cycle || $cycle->getCity()?->getId() !== $city->getId()) {
+            throw new McpToolException('Cycle nicht gefunden oder gehört nicht zu dieser Stadt.');
+        }
+
+        $cycleId = $cycle->getId();
+        $manager = $this->registry->getManager();
+
+        // Rides explizit entkoppeln (FK cycle_id nullen), damit das
+        // cascade-remove der Zuordnung sie nicht mitnimmt.
+        $rides = $manager->getRepository(Ride::class)->findBy(['cycle' => $cycle]);
+        foreach ($rides as $ride) {
+            $ride->setCycle(null);
+        }
+        $manager->flush();
+
+        $manager->remove($cycle);
+        $manager->flush();
+
+        return json_encode(['status' => 'ok', 'deletedCycleId' => $cycleId], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/SetRideEnabledTool.php
+++ b/src/Mcp/Tool/SetRideEnabledTool.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: aktiviert bzw. deaktiviert einen Ride über das enabled-Flag.
+ * Deaktivierte Rides bleiben erhalten, werden aber ausgeblendet (Soft-Delete).
+ */
+final class SetRideEnabledTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'set_ride_enabled';
+    }
+
+    public function description(): string
+    {
+        return 'Aktiviert oder deaktiviert einen Ride (enabled-Flag). enabled=false blendet den Ride aus (Soft-Delete).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+                'enabled' => ['type' => 'boolean', 'description' => 'true = aktivieren, false = deaktivieren/ausblenden.'],
+            ],
+            'required' => ['citySlug', 'rideIdentifier', 'enabled'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::RideWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!array_key_exists('enabled', $arguments) || !\is_bool($arguments['enabled'])) {
+            throw new McpToolException('enabled muss ein Boolean sein (true oder false).');
+        }
+
+        $ride = $this->resolver->ride((string) ($arguments['citySlug'] ?? ''), (string) ($arguments['rideIdentifier'] ?? ''));
+        $ride->setEnabled($arguments['enabled']);
+
+        $this->registry->getManager()->flush();
+
+        return json_encode([
+            'status' => 'ok',
+            'ride' => $ride->getTitle() ?? $ride->getDateTime()?->format('Y-m-d'),
+            'enabled' => $ride->isEnabled(),
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Controller/Api/CycleApi/CycleApiDeleteTest.php
+++ b/tests/Controller/Api/CycleApi/CycleApiDeleteTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\CycleApi;
+
+use App\Entity\City;
+use App\Entity\CityCycle;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests des Cycle-Delete-Endpunkts. Prüft insbesondere, dass zugehörige Rides
+ * NICHT mitgelöscht werden. Transaktions-isoliert.
+ */
+class CycleApiDeleteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createCityWithCycleAndRide(): array
+    {
+        $slug = 'cycle-del-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Cyclestadt');
+        $city->setTitle('Critical Mass Cyclestadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+
+        $cycle = new CityCycle();
+        $cycle->setCity($city);
+        $cycle->setDayOfWeek(5);
+        $cycle->setWeekOfMonth(0);
+        $this->entityManager->persist($cycle);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime('2026-09-01 19:00:00'));
+        $ride->setTitle('Critical Mass');
+        $ride->setCycle($cycle);
+        $this->entityManager->persist($ride);
+
+        $this->entityManager->flush();
+
+        return [$city, $cycle, $ride];
+    }
+
+    public function testDeleteCycleKeepsRides(): void
+    {
+        [$city, $cycle, $ride] = $this->createCityWithCycleAndRide();
+        $cycleId = $cycle->getId();
+        $rideId = $ride->getId();
+
+        $this->client->request('DELETE', '/api/' . $city->getMainSlugString() . '/cycles/' . $cycleId);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(CityCycle::class)->find($cycleId));
+        $survivingRide = $this->entityManager->getRepository(Ride::class)->find($rideId);
+        $this->assertNotNull($survivingRide, 'Ride must survive cycle deletion');
+        $this->assertNull($survivingRide->getCycle());
+    }
+
+    public function testDeleteCycleRejectsForeignCity(): void
+    {
+        [, $cycle] = $this->createCityWithCycleAndRide();
+
+        // Zweite Stadt, die den Cycle nicht besitzt.
+        $otherSlug = 'cycle-other-' . substr(md5(uniqid('', true)), 0, 12);
+        $otherCity = new City();
+        $otherCity->setCity('Fremdstadt');
+        $otherCity->setTitle('Critical Mass Fremdstadt');
+        $otherCity->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($otherCity);
+        $otherCitySlug = new CitySlug();
+        $otherCitySlug->setSlug($otherSlug);
+        $otherCitySlug->setCity($otherCity);
+        $this->entityManager->persist($otherCitySlug);
+        $otherCity->setMainSlug($otherCitySlug);
+        $this->entityManager->flush();
+
+        $this->client->request('DELETE', '/api/' . $otherCity->getMainSlugString() . '/cycles/' . $cycle->getId());
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Controller/Api/RideApi/RideApiEnabledTest.php
+++ b/tests/Controller/Api/RideApi/RideApiEnabledTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\RideApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests des Ride enable/disable-Endpunkts. Transaktions-isoliert.
+ */
+class RideApiEnabledTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createRide(): array
+    {
+        $slug = 'ride-enabled-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Ridestadt');
+        $city->setTitle('Critical Mass Ridestadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime('2026-09-01 19:00:00'));
+        $ride->setTitle('Critical Mass');
+        $this->entityManager->persist($ride);
+
+        $this->entityManager->flush();
+
+        return [$city, $ride];
+    }
+
+    public function testDisableRide(): void
+    {
+        [$city, $ride] = $this->createRide();
+        $rideId = $ride->getId();
+
+        $this->client->request('POST', '/api/' . $city->getMainSlugString() . '/2026-09-01/enabled', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['enabled' => false]));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Ride::class)->find($rideId);
+        $this->assertFalse($reloaded?->isEnabled());
+    }
+
+    public function testSetRideEnabledRejectsMissingFlag(): void
+    {
+        [$city] = $this->createRide();
+
+        $this->client->request('POST', '/api/' . $city->getMainSlugString() . '/2026-09-01/enabled', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['foo' => 'bar']));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -140,6 +140,68 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertSame('Neu', $updated?->getTitle());
     }
 
+    public function testSetRideEnabledDisablesRide(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $token = $this->obtainAccessToken('ride:write');
+
+        $result = $this->callTool($token, 'set_ride_enabled', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+            'enabled' => false,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertFalse($result['json']['enabled']);
+
+        $rideId = $ride->getId();
+        $this->em()->clear();
+        $reloaded = $this->em()->getRepository(Ride::class)->find($rideId);
+        self::assertFalse($reloaded?->isEnabled());
+    }
+
+    public function testDeleteCycleKeepsRides(): void
+    {
+        $city = $this->createCity();
+        $cycle = $this->createCityCycle($city);
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $ride->setCycle($cycle);
+        $this->em()->flush();
+
+        $cycleId = $cycle->getId();
+        $rideId = $ride->getId();
+        $token = $this->obtainAccessToken('cycle:write');
+
+        $result = $this->callTool($token, 'delete_cycle', [
+            'citySlug' => $city->getMainSlugString(),
+            'cycleId' => $cycleId,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        self::assertNull($this->em()->getRepository(CityCycle::class)->find($cycleId));
+        $survivingRide = $this->em()->getRepository(Ride::class)->find($rideId);
+        self::assertNotNull($survivingRide, 'Ride must survive cycle deletion');
+        self::assertNull($survivingRide->getCycle());
+    }
+
+    public function testDeleteCycleRejectsForeignCity(): void
+    {
+        $city = $this->createCity();
+        $otherCity = $this->createCity('Andere-Stadt');
+        $cycle = $this->createCityCycle($otherCity);
+        $token = $this->obtainAccessToken('cycle:write');
+
+        $result = $this->callTool($token, 'delete_cycle', [
+            'citySlug' => $city->getMainSlugString(),
+            'cycleId' => $cycle->getId(),
+        ]);
+
+        self::assertTrue($result['isError']);
+    }
+
     public function testSetParticipationPersistsForTokenUser(): void
     {
         $city = $this->createCity();


### PR DESCRIPTION
## Summary

Ergänzt Soft-Delete für Rides und echtes Löschen von Cycles. Teil der Initiative „alle CRUD-Operationen via MCP" (PR 3 von 8).

> **Stacked auf #1440** (Basis `feature/mcp-estimate-crud`). Reihenfolge: #1439 → #1440 → dieser PR.

- **MCP `set_ride_enabled`** (`ride:write`) — Ride aktivieren/deaktivieren (deaktiviert = ausgeblendet, Soft-Delete; symmetrisch zu `set_city_enabled`).
- **MCP `delete_cycle`** (`cycle:write`) — Cycle einer Stadt löschen. Zugehörige Rides werden vorher entkoppelt (`cycle=null`).
- **REST `POST /api/{citySlug}/{rideIdentifier}/enabled`** — Ride umschalten.
- **REST `DELETE /api/{citySlug}/cycles/{cycleId}`** — Cycle sicher löschen.

### Achtung: cascade-remove
`CityCycle.rides` ist als `cascade: ['remove']` gemappt — ein naives `remove($cycle)` würde **alle aus dem Cycle erzeugten Rides mitlöschen**. Beide Wege entkoppeln die Rides daher zuerst über eine explizite Query (`findBy(['cycle' => …])`, FK zuverlässig genullt), bevor der Cycle entfernt wird. Ein Regressionstest sichert ab, dass die Rides das Löschen überleben.

## Test Plan

- [x] MCP-Tests: Ride deaktivieren, Cycle löschen (Rides überleben, cycle=null), fremde Stadt → Fehler
- [x] Controller-Tests: RideApiEnabledTest, CycleApiDeleteTest (inkl. Fremd-Stadt → 404)
- [x] `tests/Mcp` + `tests/OAuth2`: 120/120 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)