### PR TITLE
MCP + API: Forenbeiträge (Posts) CRUD

### DIFF
--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -34,6 +34,7 @@ league_oauth2_server:
             - activity:write
             - location:write
             - subride:write
+            - post:write
         default:
             - ride:read
             - track:read

--- a/src/Controller/Api/PostController.php
+++ b/src/Controller/Api/PostController.php
@@ -2,13 +2,17 @@
 
 namespace App\Controller\Api;
 
+use App\Entity\City;
 use App\Entity\Post;
+use App\Repository\RideRepository;
 use MalteHuebner\DataQueryBundle\DataQueryManager\DataQueryManagerInterface;
 use MalteHuebner\DataQueryBundle\RequestParameterList\RequestToListConverter;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class PostController extends BaseController
 {
@@ -84,5 +88,179 @@ class PostController extends BaseController
         $postList = $dataQueryManager->query($queryParameterList, Post::class);
 
         return $this->createStandardResponse($postList, ['groups' => ['post-list']]);
+    }
+
+    /**
+     * Show a single post.
+     */
+    #[Route(path: '/api/post/{id}', name: 'caldera_criticalmass_rest_post_show', requirements: ['id' => '\d+'], methods: ['GET'], priority: 200)]
+    #[OA\Tag(name: 'Post')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the post', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    public function showAction(Post $post): JsonResponse
+    {
+        return $this->createStandardResponse($post, ['groups' => ['post-list']]);
+    }
+
+    /**
+     * Creates a new post for a city, optionally attached to a ride.
+     */
+    #[Route(path: '/api/{citySlug}/post', name: 'caldera_criticalmass_rest_post_create', methods: ['PUT'], priority: 190)]
+    #[OA\Tag(name: 'Post')]
+    #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\RequestBody(description: 'JSON representation of the post (message required, optional rideIdentifier)', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the submitted post is invalid')]
+    public function createPostAction(Request $request, City $city, RideRepository $rideRepository, ValidatorInterface $validator): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        try {
+            $dateTime = isset($payload['dateTime']) ? new \DateTime((string) $payload['dateTime']) : new \DateTime();
+        } catch (\Exception) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['dateTime' => 'dateTime is not a valid datetime.']);
+        }
+
+        $post = new Post();
+        $post
+            ->setCity($city)
+            ->setMessage((string) ($payload['message'] ?? ''))
+            ->setDateTime($dateTime)
+            ->setEnabled(true);
+
+        if (isset($payload['rideIdentifier']) && '' !== trim((string) $payload['rideIdentifier'])) {
+            $rideIdentifier = (string) $payload['rideIdentifier'];
+
+            try {
+                $ride = $rideRepository->findByCitySlugAndRideDate($city->getMainSlugString(), $rideIdentifier);
+            } catch (\Exception) {
+                $ride = null;
+            }
+
+            $ride ??= $rideRepository->findOneByCitySlugAndSlug($city->getMainSlugString(), $rideIdentifier);
+
+            if (null === $ride) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['rideIdentifier' => 'Ride not found.']);
+            }
+
+            $post->setRide($ride);
+        }
+
+        if (isset($payload['latitude'])) {
+            $post->setLatitude((float) $payload['latitude']);
+        }
+
+        if (isset($payload['longitude'])) {
+            $post->setLongitude((float) $payload['longitude']);
+        }
+
+        if (null !== $errorResponse = $this->validatePost($post, $validator)) {
+            return $errorResponse;
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($post);
+        $manager->flush();
+
+        return $this->createStandardResponse($post, ['groups' => ['post-list']]);
+    }
+
+    /**
+     * Updates an existing post.
+     */
+    #[Route(path: '/api/post/{id}', name: 'caldera_criticalmass_rest_post_update', requirements: ['id' => '\d+'], methods: ['POST'], priority: 200)]
+    #[OA\Tag(name: 'Post')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the post', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\RequestBody(description: 'JSON representation of the post fields to update', required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 400, description: 'Returned when the submitted post is invalid')]
+    public function updatePostAction(Request $request, Post $post, ValidatorInterface $validator): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (array_key_exists('message', $payload)) {
+            $post->setMessage((string) $payload['message']);
+        }
+
+        if (array_key_exists('enabled', $payload)) {
+            if (!is_bool($payload['enabled'])) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['enabled' => 'enabled must be a boolean.']);
+            }
+            $post->setEnabled($payload['enabled']);
+        }
+
+        if (array_key_exists('latitude', $payload)) {
+            $post->setLatitude((float) $payload['latitude']);
+        }
+
+        if (array_key_exists('longitude', $payload)) {
+            $post->setLongitude((float) $payload['longitude']);
+        }
+
+        if (array_key_exists('dateTime', $payload)) {
+            try {
+                $post->setDateTime(new \DateTime((string) $payload['dateTime']));
+            } catch (\Exception) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['dateTime' => 'dateTime is not a valid datetime.']);
+            }
+        }
+
+        if (null !== $errorResponse = $this->validatePost($post, $validator)) {
+            return $errorResponse;
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($post, ['groups' => ['post-list']]);
+    }
+
+    /**
+     * Deletes a post. Replies (child posts) are detached and kept.
+     */
+    #[Route(path: '/api/post/{id}', name: 'caldera_criticalmass_rest_post_delete', requirements: ['id' => '\d+'], methods: ['DELETE'], priority: 200)]
+    #[OA\Tag(name: 'Post')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the post', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    public function deletePostAction(Post $post): JsonResponse
+    {
+        $id = $post->getId();
+        $manager = $this->managerRegistry->getManager();
+
+        $children = $manager->getRepository(Post::class)->findBy(['parent' => $post]);
+        foreach ($children as $child) {
+            $child->setParent(null);
+        }
+        $manager->flush();
+
+        $manager->remove($post);
+        $manager->flush();
+
+        return new JsonResponse(['status' => 'ok', 'deletedPostId' => $id]);
+    }
+
+    private function validatePost(Post $post, ValidatorInterface $validator): ?JsonResponse
+    {
+        $violations = $validator->validate($post);
+
+        $errors = [];
+
+        /** @var ConstraintViolation $violation */
+        foreach ($violations as $violation) {
+            $errors[$violation->getPropertyPath()] = $violation->getMessage();
+        }
+
+        if (0 < count($errors)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, $errors);
+        }
+
+        return null;
     }
 }

--- a/src/Mcp/Support/EntityResolver.php
+++ b/src/Mcp/Support/EntityResolver.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Support;
 use App\Entity\City;
 use App\Entity\CitySlug;
 use App\Entity\Location;
+use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Entity\Subride;
@@ -120,5 +121,16 @@ final class EntityResolver
         }
 
         return $subride;
+    }
+
+    public function post(int $id): Post
+    {
+        $post = $this->registry->getRepository(Post::class)->find($id);
+
+        if (null === $post) {
+            throw new McpToolException(sprintf('Kein Forenbeitrag mit der ID %d gefunden.', $id));
+        }
+
+        return $post;
     }
 }

--- a/src/Mcp/Tool/CreatePostTool.php
+++ b/src/Mcp/Tool/CreatePostTool.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Post;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Write-Tool: legt einen Forenbeitrag (Post) für eine Stadt (optional zu einem
+ * Ride) an.
+ */
+final class CreatePostTool extends AbstractWriteTool
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        CriticalSerializerInterface $serializer,
+        ValidatorInterface $validator,
+        private readonly EntityResolver $resolver,
+    ) {
+        parent::__construct($registry, $serializer, $validator);
+    }
+
+    public function name(): string
+    {
+        return 'create_post';
+    }
+
+    public function description(): string
+    {
+        return 'Legt einen Forenbeitrag (Post) für eine Stadt an, optional einem Ride zugeordnet.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'citySlug' => ['type' => 'string', 'description' => 'Slug der Stadt.'],
+                'rideIdentifier' => ['type' => 'string', 'description' => 'Optional: Ride-Datum (YYYY-MM-DD) oder -Slug.'],
+                'post' => [
+                    'type' => 'object',
+                    'description' => 'Post-Felder: message (Pflicht), latitude, longitude, dateTime (ISO 8601, Standard jetzt).',
+                ],
+            ],
+            'required' => ['citySlug', 'post'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PostWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        $city = $this->resolver->city((string) ($arguments['citySlug'] ?? ''));
+        $data = \is_array($arguments['post'] ?? null) ? $arguments['post'] : [];
+
+        try {
+            $dateTime = isset($data['dateTime']) ? new \DateTime((string) $data['dateTime']) : new \DateTime();
+        } catch (\Exception) {
+            throw new McpToolException('post.dateTime ist kein gültiger Zeitpunkt.');
+        }
+
+        $post = new Post();
+        $post
+            ->setCity($city)
+            ->setMessage((string) ($data['message'] ?? ''))
+            ->setDateTime($dateTime)
+            ->setEnabled(true);
+
+        if (isset($arguments['rideIdentifier']) && '' !== trim((string) $arguments['rideIdentifier'])) {
+            $post->setRide($this->resolver->ride((string) $arguments['citySlug'], (string) $arguments['rideIdentifier']));
+        }
+
+        if (isset($data['latitude'])) {
+            $post->setLatitude((float) $data['latitude']);
+        }
+
+        if (isset($data['longitude'])) {
+            $post->setLongitude((float) $data['longitude']);
+        }
+
+        $this->validateEntity($post);
+        $this->persist($post);
+        $this->flush();
+
+        return $this->serializer->serialize($post, 'json', ['groups' => ['post-list']]);
+    }
+}

--- a/src/Mcp/Tool/DeletePostTool.php
+++ b/src/Mcp/Tool/DeletePostTool.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Entity\Post;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: löscht einen Forenbeitrag (per ID). Antworten (child posts)
+ * werden vorher vom Elternbeitrag entkoppelt, damit sie erhalten bleiben.
+ */
+final class DeletePostTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_post';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht einen Forenbeitrag (per ID). Antworten bleiben erhalten (werden entkoppelt).';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'postId' => ['type' => 'integer', 'description' => 'ID des Posts.'],
+            ],
+            'required' => ['postId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PostWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['postId']) || !is_numeric($arguments['postId'])) {
+            throw new McpToolException('postId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $post = $this->resolver->post((int) $arguments['postId']);
+        $id = $post->getId();
+
+        $manager = $this->registry->getManager();
+
+        // Antworten entkoppeln (parent = null), damit sie erhalten bleiben.
+        $children = $manager->getRepository(Post::class)->findBy(['parent' => $post]);
+        foreach ($children as $child) {
+            $child->setParent(null);
+        }
+        $manager->flush();
+
+        $manager->remove($post);
+        $manager->flush();
+
+        return json_encode(['status' => 'ok', 'deletedPostId' => $id], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/GetPostTool.php
+++ b/src/Mcp/Tool/GetPostTool.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+
+/**
+ * Read-Tool: liefert einen einzelnen Forenbeitrag (Post) per ID.
+ */
+final class GetPostTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly CriticalSerializerInterface $serializer,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'get_post';
+    }
+
+    public function description(): string
+    {
+        return 'Liefert einen einzelnen Forenbeitrag (Post) per ID.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'postId' => ['type' => 'integer', 'description' => 'ID des Posts.'],
+            ],
+            'required' => ['postId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PostRead;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['postId']) || !is_numeric($arguments['postId'])) {
+            throw new McpToolException('postId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $post = $this->resolver->post((int) $arguments['postId']);
+
+        return $this->serializer->serialize($post, 'json', ['groups' => ['post-list']]);
+    }
+}

--- a/src/Mcp/Tool/UpdatePostTool.php
+++ b/src/Mcp/Tool/UpdatePostTool.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Write-Tool: aktualisiert einen bestehenden Forenbeitrag (per ID).
+ */
+final class UpdatePostTool extends AbstractWriteTool
+{
+    public function __construct(
+        ManagerRegistry $registry,
+        CriticalSerializerInterface $serializer,
+        ValidatorInterface $validator,
+        private readonly EntityResolver $resolver,
+    ) {
+        parent::__construct($registry, $serializer, $validator);
+    }
+
+    public function name(): string
+    {
+        return 'update_post';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert einen bestehenden Forenbeitrag (per ID): message, enabled, Koordinaten.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'postId' => ['type' => 'integer', 'description' => 'ID des Posts.'],
+                'post' => [
+                    'type' => 'object',
+                    'description' => 'Zu ändernde Felder: message, enabled, latitude, longitude, dateTime (ISO 8601).',
+                ],
+            ],
+            'required' => ['postId', 'post'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PostWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['postId']) || !is_numeric($arguments['postId'])) {
+            throw new McpToolException('postId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $post = $this->resolver->post((int) $arguments['postId']);
+        $data = \is_array($arguments['post'] ?? null) ? $arguments['post'] : [];
+
+        if (array_key_exists('message', $data)) {
+            $post->setMessage((string) $data['message']);
+        }
+
+        if (array_key_exists('enabled', $data)) {
+            if (!\is_bool($data['enabled'])) {
+                throw new McpToolException('post.enabled muss ein Boolean sein.');
+            }
+            $post->setEnabled($data['enabled']);
+        }
+
+        if (array_key_exists('latitude', $data)) {
+            $post->setLatitude((float) $data['latitude']);
+        }
+
+        if (array_key_exists('longitude', $data)) {
+            $post->setLongitude((float) $data['longitude']);
+        }
+
+        if (array_key_exists('dateTime', $data)) {
+            try {
+                $post->setDateTime(new \DateTime((string) $data['dateTime']));
+            } catch (\Exception) {
+                throw new McpToolException('post.dateTime ist kein gültiger Zeitpunkt.');
+            }
+        }
+
+        $this->validateEntity($post);
+        $this->flush();
+
+        return $this->serializer->serialize($post, 'json', ['groups' => ['post-list']]);
+    }
+}

--- a/src/OAuth2/OAuthScope.php
+++ b/src/OAuth2/OAuthScope.php
@@ -28,6 +28,7 @@ enum OAuthScope: string
     case ActivityWrite = 'activity:write';
     case LocationWrite = 'location:write';
     case SubrideWrite = 'subride:write';
+    case PostWrite = 'post:write';
 
     public function label(): string
     {
@@ -48,6 +49,7 @@ enum OAuthScope: string
             self::ActivityWrite => 'Aktivitäts-Scores von Städten melden',
             self::LocationWrite => 'Treffpunkte (Locations) anlegen und bearbeiten',
             self::SubrideWrite => 'Subrides (Anfahrten) anlegen und bearbeiten',
+            self::PostWrite => 'Forenbeiträge anlegen, bearbeiten und löschen',
         };
     }
 

--- a/tests/Controller/Api/PostApi/PostApiWriteTest.php
+++ b/tests/Controller/Api/PostApi/PostApiWriteTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller\Api\PostApi;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Post;
+use Tests\Controller\Api\AbstractApiControllerTestCase;
+
+/**
+ * Tests der schreibenden Post-Endpunkte (create/show/update/delete).
+ * Transaktions-isoliert.
+ */
+class PostApiWriteTest extends AbstractApiControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        parent::tearDown();
+    }
+
+    private function createCity(): City
+    {
+        $slug = 'post-api-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Poststadt');
+        $city->setTitle('Critical Mass Poststadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+        $this->entityManager->flush();
+
+        return $city;
+    }
+
+    private function addPost(City $city, string $message = 'Testbeitrag'): Post
+    {
+        $post = new Post();
+        $post->setCity($city);
+        $post->setMessage($message);
+        $post->setDateTime(new \DateTime('2026-09-01 12:00:00'));
+        $post->setEnabled(true);
+        $this->entityManager->persist($post);
+        $this->entityManager->flush();
+
+        return $post;
+    }
+
+    public function testCreatePost(): void
+    {
+        $city = $this->createCity();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/post', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['message' => 'Hallo Welt']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertCount(1, $this->entityManager->getRepository(Post::class)->findBy(['city' => $city]));
+    }
+
+    public function testCreatePostRejectsBlankMessage(): void
+    {
+        $city = $this->createCity();
+
+        $this->client->request('PUT', '/api/' . $city->getMainSlugString() . '/post', [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['message' => '']));
+
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testShowPost(): void
+    {
+        $city = $this->createCity();
+        $post = $this->addPost($city, 'Sichtbar');
+
+        $this->client->request('GET', '/api/post/' . $post->getId());
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $data = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertSame('Sichtbar', $data['message']);
+    }
+
+    public function testUpdatePost(): void
+    {
+        $city = $this->createCity();
+        $post = $this->addPost($city, 'Alt');
+        $postId = $post->getId();
+
+        $this->client->request('POST', '/api/post/' . $postId, [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], json_encode(['message' => 'Neu']));
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(Post::class)->find($postId);
+        $this->assertSame('Neu', $updated?->getMessage());
+    }
+
+    public function testDeletePost(): void
+    {
+        $city = $this->createCity();
+        $post = $this->addPost($city);
+        $postId = $post->getId();
+
+        $this->client->request('DELETE', '/api/post/' . $postId);
+
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $this->assertNull($this->entityManager->getRepository(Post::class)->find($postId));
+    }
+}

--- a/tests/Mcp/AbstractMcpTestCase.php
+++ b/tests/Mcp/AbstractMcpTestCase.php
@@ -7,6 +7,7 @@ use App\Entity\CityCycle;
 use App\Entity\CitySlug;
 use App\Entity\Location;
 use App\Entity\Photo;
+use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Entity\Subride;
@@ -272,6 +273,19 @@ abstract class AbstractMcpTestCase extends WebTestCase
         $this->em()->flush();
 
         return $estimate;
+    }
+
+    protected function createPost(City $city, string $message = 'Testbeitrag'): Post
+    {
+        $post = new Post();
+        $post->setCity($city);
+        $post->setMessage($message);
+        $post->setDateTime(new \DateTime('2026-09-01 12:00:00'));
+        $post->setEnabled(true);
+        $this->em()->persist($post);
+        $this->em()->flush();
+
+        return $post;
     }
 
     protected function createCityCycle(City $city): CityCycle

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -547,6 +547,79 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertStringContainsString('Signaltyp', $result['text']);
     }
 
+    public function testCreatePostPersists(): void
+    {
+        $city = $this->createCity();
+        $token = $this->obtainAccessToken('post:write');
+
+        $result = $this->callTool($token, 'create_post', [
+            'citySlug' => $city->getMainSlugString(),
+            'post' => ['message' => 'Hallo Welt'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertCount(1, $this->em()->getRepository(\App\Entity\Post::class)->findBy(['city' => $city]));
+    }
+
+    public function testCreatePostRejectsBlankMessage(): void
+    {
+        $city = $this->createCity();
+        $token = $this->obtainAccessToken('post:write');
+
+        $result = $this->callTool($token, 'create_post', [
+            'citySlug' => $city->getMainSlugString(),
+            'post' => ['message' => ''],
+        ]);
+
+        self::assertTrue($result['isError']);
+    }
+
+    public function testUpdatePostChangesMessage(): void
+    {
+        $city = $this->createCity();
+        $post = $this->createPost($city, 'Alt');
+        $token = $this->obtainAccessToken('post:write');
+
+        $result = $this->callTool($token, 'update_post', [
+            'postId' => $post->getId(),
+            'post' => ['message' => 'Neu'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $postId = $post->getId();
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(\App\Entity\Post::class)->find($postId);
+        self::assertSame('Neu', $updated?->getMessage());
+    }
+
+    public function testDeletePostRemovesIt(): void
+    {
+        $city = $this->createCity();
+        $post = $this->createPost($city);
+        $postId = $post->getId();
+        $token = $this->obtainAccessToken('post:write');
+
+        $result = $this->callTool($token, 'delete_post', ['postId' => $postId]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        self::assertNull($this->em()->getRepository(\App\Entity\Post::class)->find($postId));
+    }
+
+    public function testGetPostReturnsIt(): void
+    {
+        $city = $this->createCity();
+        $post = $this->createPost($city, 'Sichtbar');
+        $token = $this->obtainAccessToken('post:read');
+
+        $result = $this->callTool($token, 'get_post', ['postId' => $post->getId()]);
+
+        self::assertFalse($result['isError'], $result['text']);
+        self::assertSame('Sichtbar', $result['json']['message']);
+    }
+
     public function testWriteToolRejectedWithoutScope(): void
     {
         $token = $this->obtainAccessToken('ride:read');


### PR DESCRIPTION
## Summary

Macht Forenbeiträge (Posts) voll verwaltbar — bisher nur als Liste lesbar. Teil der Initiative „alle CRUD-Operationen via MCP" (PR 6 von 8).

> **Stacked auf #1443**. Reihenfolge: #1439 → #1440 → #1441 → #1442 → #1443 → dieser PR.

- **Neuer Scope `post:write`** (Enum + `league_oauth2_server.yaml`).
- **MCP-Tools:** `get_post` (`post:read`), `create_post`, `update_post`, `delete_post` (`post:write`). `EntityResolver` bekommt `post(id)`.
- **REST:** `GET /api/post/{id}`, `PUT /api/{citySlug}/post`, `POST` + `DELETE /api/post/{id}`.

Posts werden für eine Stadt angelegt und können optional per `rideIdentifier` einem Ride zugeordnet werden. Beim Löschen werden Antworten (child posts) vorher entkoppelt (`parent=null`), damit sie erhalten bleiben.

## Test Plan

- [x] MCP-Tests: create, leere Message → Fehler, update, delete, get
- [x] PostApi-Write-Tests: create, leere Message → 400, show, update, delete
- [x] `tests/Mcp` + `tests/OAuth2` + `tests/Controller/Api/PostApi`: 172/172 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)