### PR TITLE
MCP + API: Subrides CRUD

### DIFF
--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -33,6 +33,7 @@ league_oauth2_server:
             - socialnetwork:write
             - activity:write
             - location:write
+            - subride:write
         default:
             - ride:read
             - track:read

--- a/src/Controller/Api/SubrideController.php
+++ b/src/Controller/Api/SubrideController.php
@@ -6,7 +6,11 @@ use App\Entity\Ride;
 use App\Entity\Subride;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SubrideController extends BaseController
 {
@@ -39,5 +43,166 @@ class SubrideController extends BaseController
     public function showSubrideAction(Subride $subride): JsonResponse
     {
         return $this->createStandardResponse($subride);
+    }
+
+    /**
+     * Creates a new subride for a ride.
+     */
+    #[Route(path: '/api/{citySlug}/{rideIdentifier}/subride', name: 'caldera_criticalmass_rest_subride_create', methods: ['PUT'], priority: 190)]
+    #[OA\Tag(name: 'Subride')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON representation of the subride', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the submitted subride is invalid')]
+    public function createSubrideAction(Request $request, Ride $ride, ValidatorInterface $validator): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (!isset($payload['dateTime'])) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['dateTime' => 'A dateTime is required.']);
+        }
+
+        try {
+            $dateTime = new \DateTime((string) $payload['dateTime']);
+        } catch (\Exception) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['dateTime' => 'dateTime is not a valid datetime.']);
+        }
+
+        $subride = new Subride();
+        $subride
+            ->setRide($ride)
+            ->setTitle((string) ($payload['title'] ?? ''))
+            ->setLocation((string) ($payload['location'] ?? ''))
+            ->setDateTime($dateTime)
+            ->setDescription(isset($payload['description']) ? (string) $payload['description'] : null)
+            ->setCreatedAt(new \DateTime());
+
+        if (isset($payload['latitude'])) {
+            $subride->setLatitude((float) $payload['latitude']);
+        }
+
+        if (isset($payload['longitude'])) {
+            $subride->setLongitude((float) $payload['longitude']);
+        }
+
+        if (null !== $errorResponse = $this->validateSubride($subride, $validator)) {
+            return $errorResponse;
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($subride);
+        $manager->flush();
+
+        return $this->createStandardResponse($subride, ['groups' => ['subride-list']]);
+    }
+
+    /**
+     * Updates an existing subride.
+     */
+    #[Route(path: '/api/{citySlug}/{rideIdentifier}/{subrideId}', name: 'caldera_criticalmass_rest_subride_update', requirements: ['subrideId' => '\d+'], methods: ['POST'], priority: 190)]
+    #[OA\Tag(name: 'Subride')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'subrideId', in: 'path', description: 'Id of the subride', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\RequestBody(description: 'JSON representation of the subride fields to update', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 404, description: 'Returned when the subride does not belong to the ride')]
+    public function updateSubrideAction(Request $request, Ride $ride, int $subrideId, ValidatorInterface $validator): JsonResponse
+    {
+        $subride = $this->managerRegistry->getRepository(Subride::class)->find($subrideId);
+
+        if (!$subride || $subride->getRide()->getId() !== $ride->getId()) {
+            return new JsonResponse(['error' => 'Subride not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (array_key_exists('title', $payload)) {
+            $subride->setTitle((string) $payload['title']);
+        }
+
+        if (array_key_exists('location', $payload)) {
+            $subride->setLocation((string) $payload['location']);
+        }
+
+        if (array_key_exists('description', $payload)) {
+            $subride->setDescription(null === $payload['description'] ? null : (string) $payload['description']);
+        }
+
+        if (array_key_exists('dateTime', $payload)) {
+            try {
+                $subride->setDateTime(new \DateTime((string) $payload['dateTime']));
+            } catch (\Exception) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['dateTime' => 'dateTime is not a valid datetime.']);
+            }
+        }
+
+        if (array_key_exists('latitude', $payload)) {
+            $subride->setLatitude((float) $payload['latitude']);
+        }
+
+        if (array_key_exists('longitude', $payload)) {
+            $subride->setLongitude((float) $payload['longitude']);
+        }
+
+        if (null !== $errorResponse = $this->validateSubride($subride, $validator)) {
+            return $errorResponse;
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($subride, ['groups' => ['subride-list']]);
+    }
+
+    /**
+     * Deletes a subride.
+     */
+    #[Route(path: '/api/{citySlug}/{rideIdentifier}/{subrideId}', name: 'caldera_criticalmass_rest_subride_delete', requirements: ['subrideId' => '\d+'], methods: ['DELETE'], priority: 190)]
+    #[OA\Tag(name: 'Subride')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'rideIdentifier', in: 'path', description: 'Identifier of the ride (date or slug)', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'subrideId', in: 'path', description: 'Id of the subride', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 404, description: 'Returned when the subride does not belong to the ride')]
+    public function deleteSubrideAction(Ride $ride, int $subrideId): JsonResponse
+    {
+        $subride = $this->managerRegistry->getRepository(Subride::class)->find($subrideId);
+
+        if (!$subride || $subride->getRide()->getId() !== $ride->getId()) {
+            return new JsonResponse(['error' => 'Subride not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->remove($subride);
+        $manager->flush();
+
+        return new JsonResponse(['status' => 'ok', 'deletedSubrideId' => $subrideId]);
+    }
+
+    private function validateSubride(Subride $subride, ValidatorInterface $validator): ?JsonResponse
+    {
+        $violations = $validator->validate($subride);
+
+        $errors = [];
+
+        /** @var ConstraintViolation $violation */
+        foreach ($violations as $violation) {
+            $errors[$violation->getPropertyPath()] = $violation->getMessage();
+        }
+
+        if (0 < count($errors)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, $errors);
+        }
+
+        return null;
     }
 }

--- a/src/Mcp/Support/EntityResolver.php
+++ b/src/Mcp/Support/EntityResolver.php
@@ -7,6 +7,7 @@ use App\Entity\CitySlug;
 use App\Entity\Location;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
+use App\Entity\Subride;
 use App\Mcp\Tool\McpToolException;
 use App\Repository\RideRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -103,5 +104,21 @@ final class EntityResolver
         }
 
         return $location;
+    }
+
+    /**
+     * Löst einen Subride über citySlug + rideIdentifier + Subride-ID auf und
+     * stellt sicher, dass er zum Ride gehört.
+     */
+    public function subride(string $citySlug, string $rideIdentifier, int $subrideId): Subride
+    {
+        $ride = $this->ride($citySlug, $rideIdentifier);
+        $subride = $this->registry->getRepository(Subride::class)->find($subrideId);
+
+        if (null === $subride || $subride->getRide()->getId() !== $ride->getId()) {
+            throw new McpToolException(sprintf('Kein Subride mit der ID %d für diesen Ride gefunden.', $subrideId));
+        }
+
+        return $subride;
     }
 }

--- a/src/Mcp/Tool/CreateSubrideTool.php
+++ b/src/Mcp/Tool/CreateSubrideTool.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Subride;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Write-Tool: legt einen Subride (Anfahrt/Teilstrecke) für einen Ride an.
+ */
+final class CreateSubrideTool extends AbstractWriteTool
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        CriticalSerializerInterface $serializer,
+        ValidatorInterface $validator,
+        private readonly EntityResolver $resolver,
+    ) {
+        parent::__construct($registry, $serializer, $validator);
+    }
+
+    public function name(): string
+    {
+        return 'create_subride';
+    }
+
+    public function description(): string
+    {
+        return 'Legt einen Subride (Anfahrt/Teilstrecke) für einen Ride an.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+                'subride' => [
+                    'type' => 'object',
+                    'description' => 'Subride-Felder: title (Pflicht), location (Pflicht), dateTime (Pflicht, ISO 8601), description, latitude, longitude.',
+                ],
+            ],
+            'required' => ['citySlug', 'rideIdentifier', 'subride'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::SubrideWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $ride = $this->resolver->ride((string) ($arguments['citySlug'] ?? ''), (string) ($arguments['rideIdentifier'] ?? ''));
+        $data = \is_array($arguments['subride'] ?? null) ? $arguments['subride'] : [];
+
+        if (!isset($data['dateTime'])) {
+            throw new McpToolException('subride.dateTime ist erforderlich.');
+        }
+
+        try {
+            $dateTime = new \DateTime((string) $data['dateTime']);
+        } catch (\Exception) {
+            throw new McpToolException('subride.dateTime ist kein gültiger Zeitpunkt.');
+        }
+
+        $subride = new Subride();
+        $subride
+            ->setRide($ride)
+            ->setTitle((string) ($data['title'] ?? ''))
+            ->setLocation((string) ($data['location'] ?? ''))
+            ->setDateTime($dateTime)
+            ->setDescription(isset($data['description']) ? (string) $data['description'] : null)
+            ->setCreatedAt(new \DateTime());
+
+        if (isset($data['latitude'])) {
+            $subride->setLatitude((float) $data['latitude']);
+        }
+
+        if (isset($data['longitude'])) {
+            $subride->setLongitude((float) $data['longitude']);
+        }
+
+        $this->validateEntity($subride);
+        $this->persist($subride);
+        $this->flush();
+
+        return $this->serializer->serialize($subride, 'json', ['groups' => ['subride-list']]);
+    }
+}

--- a/src/Mcp/Tool/DeleteSubrideTool.php
+++ b/src/Mcp/Tool/DeleteSubrideTool.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: löscht einen Subride eines Rides (per ID).
+ */
+final class DeleteSubrideTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_subride';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht einen Subride eines Rides (per ID).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+                'subrideId' => ['type' => 'integer', 'description' => 'ID des Subrides.'],
+            ],
+            'required' => ['citySlug', 'rideIdentifier', 'subrideId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::SubrideWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $subride = $this->resolver->subride(
+            (string) ($arguments['citySlug'] ?? ''),
+            (string) ($arguments['rideIdentifier'] ?? ''),
+            (int) ($arguments['subrideId'] ?? 0),
+        );
+
+        $id = $subride->getId();
+
+        $manager = $this->registry->getManager();
+        $manager->remove($subride);
+        $manager->flush();
+
+        return json_encode(['status' => 'ok', 'deletedSubrideId' => $id], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/UpdateSubrideTool.php
+++ b/src/Mcp/Tool/UpdateSubrideTool.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Write-Tool: aktualisiert einen bestehenden Subride (per ID).
+ */
+final class UpdateSubrideTool extends AbstractWriteTool
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        CriticalSerializerInterface $serializer,
+        ValidatorInterface $validator,
+        private readonly EntityResolver $resolver,
+    ) {
+        parent::__construct($registry, $serializer, $validator);
+    }
+
+    public function name(): string
+    {
+        return 'update_subride';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert einen bestehenden Subride eines Rides (per ID).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+                'subrideId' => ['type' => 'integer', 'description' => 'ID des Subrides.'],
+                'subride' => [
+                    'type' => 'object',
+                    'description' => 'Zu ändernde Felder: title, location, dateTime (ISO 8601), description, latitude, longitude.',
+                ],
+            ],
+            'required' => ['citySlug', 'rideIdentifier', 'subrideId', 'subride'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::SubrideWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $subride = $this->resolver->subride(
+            (string) ($arguments['citySlug'] ?? ''),
+            (string) ($arguments['rideIdentifier'] ?? ''),
+            (int) ($arguments['subrideId'] ?? 0),
+        );
+
+        $data = \is_array($arguments['subride'] ?? null) ? $arguments['subride'] : [];
+
+        if (array_key_exists('title', $data)) {
+            $subride->setTitle((string) $data['title']);
+        }
+
+        if (array_key_exists('location', $data)) {
+            $subride->setLocation((string) $data['location']);
+        }
+
+        if (array_key_exists('description', $data)) {
+            $subride->setDescription(null === $data['description'] ? null : (string) $data['description']);
+        }
+
+        if (array_key_exists('dateTime', $data)) {
+            try {
+                $subride->setDateTime(new \DateTime((string) $data['dateTime']));
+            } catch (\Exception) {
+                throw new McpToolException('subride.dateTime ist kein gültiger Zeitpunkt.');
+            }
+        }
+
+        if (array_key_exists('latitude', $data)) {
+            $subride->setLatitude((float) $data['latitude']);
+        }
+
+        if (array_key_exists('longitude', $data)) {
+            $subride->setLongitude((float) $data['longitude']);
+        }
+
+        $this->validateEntity($subride);
+        $this->flush();
+
+        return $this->serializer->serialize($subride, 'json', ['groups' => ['subride-list']]);
+    }
+}

--- a/src/OAuth2/OAuthScope.php
+++ b/src/OAuth2/OAuthScope.php
@@ -27,6 +27,7 @@ enum OAuthScope: string
     case SocialNetworkWrite = 'socialnetwork:write';
     case ActivityWrite = 'activity:write';
     case LocationWrite = 'location:write';
+    case SubrideWrite = 'subride:write';
 
     public function label(): string
     {
@@ -46,6 +47,7 @@ enum OAuthScope: string
             self::SocialNetworkWrite => 'Social-Network-Profile und -Feeds verwalten',
             self::ActivityWrite => 'Aktivitäts-Scores von Städten melden',
             self::LocationWrite => 'Treffpunkte (Locations) anlegen und bearbeiten',
+            self::SubrideWrite => 'Subrides (Anfahrten) anlegen und bearbeiten',
         };
     }
 

--- a/tests/Controller/Api/SubrideApi/SubrideApiWriteTest.php
+++ b/tests/Controller/Api/SubrideApi/SubrideApiWriteTest.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\SubrideApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Entity\Subride;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests der schreibenden Subride-Endpunkte (create/update/delete).
+ * Transaktions-isoliert.
+ */
+class SubrideApiWriteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createRide(): array
+    {
+        $slug = 'subride-api-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Subridestadt');
+        $city->setTitle('Critical Mass Subridestadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime('2026-09-01 19:00:00'));
+        $ride->setTitle('Critical Mass');
+        $this->entityManager->persist($ride);
+
+        $this->entityManager->flush();
+
+        return [$city, $ride];
+    }
+
+    private function addSubride(Ride $ride): Subride
+    {
+        $subride = new Subride();
+        $subride->setRide($ride);
+        $subride->setTitle('Anfahrt Nord');
+        $subride->setLocation('Hauptbahnhof');
+        $subride->setDateTime(new \DateTime('2026-09-01 18:00:00'));
+        $subride->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($subride);
+        $this->entityManager->flush();
+
+        return $subride;
+    }
+
+    public function testCreateSubride(): void
+    {
+        [$city, $ride] = $this->createRide();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/2026-09-01/subride', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Anfahrt Süd', 'location' => 'Südbahnhof', 'dateTime' => '2026-09-01 18:00:00']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertCount(1, $this->entityManager->getRepository(Subride::class)->findBy(['ride' => $ride]));
+    }
+
+    public function testCreateSubrideRejectsMissingLocation(): void
+    {
+        [$city] = $this->createRide();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/2026-09-01/subride', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Ohne Ort', 'dateTime' => '2026-09-01 18:00:00']));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testUpdateSubride(): void
+    {
+        [$city, $ride] = $this->createRide();
+        $subride = $this->addSubride($ride);
+        $subrideId = $subride->getId();
+
+        $this->client->request('POST', '/api/' . $city->getMainSlugString() . '/2026-09-01/' . $subrideId, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['title' => 'Anfahrt West']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(Subride::class)->find($subrideId);
+        $this->assertSame('Anfahrt West', $updated?->getTitle());
+    }
+
+    public function testDeleteSubride(): void
+    {
+        [$city, $ride] = $this->createRide();
+        $subride = $this->addSubride($ride);
+        $subrideId = $subride->getId();
+
+        $this->client->request('DELETE', '/api/' . $city->getMainSlugString() . '/2026-09-01/' . $subrideId);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(Subride::class)->find($subrideId));
+    }
+}

--- a/tests/Mcp/AbstractMcpTestCase.php
+++ b/tests/Mcp/AbstractMcpTestCase.php
@@ -252,7 +252,9 @@ abstract class AbstractMcpTestCase extends WebTestCase
         $subride = new Subride();
         $subride->setRide($ride);
         $subride->setTitle('Anfahrt Nord');
+        $subride->setLocation('Hauptbahnhof');
         $subride->setDateTime(new \DateTime('2026-09-01 18:00:00'));
+        $subride->setCreatedAt(new \DateTime());
         $this->em()->persist($subride);
         $this->em()->flush();
 

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -432,6 +432,79 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertSame('treffpunkt', $result['json']['slug']);
     }
 
+    public function testCreateSubridePersists(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $token = $this->obtainAccessToken('subride:write');
+
+        $result = $this->callTool($token, 'create_subride', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+            'subride' => ['title' => 'Anfahrt Süd', 'location' => 'Südbahnhof', 'dateTime' => '2026-09-01 18:00:00'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertCount(1, $this->em()->getRepository(\App\Entity\Subride::class)->findBy(['ride' => $ride]));
+    }
+
+    public function testCreateSubrideRejectsMissingLocation(): void
+    {
+        $city = $this->createCity();
+        $this->createRide($city, '2026-09-01 19:00:00');
+        $token = $this->obtainAccessToken('subride:write');
+
+        $result = $this->callTool($token, 'create_subride', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+            'subride' => ['title' => 'Ohne Ort', 'dateTime' => '2026-09-01 18:00:00'],
+        ]);
+
+        self::assertTrue($result['isError']);
+    }
+
+    public function testUpdateSubrideChangesTitle(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $subride = $this->createSubride($ride);
+        $token = $this->obtainAccessToken('subride:write');
+
+        $result = $this->callTool($token, 'update_subride', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+            'subrideId' => $subride->getId(),
+            'subride' => ['title' => 'Anfahrt West'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $subrideId = $subride->getId();
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(\App\Entity\Subride::class)->find($subrideId);
+        self::assertSame('Anfahrt West', $updated?->getTitle());
+    }
+
+    public function testDeleteSubrideRemovesIt(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $subride = $this->createSubride($ride);
+        $subrideId = $subride->getId();
+        $token = $this->obtainAccessToken('subride:write');
+
+        $result = $this->callTool($token, 'delete_subride', [
+            'citySlug' => $city->getMainSlugString(),
+            'rideIdentifier' => '2026-09-01',
+            'subrideId' => $subrideId,
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        self::assertNull($this->em()->getRepository(\App\Entity\Subride::class)->find($subrideId));
+    }
+
     public function testCreateCityActivityPersistsAndUpdatesScore(): void
     {
         $city = $this->createCity();


### PR DESCRIPTION
## Summary

Macht Subrides (Anfahrten/Teilstrecken) voll verwaltbar — bisher nur lesbar. Teil der Initiative „alle CRUD-Operationen via MCP" (PR 5 von 8).

> **Stacked auf #1442**. Reihenfolge: #1439 → #1440 → #1441 → #1442 → dieser PR.

- **Neuer Scope `subride:write`** (Enum + `league_oauth2_server.yaml`).
- **MCP-Tools:** `create_subride`, `update_subride`, `delete_subride`. `EntityResolver` bekommt `subride(citySlug, rideIdentifier, id)`.
- **REST:** `PUT /api/{citySlug}/{rideIdentifier}/subride` sowie `POST` + `DELETE /api/{citySlug}/{rideIdentifier}/{subrideId}`.

### Routing-Stolperstein (behoben)
Die Write-Routen nutzen `{subrideId}`, **nicht** `{id}`. Sonst mappt Symfonys Standard-`EntityValueResolver` das `Ride`-Argument über den `{id}`-Primärschlüssel (falscher Ride!), bevor der custom slug-basierte `RideValueResolver` greift. Ein Test sichert Update/Delete am korrekten Ride ab.

## Test Plan

- [x] MCP-Tests: create, fehlender Ort → Fehler, update, delete
- [x] SubrideApi-Write-Tests: create, fehlender Ort → 400, update, delete
- [x] `tests/Mcp` + `tests/OAuth2`: 135/135 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)