### PR TITLE
MCP + API: Locations (Treffpunkte) CRUD

### DIFF
--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -32,6 +32,7 @@ league_oauth2_server:
             - cycle:write
             - socialnetwork:write
             - activity:write
+            - location:write
         default:
             - ride:read
             - track:read

--- a/src/Controller/Api/LocationController.php
+++ b/src/Controller/Api/LocationController.php
@@ -4,9 +4,13 @@ namespace App\Controller\Api;
 
 use App\Entity\City;
 use App\Entity\Location;
+use App\Repository\LocationRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\String\Slugger\SluggerInterface;
 
 class LocationController extends BaseController
 {
@@ -35,5 +39,127 @@ class LocationController extends BaseController
     public function showLocationAction(Location $location): JsonResponse
     {
         return $this->createStandardResponse($location);
+    }
+
+    /**
+     * Creates a new location for a city.
+     */
+    #[Route(path: '/api/{citySlug}/location', name: 'caldera_criticalmass_rest_location_create', methods: ['PUT'], priority: 190)]
+    #[OA\Tag(name: 'Location')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON representation of the location', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the title is missing')]
+    #[OA\Response(response: 409, description: 'Returned when a location with this slug already exists in the city')]
+    public function createLocationAction(Request $request, City $city, SluggerInterface $slugger, LocationRepository $locationRepository): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        $title = trim((string) ($payload['title'] ?? ''));
+
+        if ('' === $title) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['title' => 'A title is required.']);
+        }
+
+        $slug = trim((string) ($payload['slug'] ?? ''));
+        if ('' === $slug) {
+            $slug = strtolower((string) $slugger->slug($title));
+        }
+
+        if (null !== $locationRepository->findOneBy(['city' => $city, 'slug' => $slug])) {
+            return $this->createErrors(JsonResponse::HTTP_CONFLICT, ['slug' => sprintf('A location with slug "%s" already exists in this city.', $slug)]);
+        }
+
+        $location = new Location();
+        $location
+            ->setCity($city)
+            ->setTitle($title)
+            ->setSlug($slug)
+            ->setDescription(isset($payload['description']) ? (string) $payload['description'] : null)
+            ->setLatitude(isset($payload['latitude']) ? (float) $payload['latitude'] : null)
+            ->setLongitude(isset($payload['longitude']) ? (float) $payload['longitude'] : null);
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($location);
+        $manager->flush();
+
+        return $this->createStandardResponse($location);
+    }
+
+    /**
+     * Updates an existing location.
+     */
+    #[Route(path: '/api/{citySlug}/location/{slug}', name: 'caldera_criticalmass_rest_location_update', methods: ['POST'], priority: 190)]
+    #[OA\Tag(name: 'Location')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'slug', in: 'path', description: 'Slug of the location', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON representation of the location fields to update', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 404, description: 'Returned when the location does not exist in the city')]
+    public function updateLocationAction(Request $request, City $city, string $slug, LocationRepository $locationRepository): JsonResponse
+    {
+        $location = $locationRepository->findOneBy(['city' => $city, 'slug' => $slug]);
+
+        if (!$location) {
+            return new JsonResponse(['error' => 'Location not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (array_key_exists('title', $payload)) {
+            $title = trim((string) $payload['title']);
+            if ('' === $title) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['title' => 'The title must not be empty.']);
+            }
+            $location->setTitle($title);
+        }
+
+        if (array_key_exists('description', $payload)) {
+            $location->setDescription(null === $payload['description'] ? null : (string) $payload['description']);
+        }
+
+        if (array_key_exists('latitude', $payload)) {
+            $location->setLatitude(null === $payload['latitude'] ? null : (float) $payload['latitude']);
+        }
+
+        if (array_key_exists('longitude', $payload)) {
+            $location->setLongitude(null === $payload['longitude'] ? null : (float) $payload['longitude']);
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($location);
+    }
+
+    /**
+     * Deletes a location.
+     */
+    #[Route(path: '/api/{citySlug}/location/{slug}', name: 'caldera_criticalmass_rest_location_delete', methods: ['DELETE'], priority: 190)]
+    #[OA\Tag(name: 'Location')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'slug', in: 'path', description: 'Slug of the location', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 404, description: 'Returned when the location does not exist in the city')]
+    public function deleteLocationAction(City $city, string $slug, LocationRepository $locationRepository): JsonResponse
+    {
+        $location = $locationRepository->findOneBy(['city' => $city, 'slug' => $slug]);
+
+        if (!$location) {
+            return new JsonResponse(['error' => 'Location not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->remove($location);
+        $manager->flush();
+
+        return new JsonResponse(['status' => 'ok', 'deletedLocationSlug' => $slug]);
     }
 }

--- a/src/Mcp/Support/EntityResolver.php
+++ b/src/Mcp/Support/EntityResolver.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Support;
 
 use App\Entity\City;
 use App\Entity\CitySlug;
+use App\Entity\Location;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Mcp\Tool\McpToolException;
@@ -78,5 +79,29 @@ final class EntityResolver
         }
 
         return $estimate;
+    }
+
+    /**
+     * Löst eine Location über citySlug + Location-Slug auf.
+     */
+    public function location(string $citySlug, string $locationSlug): Location
+    {
+        $city = $this->city($citySlug);
+        $locationSlug = trim($locationSlug);
+
+        if ('' === $locationSlug) {
+            throw new McpToolException('locationSlug ist erforderlich.');
+        }
+
+        $location = $this->registry->getRepository(Location::class)->findOneBy([
+            'city' => $city,
+            'slug' => $locationSlug,
+        ]);
+
+        if (null === $location) {
+            throw new McpToolException(sprintf('Keine Location "%s" in Stadt "%s" gefunden.', $locationSlug, $citySlug));
+        }
+
+        return $location;
     }
 }

--- a/src/Mcp/Tool/CreateLocationTool.php
+++ b/src/Mcp/Tool/CreateLocationTool.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Location;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * Write-Tool: legt einen Treffpunkt (Location) für eine Stadt an.
+ */
+final class CreateLocationTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly SluggerInterface $slugger,
+        private readonly CriticalSerializerInterface $serializer,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'create_location';
+    }
+
+    public function description(): string
+    {
+        return 'Legt einen Treffpunkt (Location) für eine Stadt an.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'location' => [
+                    'type' => 'object',
+                    'description' => 'Location-Felder: title (Pflicht), slug (optional, wird sonst aus dem Titel abgeleitet), latitude, longitude, description.',
+                ],
+            ],
+            'required' => ['citySlug', 'location'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::LocationWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $city = $this->resolver->city((string) ($arguments['citySlug'] ?? ''));
+        $data = \is_array($arguments['location'] ?? null) ? $arguments['location'] : [];
+
+        $title = trim((string) ($data['title'] ?? ''));
+
+        if ('' === $title) {
+            throw new McpToolException('location.title ist erforderlich.');
+        }
+
+        $slug = trim((string) ($data['slug'] ?? ''));
+        if ('' === $slug) {
+            $slug = strtolower((string) $this->slugger->slug($title));
+        }
+
+        $repository = $this->registry->getRepository(Location::class);
+
+        if (null !== $repository->findOneBy(['city' => $city, 'slug' => $slug])) {
+            throw new McpToolException(sprintf('In dieser Stadt existiert bereits eine Location mit dem Slug "%s".', $slug));
+        }
+
+        $location = new Location();
+        $location
+            ->setCity($city)
+            ->setTitle($title)
+            ->setSlug($slug)
+            ->setDescription(isset($data['description']) ? (string) $data['description'] : null)
+            ->setLatitude(isset($data['latitude']) ? (float) $data['latitude'] : null)
+            ->setLongitude(isset($data['longitude']) ? (float) $data['longitude'] : null);
+
+        $manager = $this->registry->getManager();
+        $manager->persist($location);
+        $manager->flush();
+
+        return $this->serializer->serialize($location, 'json', []);
+    }
+}

--- a/src/Mcp/Tool/DeleteLocationTool.php
+++ b/src/Mcp/Tool/DeleteLocationTool.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: löscht einen Treffpunkt (Location) einer Stadt.
+ */
+final class DeleteLocationTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_location';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht einen Treffpunkt (Location) einer Stadt.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'locationSlug' => ['type' => 'string', 'description' => 'Slug der Location.'],
+            ],
+            'required' => ['citySlug', 'locationSlug'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::LocationWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $location = $this->resolver->location(
+            (string) ($arguments['citySlug'] ?? ''),
+            (string) ($arguments['locationSlug'] ?? ''),
+        );
+
+        $slug = $location->getSlug();
+
+        $manager = $this->registry->getManager();
+        $manager->remove($location);
+        $manager->flush();
+
+        return json_encode(['status' => 'ok', 'deletedLocationSlug' => $slug], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/GetLocationTool.php
+++ b/src/Mcp/Tool/GetLocationTool.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+
+/**
+ * Read-Tool: spiegelt GET /api/{citySlug}/location/{slug} (einzelne Location).
+ */
+final class GetLocationTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly CriticalSerializerInterface $serializer,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'get_location';
+    }
+
+    public function description(): string
+    {
+        return 'Liefert die Details eines Treffpunkts (Location) einer Stadt.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'locationSlug' => ['type' => 'string', 'description' => 'Slug der Location.'],
+            ],
+            'required' => ['citySlug', 'locationSlug'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::CityRead;
+    }
+
+    public function call(array $arguments): string
+    {
+        $location = $this->resolver->location(
+            (string) ($arguments['citySlug'] ?? ''),
+            (string) ($arguments['locationSlug'] ?? ''),
+        );
+
+        return $this->serializer->serialize($location, 'json', []);
+    }
+}

--- a/src/Mcp/Tool/UpdateLocationTool.php
+++ b/src/Mcp/Tool/UpdateLocationTool.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Location;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: aktualisiert einen bestehenden Treffpunkt (Location).
+ */
+final class UpdateLocationTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly CriticalSerializerInterface $serializer,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'update_location';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert einen bestehenden Treffpunkt (Location) einer Stadt.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'locationSlug' => ['type' => 'string', 'description' => 'Slug der Location.'],
+                'location' => [
+                    'type' => 'object',
+                    'description' => 'Zu ändernde Felder: title, latitude, longitude, description.',
+                ],
+            ],
+            'required' => ['citySlug', 'locationSlug', 'location'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::LocationWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $location = $this->resolver->location(
+            (string) ($arguments['citySlug'] ?? ''),
+            (string) ($arguments['locationSlug'] ?? ''),
+        );
+
+        $data = \is_array($arguments['location'] ?? null) ? $arguments['location'] : [];
+
+        if (array_key_exists('title', $data)) {
+            $title = trim((string) $data['title']);
+            if ('' === $title) {
+                throw new McpToolException('location.title darf nicht leer sein.');
+            }
+            $location->setTitle($title);
+        }
+
+        if (array_key_exists('description', $data)) {
+            $location->setDescription(null === $data['description'] ? null : (string) $data['description']);
+        }
+
+        if (array_key_exists('latitude', $data)) {
+            $location->setLatitude(null === $data['latitude'] ? null : (float) $data['latitude']);
+        }
+
+        if (array_key_exists('longitude', $data)) {
+            $location->setLongitude(null === $data['longitude'] ? null : (float) $data['longitude']);
+        }
+
+        $this->registry->getManager()->flush();
+
+        return $this->serializer->serialize($location, 'json', []);
+    }
+}

--- a/src/OAuth2/OAuthScope.php
+++ b/src/OAuth2/OAuthScope.php
@@ -26,6 +26,7 @@ enum OAuthScope: string
     case CycleWrite = 'cycle:write';
     case SocialNetworkWrite = 'socialnetwork:write';
     case ActivityWrite = 'activity:write';
+    case LocationWrite = 'location:write';
 
     public function label(): string
     {
@@ -44,6 +45,7 @@ enum OAuthScope: string
             self::CycleWrite => 'Termin-Zyklen anlegen und bearbeiten',
             self::SocialNetworkWrite => 'Social-Network-Profile und -Feeds verwalten',
             self::ActivityWrite => 'Aktivitäts-Scores von Städten melden',
+            self::LocationWrite => 'Treffpunkte (Locations) anlegen und bearbeiten',
         };
     }
 

--- a/tests/Controller/Api/LocationApi/LocationApiWriteTest.php
+++ b/tests/Controller/Api/LocationApi/LocationApiWriteTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\LocationApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Location;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests der schreibenden Location-Endpunkte (create/update/delete).
+ * Transaktions-isoliert.
+ */
+class LocationApiWriteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createCity(): City
+    {
+        $slug = 'location-api-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Locationstadt');
+        $city->setTitle('Critical Mass Locationstadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+        $this->entityManager->flush();
+
+        return $city;
+    }
+
+    private function addLocation(City $city, string $slug = 'treffpunkt'): Location
+    {
+        $location = new Location();
+        $location->setCity($city);
+        $location->setTitle('Treffpunkt');
+        $location->setSlug($slug);
+        $this->entityManager->persist($location);
+        $this->entityManager->flush();
+
+        return $location;
+    }
+
+    public function testCreateLocation(): void
+    {
+        $city = $this->createCity();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/location', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Rathausmarkt', 'latitude' => 53.55, 'longitude' => 9.99]));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertCount(1, $this->entityManager->getRepository(Location::class)->findBy(['city' => $city]));
+    }
+
+    public function testCreateLocationRejectsMissingTitle(): void
+    {
+        $city = $this->createCity();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/location', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['latitude' => 53.55]));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testUpdateLocationChangesTitle(): void
+    {
+        $city = $this->createCity();
+        $location = $this->addLocation($city);
+        $locationId = $location->getId();
+
+        $this->client->request('POST', '/api/' . $city->getMainSlugString() . '/location/treffpunkt', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Geänderter Treffpunkt']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(Location::class)->find($locationId);
+        $this->assertSame('Geänderter Treffpunkt', $updated?->getTitle());
+    }
+
+    public function testDeleteLocation(): void
+    {
+        $city = $this->createCity();
+        $location = $this->addLocation($city);
+        $locationId = $location->getId();
+
+        $this->client->request('DELETE', '/api/' . $city->getMainSlugString() . '/location/treffpunkt');
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(Location::class)->find($locationId));
+    }
+
+    public function testDeleteUnknownLocationReturns404(): void
+    {
+        $city = $this->createCity();
+
+        $this->client->request('DELETE', '/api/' . $city->getMainSlugString() . '/location/gibtsnicht');
+
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -365,6 +365,73 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertCount(1, $this->em()->getRepository(SocialNetworkProfile::class)->findBy(['city' => $city]));
     }
 
+    public function testCreateLocationPersists(): void
+    {
+        $city = $this->createCity();
+        $token = $this->obtainAccessToken('location:write');
+
+        $result = $this->callTool($token, 'create_location', [
+            'citySlug' => $city->getMainSlugString(),
+            'location' => ['title' => 'Rathausmarkt', 'latitude' => 53.55, 'longitude' => 9.99],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertCount(1, $this->em()->getRepository(\App\Entity\Location::class)->findBy(['city' => $city]));
+    }
+
+    public function testUpdateLocationChangesTitle(): void
+    {
+        $city = $this->createCity();
+        $location = $this->createLocation($city, 'treffpunkt');
+        $token = $this->obtainAccessToken('location:write');
+
+        $result = $this->callTool($token, 'update_location', [
+            'citySlug' => $city->getMainSlugString(),
+            'locationSlug' => 'treffpunkt',
+            'location' => ['title' => 'Neuer Treffpunkt'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $locationId = $location->getId();
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(\App\Entity\Location::class)->find($locationId);
+        self::assertSame('Neuer Treffpunkt', $updated?->getTitle());
+    }
+
+    public function testDeleteLocationRemovesIt(): void
+    {
+        $city = $this->createCity();
+        $location = $this->createLocation($city, 'treffpunkt');
+        $locationId = $location->getId();
+        $token = $this->obtainAccessToken('location:write');
+
+        $result = $this->callTool($token, 'delete_location', [
+            'citySlug' => $city->getMainSlugString(),
+            'locationSlug' => 'treffpunkt',
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        self::assertNull($this->em()->getRepository(\App\Entity\Location::class)->find($locationId));
+    }
+
+    public function testGetLocationReturnsIt(): void
+    {
+        $city = $this->createCity();
+        $this->createLocation($city, 'treffpunkt');
+        $token = $this->obtainAccessToken('city:read');
+
+        $result = $this->callTool($token, 'get_location', [
+            'citySlug' => $city->getMainSlugString(),
+            'locationSlug' => 'treffpunkt',
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertSame('treffpunkt', $result['json']['slug']);
+    }
+
     public function testCreateCityActivityPersistsAndUpdatesScore(): void
     {
         $city = $this->createCity();


### PR DESCRIPTION
## Summary

Macht Treffpunkte (Locations) voll verwaltbar — bisher nur lesbar. Teil der Initiative „alle CRUD-Operationen via MCP" (PR 4 von 8).

> **Stacked auf #1441**. Reihenfolge: #1439 → #1440 → #1441 → dieser PR.

- **Neuer Scope `location:write`** (`OAuthScope`-Enum + `league_oauth2_server.yaml`, gekoppelt via `OAuthScopeTest`).
- **MCP-Tools:** `create_location`, `update_location`, `delete_location` (`location:write`) sowie `get_location` (`city:read`). Slugs werden aus dem Titel abgeleitet, wenn nicht angegeben; Eindeutigkeit je Stadt wird erzwungen.
- **REST:** `PUT /api/{citySlug}/location`, `POST` + `DELETE /api/{citySlug}/location/{slug}`.
- `EntityResolver` bekommt `location(citySlug, locationSlug)`.

## Test Plan

- [x] MCP-Tests: create, update (Titel), delete, get
- [x] LocationApi-Write-Tests: create, fehlender Titel → 400, update, delete, unbekannt → 404
- [x] `tests/Mcp` + `tests/OAuth2` + `tests/Controller/Api/LocationApi`: 147/147 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)