### PR TITLE
MCP + API: Track/Photo bearbeiten & löschen (+ 2 Bugfixes)

### DIFF
--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -35,6 +35,7 @@ league_oauth2_server:
             - location:write
             - subride:write
             - post:write
+            - photo:write
         default:
             - ride:read
             - track:read

--- a/src/Controller/Api/PhotoController.php
+++ b/src/Controller/Api/PhotoController.php
@@ -143,15 +143,76 @@ class PhotoController extends BaseController
     /**
      * Update properties of a photo.
      */
-    #[Route(path: '/api/photo/{id}', name: 'caldera_criticalmass_rest_photo_post', methods: ['POST'], priority: 200)]
+    #[Route(path: '/api/photo/{id}', name: 'caldera_criticalmass_rest_photo_post', requirements: ['id' => '\d+'], methods: ['POST'], priority: 200)]
     #[OA\Tag(name: 'Photo')]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the photo to update', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\RequestBody(description: 'JSON representation of the photo data', required: true, content: new OA\JsonContent(type: 'object'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
-    public function updatePhotoAction(Request $request): JsonResponse
+    #[OA\Response(response: 404, description: 'Returned when the photo does not exist')]
+    public function updatePhotoAction(Request $request, int $id): JsonResponse
     {
-        $photo = $this->deserializeRequest($request, Photo::class);
+        $photo = $this->managerRegistry->getRepository(Photo::class)->find($id);
 
-        return $this->createStandardResponse($photo);
+        if (!$photo) {
+            throw new NotFoundHttpException('Photo not found');
+        }
+
+        $payload = json_decode($request->getContent(), true);
+
+        if (!is_array($payload)) {
+            return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['body' => 'A JSON object is required.']);
+        }
+
+        if (array_key_exists('description', $payload)) {
+            $photo->setDescription(null === $payload['description'] ? null : (string) $payload['description']);
+        }
+
+        if (array_key_exists('enabled', $payload)) {
+            if (!is_bool($payload['enabled'])) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['enabled' => 'enabled must be a boolean.']);
+            }
+            $photo->setEnabled($payload['enabled']);
+        }
+
+        if (array_key_exists('deleted', $payload)) {
+            if (!is_bool($payload['deleted'])) {
+                return $this->createErrors(JsonResponse::HTTP_BAD_REQUEST, ['deleted' => 'deleted must be a boolean.']);
+            }
+            $photo->setDeleted($payload['deleted']);
+        }
+
+        if (array_key_exists('latitude', $payload)) {
+            $photo->setLatitude(null === $payload['latitude'] ? null : (float) $payload['latitude']);
+        }
+
+        if (array_key_exists('longitude', $payload)) {
+            $photo->setLongitude(null === $payload['longitude'] ? null : (float) $payload['longitude']);
+        }
+
+        $this->managerRegistry->getManager()->flush();
+
+        return $this->createStandardResponse($photo, ['groups' => ['photo-details']]);
+    }
+
+    /**
+     * Deletes a photo (soft delete).
+     */
+    #[Route(path: '/api/photo/{id}', name: 'caldera_criticalmass_rest_photo_delete', requirements: ['id' => '\d+'], methods: ['DELETE'], priority: 200)]
+    #[OA\Tag(name: 'Photo')]
+    #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the photo to delete', required: true, schema: new OA\Schema(type: 'integer'))]
+    #[OA\Response(response: 200, description: 'Returned when successful')]
+    #[OA\Response(response: 404, description: 'Returned when the photo does not exist')]
+    public function deletePhotoAction(int $id): JsonResponse
+    {
+        $photo = $this->managerRegistry->getRepository(Photo::class)->find($id);
+
+        if (!$photo) {
+            throw new NotFoundHttpException('Photo not found');
+        }
+
+        $photo->setDeleted(true);
+        $this->managerRegistry->getManager()->flush();
+
+        return new JsonResponse(['status' => 'ok', 'deletedPhotoId' => $id]);
     }
 }

--- a/src/Controller/Api/TrackController.php
+++ b/src/Controller/Api/TrackController.php
@@ -49,7 +49,7 @@ class TrackController extends BaseController
             $groups[] = 'api-private';
         }
 
-        return $this->createStandardResponse($track);
+        return $this->createStandardResponse($track, ['groups' => $groups]);
     }
 
     /**
@@ -116,7 +116,7 @@ class TrackController extends BaseController
             $groups[] = 'api-private';
         }
 
-        return $this->createStandardResponse($trackList);
+        return $this->createStandardResponse($trackList, ['groups' => $groups]);
     }
 
     /**

--- a/src/Mcp/Support/EntityResolver.php
+++ b/src/Mcp/Support/EntityResolver.php
@@ -5,10 +5,12 @@ namespace App\Mcp\Support;
 use App\Entity\City;
 use App\Entity\CitySlug;
 use App\Entity\Location;
+use App\Entity\Photo;
 use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\RideEstimate;
 use App\Entity\Subride;
+use App\Entity\Track;
 use App\Mcp\Tool\McpToolException;
 use App\Repository\RideRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -132,5 +134,27 @@ final class EntityResolver
         }
 
         return $post;
+    }
+
+    public function track(int $id): Track
+    {
+        $track = $this->registry->getRepository(Track::class)->find($id);
+
+        if (null === $track) {
+            throw new McpToolException(sprintf('Kein Track mit der ID %d gefunden.', $id));
+        }
+
+        return $track;
+    }
+
+    public function photo(int $id): Photo
+    {
+        $photo = $this->registry->getRepository(Photo::class)->find($id);
+
+        if (null === $photo) {
+            throw new McpToolException(sprintf('Kein Foto mit der ID %d gefunden.', $id));
+        }
+
+        return $photo;
     }
 }

--- a/src/Mcp/Tool/DeletePhotoTool.php
+++ b/src/Mcp/Tool/DeletePhotoTool.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: löscht ein Foto (Soft-Delete via deleted-Flag).
+ */
+final class DeletePhotoTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_photo';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht ein Foto (Soft-Delete). Das Foto bleibt erhalten, wird aber als gelöscht markiert.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'photoId' => ['type' => 'integer', 'description' => 'ID des Fotos.'],
+            ],
+            'required' => ['photoId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PhotoWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['photoId']) || !is_numeric($arguments['photoId'])) {
+            throw new McpToolException('photoId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $photo = $this->resolver->photo((int) $arguments['photoId']);
+        $photo->setDeleted(true);
+
+        $this->registry->getManager()->flush();
+
+        return json_encode(['status' => 'ok', 'deletedPhotoId' => $photo->getId()], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/DeleteTrackTool.php
+++ b/src/Mcp/Tool/DeleteTrackTool.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Event\Track\TrackDeletedEvent;
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Write-Tool: löscht einen Track (Soft-Delete via deleted-Flag) und feuert
+ * TrackDeletedEvent, analog zu DELETE /api/track/{id}.
+ */
+final class DeleteTrackTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'delete_track';
+    }
+
+    public function description(): string
+    {
+        return 'Löscht einen Track (Soft-Delete). Der Track bleibt erhalten, wird aber als gelöscht markiert.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'trackId' => ['type' => 'integer', 'description' => 'ID des Tracks.'],
+            ],
+            'required' => ['trackId'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::TrackWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['trackId']) || !is_numeric($arguments['trackId'])) {
+            throw new McpToolException('trackId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $track = $this->resolver->track((int) $arguments['trackId']);
+        $track->setDeleted(true);
+
+        $this->registry->getManager()->flush();
+
+        $this->eventDispatcher->dispatch(new TrackDeletedEvent($track), TrackDeletedEvent::NAME);
+
+        return json_encode(['status' => 'ok', 'deletedTrackId' => $track->getId()], JSON_THROW_ON_ERROR);
+    }
+}

--- a/src/Mcp/Tool/UpdatePhotoTool.php
+++ b/src/Mcp/Tool/UpdatePhotoTool.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace App\Mcp\Tool;
+
+use App\Mcp\Support\EntityResolver;
+use App\OAuth2\OAuthScope;
+use App\Serializer\CriticalSerializerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * Write-Tool: aktualisiert die Eigenschaften eines Fotos (per ID):
+ * Beschreibung, Sichtbarkeit (enabled), Löschstatus (deleted), Koordinaten.
+ */
+final class UpdatePhotoTool implements McpToolInterface
+{
+    public function __construct(
+        private readonly EntityResolver $resolver,
+        private readonly ManagerRegistry $registry,
+        private readonly CriticalSerializerInterface $serializer,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'update_photo';
+    }
+
+    public function description(): string
+    {
+        return 'Aktualisiert ein Foto (per ID): description, enabled, deleted, latitude, longitude.';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'photoId' => ['type' => 'integer', 'description' => 'ID des Fotos.'],
+                'photo' => [
+                    'type' => 'object',
+                    'description' => 'Zu ändernde Felder: description, enabled (bool), deleted (bool), latitude, longitude.',
+                ],
+            ],
+            'required' => ['photoId', 'photo'],
+        ];
+    }
+
+    public function requiredScope(): OAuthScope
+    {
+        return OAuthScope::PhotoWrite;
+    }
+
+    public function call(array $arguments): string
+    {
+        if (!isset($arguments['photoId']) || !is_numeric($arguments['photoId'])) {
+            throw new McpToolException('photoId ist erforderlich und muss eine Zahl sein.');
+        }
+
+        $photo = $this->resolver->photo((int) $arguments['photoId']);
+        $data = \is_array($arguments['photo'] ?? null) ? $arguments['photo'] : [];
+
+        if (array_key_exists('description', $data)) {
+            $photo->setDescription(null === $data['description'] ? null : (string) $data['description']);
+        }
+
+        if (array_key_exists('enabled', $data)) {
+            if (!\is_bool($data['enabled'])) {
+                throw new McpToolException('photo.enabled muss ein Boolean sein.');
+            }
+            $photo->setEnabled($data['enabled']);
+        }
+
+        if (array_key_exists('deleted', $data)) {
+            if (!\is_bool($data['deleted'])) {
+                throw new McpToolException('photo.deleted muss ein Boolean sein.');
+            }
+            $photo->setDeleted($data['deleted']);
+        }
+
+        if (array_key_exists('latitude', $data)) {
+            $photo->setLatitude(null === $data['latitude'] ? null : (float) $data['latitude']);
+        }
+
+        if (array_key_exists('longitude', $data)) {
+            $photo->setLongitude(null === $data['longitude'] ? null : (float) $data['longitude']);
+        }
+
+        $this->registry->getManager()->flush();
+
+        return $this->serializer->serialize($photo, 'json', ['groups' => ['photo-details']]);
+    }
+}

--- a/src/OAuth2/OAuthScope.php
+++ b/src/OAuth2/OAuthScope.php
@@ -29,6 +29,7 @@ enum OAuthScope: string
     case LocationWrite = 'location:write';
     case SubrideWrite = 'subride:write';
     case PostWrite = 'post:write';
+    case PhotoWrite = 'photo:write';
 
     public function label(): string
     {
@@ -50,6 +51,7 @@ enum OAuthScope: string
             self::LocationWrite => 'Treffpunkte (Locations) anlegen und bearbeiten',
             self::SubrideWrite => 'Subrides (Anfahrten) anlegen und bearbeiten',
             self::PostWrite => 'Forenbeiträge anlegen, bearbeiten und löschen',
+            self::PhotoWrite => 'Fotos bearbeiten und löschen',
         };
     }
 

--- a/tests/Controller/Api/PhotoApi/PhotoApiWriteTest.php
+++ b/tests/Controller/Api/PhotoApi/PhotoApiWriteTest.php
@@ -2,77 +2,125 @@
 
 namespace Tests\Controller\Api\PhotoApi;
 
+use App\Entity\City;
+use App\Entity\CitySlug;
 use App\Entity\Photo;
+use App\Entity\Ride;
 use PHPUnit\Framework\Attributes\TestDox;
 use Tests\Controller\Api\AbstractApiControllerTestCase;
 
 #[TestDox('Photo API Write Operations')]
 class PhotoApiWriteTest extends AbstractApiControllerTestCase
 {
-    #[TestDox('POST /api/photo/{id} accepts update request')]
-    public function testUpdatePhoto(): void
+    protected function setUp(): void
     {
-        $photos = $this->entityManager->getRepository(Photo::class)->findAll();
+        parent::setUp();
+        $this->entityManager->getConnection()->beginTransaction();
+    }
 
-        if (empty($photos)) {
-            $this->markTestSkipped('No photos found in database');
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
         }
 
-        $photo = $photos[0];
+        parent::tearDown();
+    }
 
-        $updateData = [
-            'description' => 'Updated description via API test',
-            'location' => 'Updated Location',
-        ];
+    private function createPhoto(): Photo
+    {
+        $slug = 'photo-api-' . substr(md5(uniqid('', true)), 0, 12);
+
+        $city = new City();
+        $city->setCity('Fotostadt');
+        $city->setTitle('Critical Mass Fotostadt');
+        $city->setCreatedAt(new \DateTime());
+        $this->entityManager->persist($city);
+
+        $citySlug = new CitySlug();
+        $citySlug->setSlug($slug);
+        $citySlug->setCity($city);
+        $this->entityManager->persist($citySlug);
+        $city->setMainSlug($citySlug);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setDateTime(new \DateTime('2026-09-01 19:00:00'));
+        $ride->setTitle('Critical Mass');
+        $this->entityManager->persist($ride);
+
+        $photo = new Photo();
+        $photo->setRide($ride);
+        $photo->setCity($city);
+        $photo->setImageName('test.jpg');
+        $photo->setCreationDateTime(new \DateTime());
+        $photo->setEnabled(true);
+        $photo->setDeleted(false);
+        $this->entityManager->persist($photo);
+
+        $this->entityManager->flush();
+
+        return $photo;
+    }
+
+    #[TestDox('POST /api/photo/{id} persists a description change')]
+    public function testUpdatePhotoDescriptionPersists(): void
+    {
+        $photo = $this->createPhoto();
+        $photoId = $photo->getId();
 
         $this->client->request(
             'POST',
-            sprintf('/api/photo/%d', $photo->getId()),
+            sprintf('/api/photo/%d', $photoId),
             [],
             [],
             ['CONTENT_TYPE' => 'application/json'],
-            json_encode($updateData)
+            json_encode(['description' => 'Geänderte Beschreibung'])
         );
 
-        // Note: The current PhotoController implementation doesn't actually
-        // update the photo - it deserializes and re-serializes the input
         $this->assertResponseIsSuccessful();
 
-        // Response is valid JSON (even if double-serialized)
-        $content = $this->client->getResponse()->getContent();
-        $decoded = json_decode($content, true);
-        $this->assertNotNull($decoded, 'Response should be valid JSON');
+        $this->entityManager->clear();
+        $updated = $this->entityManager->getRepository(Photo::class)->find($photoId);
+        $this->assertSame('Geänderte Beschreibung', $updated?->getDescription());
     }
 
-    #[TestDox('POST /api/photo/{nonExistentId} returns 200 (current behavior - id is not used)')]
-    public function testUpdateNonExistentPhotoReturnsOk(): void
+    #[TestDox('DELETE /api/photo/{id} soft-deletes the photo')]
+    public function testDeletePhotoSoftDeletes(): void
     {
-        // Note: The current PhotoController implementation ignores the {id}
-        // parameter and just deserializes the request body. This is a known
-        // limitation of the current API.
+        $photo = $this->createPhoto();
+        $photoId = $photo->getId();
+
+        $this->client->request('DELETE', sprintf('/api/photo/%d', $photoId));
+
+        $this->assertResponseIsSuccessful();
+
+        $this->entityManager->clear();
+        $reloaded = $this->entityManager->getRepository(Photo::class)->find($photoId);
+        $this->assertTrue($reloaded?->isDeleted());
+    }
+
+    #[TestDox('POST /api/photo/{nonExistentId} returns 404')]
+    public function testUpdateNonExistentPhotoReturns404(): void
+    {
         $this->client->request(
             'POST',
-            '/api/photo/999999',
+            '/api/photo/999999999',
             [],
             [],
             ['CONTENT_TYPE' => 'application/json'],
             json_encode(['description' => 'Test'])
         );
 
-        // Currently returns 200 because the controller doesn't verify the photo exists
-        $this->assertResponseIsSuccessful();
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
     }
 
-    #[TestDox('POST /api/photo/{id} with empty body returns response')]
+    #[TestDox('POST /api/photo/{id} with empty body succeeds without changes')]
     public function testUpdatePhotoWithEmptyBody(): void
     {
-        $photos = $this->entityManager->getRepository(Photo::class)->findAll();
-
-        if (empty($photos)) {
-            $this->markTestSkipped('No photos found in database');
-        }
-
-        $photo = $photos[0];
+        $photo = $this->createPhoto();
 
         $this->client->request(
             'POST',
@@ -83,21 +131,13 @@ class PhotoApiWriteTest extends AbstractApiControllerTestCase
             '{}'
         );
 
-        // Either success or error response
-        $statusCode = $this->client->getResponse()->getStatusCode();
-        $this->assertContains($statusCode, [200, 400, 500], 'Should return a valid response');
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
     }
 
-    #[TestDox('POST /api/photo/{id} with invalid JSON returns error')]
+    #[TestDox('POST /api/photo/{id} with invalid JSON returns 400')]
     public function testUpdatePhotoWithInvalidJson(): void
     {
-        $photos = $this->entityManager->getRepository(Photo::class)->findAll();
-
-        if (empty($photos)) {
-            $this->markTestSkipped('No photos found in database');
-        }
-
-        $photo = $photos[0];
+        $photo = $this->createPhoto();
 
         $this->client->request(
             'POST',
@@ -108,8 +148,6 @@ class PhotoApiWriteTest extends AbstractApiControllerTestCase
             'invalid json {'
         );
 
-        // Should return error status
-        $statusCode = $this->client->getResponse()->getStatusCode();
-        $this->assertContains($statusCode, [400, 500], 'Invalid JSON should return error');
+        $this->assertEquals(400, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Mcp/WriteToolsTest.php
+++ b/tests/Mcp/WriteToolsTest.php
@@ -620,6 +620,60 @@ final class WriteToolsTest extends AbstractMcpTestCase
         self::assertSame('Sichtbar', $result['json']['message']);
     }
 
+    public function testDeleteTrackSoftDeletes(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $track = $this->createTrack($ride);
+        $trackId = $track->getId();
+        $token = $this->obtainAccessToken('track:write');
+
+        $result = $this->callTool($token, 'delete_track', ['trackId' => $trackId]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        $reloaded = $this->em()->getRepository(\App\Entity\Track::class)->find($trackId);
+        self::assertTrue($reloaded?->getDeleted());
+    }
+
+    public function testUpdatePhotoChangesDescription(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $photo = $this->createPhoto($ride, $city);
+        $photoId = $photo->getId();
+        $token = $this->obtainAccessToken('photo:write');
+
+        $result = $this->callTool($token, 'update_photo', [
+            'photoId' => $photoId,
+            'photo' => ['description' => 'Schöner Ausblick'],
+        ]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        $updated = $this->em()->getRepository(\App\Entity\Photo::class)->find($photoId);
+        self::assertSame('Schöner Ausblick', $updated?->getDescription());
+    }
+
+    public function testDeletePhotoSoftDeletes(): void
+    {
+        $city = $this->createCity();
+        $ride = $this->createRide($city, '2026-09-01 19:00:00');
+        $photo = $this->createPhoto($ride, $city);
+        $photoId = $photo->getId();
+        $token = $this->obtainAccessToken('photo:write');
+
+        $result = $this->callTool($token, 'delete_photo', ['photoId' => $photoId]);
+
+        self::assertFalse($result['isError'], $result['text']);
+
+        $this->em()->clear();
+        $reloaded = $this->em()->getRepository(\App\Entity\Photo::class)->find($photoId);
+        self::assertTrue($reloaded?->isDeleted());
+    }
+
     public function testWriteToolRejectedWithoutScope(): void
     {
         $token = $this->obtainAccessToken('ride:read');


### PR DESCRIPTION
## Summary

Ergänzt Bearbeiten/Löschen für Tracks und Fotos über MCP (Anlegen bleibt ausgelassen — Datei-Upload). Behebt zusätzlich zwei bestehende REST-API-Bugs. Teil der Initiative „alle CRUD-Operationen via MCP" (PR 7 von 8).

> **Stacked auf #1444**. Reihenfolge: #1439 → #1440 → #1441 → #1442 → #1443 → #1444 → dieser PR.

- **Neuer Scope `photo:write`** (Enum + `league_oauth2_server.yaml`).
- **MCP-Tools:** `delete_track` (`track:write`, Soft-Delete + `TrackDeletedEvent`), `update_photo` + `delete_photo` (`photo:write`, Soft-Delete). `EntityResolver` bekommt `track(id)`, `photo(id)`.

### Bugfixes (bestehende API)
1. **`POST /api/photo/{id}` war ein No-Op:** lud das Foto nie per ID, deserialisierte ein Wegwerf-Objekt und flushte nie. Jetzt: Foto laden, Felder (description/enabled/deleted/Koordinaten) setzen, flushen. Neu: `DELETE /api/photo/{id}` (Soft-Delete).
2. **`GET /api/track/{id}` und `GET /api/track`** bauten die Serialisierungsgruppen (`api-public`/`api-private`) zusammen, übergaben sie aber nie an die Response. Jetzt korrekt übergeben.

Der vorhandene `PhotoApiWriteTest` (der das alte No-Op-Verhalten dokumentierte, inkl. „404er-Foto → 200") wird auf das korrigierte Verhalten (404, persistierendes Update) umgestellt.

## Test Plan

- [x] MCP-Tests: delete_track (deleted=true), update_photo (description), delete_photo
- [x] PhotoApi-Write-Tests: Update persistiert, Delete (soft), unbekannt → 404, leerer Body → 200, invalides JSON → 400
- [x] `tests/Mcp` + `tests/OAuth2` + `tests/Controller/Api/PhotoApi` + `.../TrackApi`: 227/227 grün
- [x] PHPStan (Level 6): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)