### PR TITLE
Passkeys: Firewall-Authenticator und Endpunkte (2/4)

### DIFF
--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -12,6 +12,14 @@ framework:
             limit: 5
             interval: '15 minutes'
 
+        # Passkey-Endpunkte pro Client-IP. Der Token Bucket verkraftet Lastspitzen —
+        # die Conditional UI ruft /passkey/login/options bei jedem Aufruf der Login-Seite
+        # auf — deckelt aber den Dauerdurchsatz.
+        passkey:
+            policy: token_bucket
+            limit: 60
+            rate: { interval: '1 minute', amount: 20 }
+
         # Track-Uploads pro User (Bulk = eine Anfrage je Datei). Großzügig, damit
         # legitime Bulk-Importe durchgehen, aber Missbrauch gedrosselt wird.
         upload:

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -22,6 +22,22 @@ security:
             login_link:
                 check_route: login_check
                 signature_properties: [ 'email' ]
+            # Passkeys als dritte Anmeldeart neben Magic Link und OAuth. Die Pfade sind
+            # sämtlich überschrieben: die Vorgaben des Bundles wären `/login/options`,
+            # `POST /login`, `/register/options` und `POST /register` — und `POST /login`
+            # gehört bereits `login_perform`.
+            webauthn:
+                authentication:
+                    enabled: true
+                    routes:
+                        options_path: /passkey/login/options
+                        result_path: /passkey/login
+                registration:
+                    # Standardmäßig aus, muss ausdrücklich eingeschaltet werden.
+                    enabled: true
+                    routes:
+                        options_path: /passkey/register/options
+                        result_path: /passkey/register
             provider: users
             pattern: .*
             context: user
@@ -50,6 +66,14 @@ security:
         # Related Origin Requests: der Browser holt diese Liste, bevor er einen Passkey
         # mit RP ID criticalmass.one auf criticalmass.in zulässt.
         - { path: '^/\.well-known/webauthn$', role: PUBLIC_ACCESS }
+
+        # Anmelden per Passkey muss anonym möglich sein.
+        - { path: ^/passkey/login, role: PUBLIC_ACCESS }
+        # Einen Passkey anlegen dagegen nie: wer hier durchkäme, könnte sich einen
+        # Authenticator auf ein fremdes Konto legen. Zweite Absicherung ist der
+        # CurrentUserEntityGuesser in services.yaml, der den Kontobezug aus der Sitzung
+        # nimmt statt aus dem Request-Body.
+        - { path: ^/passkey/register, role: ROLE_USER }
 
         # OAuth2 / MCP
         - { path: '^/\.well-known/oauth', role: PUBLIC_ACCESS }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -164,3 +164,12 @@ services:
 
     Sabre\VObject\Component\VCalendar: ~
 
+
+    # Der Firewall-Authenticator verdrahtet für den Registrierungs-Endpunkt fest den
+    # RequestBodyUserEntityGuesser — der nimmt den Benutzernamen aus dem Request-Body.
+    # Damit könnte jemand einen Passkey auf ein fremdes Konto legen. Der Klassenname ist
+    # in der Factory hart referenziert und über die Bundle-Konfiguration nicht
+    # austauschbar, also biegen wir den Service auf die sitzungsbasierte Variante um:
+    # Ein Passkey lässt sich damit ausschließlich für das eigene, eingeloggte Konto anlegen.
+    Webauthn\Bundle\Security\Guesser\RequestBodyUserEntityGuesser:
+        alias: Webauthn\Bundle\Security\Guesser\CurrentUserEntityGuesser

--- a/src/EventSubscriber/PasskeyRateLimitSubscriber.php
+++ b/src/EventSubscriber/PasskeyRateLimitSubscriber.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+/**
+ * Drosselt die vier Passkey-Endpunkte pro Client-IP. Die echte IP setzt trusted_proxies
+ * voraus.
+ *
+ * Ein Subscriber statt der Drosselung im Controller, weil die Controller vom Bundle
+ * kommen und uns nicht gehören. Symfonys `login_throttling` an der Firewall wäre die
+ * elegantere Variante, würde aber Magic Link und OAuth gleich mitdrosseln.
+ *
+ * Passkeys lassen sich nicht erraten, hier geht es also nicht um Brute Force, sondern um
+ * Rechenlast: jede Anmeldung prüft eine Signatur. Die Grenzen sind entsprechend weit
+ * gesetzt, damit sie hinter geteilten Adressen (Mobilfunk, Firmennetze) nicht im
+ * Alltagsbetrieb zuschlagen.
+ */
+final class PasskeyRateLimitSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly RateLimiterFactory $passkeyLimiter,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 16],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!str_starts_with($request->getPathInfo(), '/passkey/')) {
+            return;
+        }
+
+        $limit = $this->passkeyLimiter->create($request->getClientIp())->consume();
+
+        if (false === $limit->isAccepted()) {
+            throw new TooManyRequestsHttpException(
+                max(0, $limit->getRetryAfter()->getTimestamp() - time()),
+                'Zu viele Passkey-Anfragen. Bitte versuche es später erneut.',
+            );
+        }
+    }
+}

--- a/tests/EventSubscriber/PasskeyRateLimitSubscriberTest.php
+++ b/tests/EventSubscriber/PasskeyRateLimitSubscriberTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\PasskeyRateLimitSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+/**
+ * Wie im ApiRateLimitSubscriberTest: echte RateLimiterFactory (final) mit
+ * In-Memory-Storage und limit 1, der IP-Bucket wird gezielt vorab erschöpft.
+ */
+final class PasskeyRateLimitSubscriberTest extends TestCase
+{
+    private const CLIENT_IP = '127.0.0.1';
+
+    public function testThrottlesLoginOptionsWhenLimitExceeded(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        (new PasskeyRateLimitSubscriber($factory))->onKernelRequest($this->event('/passkey/login/options'));
+    }
+
+    public function testThrottlesRegistrationWhenLimitExceeded(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        (new PasskeyRateLimitSubscriber($factory))->onKernelRequest($this->event('/passkey/register'));
+    }
+
+    public function testAllowsRequestWithinLimit(): void
+    {
+        (new PasskeyRateLimitSubscriber($this->factory()))->onKernelRequest($this->event('/passkey/login'));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Der Magic-Link-Login hat seine eigene Drosselung und darf hier nicht mit
+     * hineingezogen werden — /login beginnt nicht mit /passkey/.
+     */
+    public function testIgnoresOtherLoginRoutes(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        (new PasskeyRateLimitSubscriber($factory))->onKernelRequest($this->event('/login'));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testIgnoresSubRequests(): void
+    {
+        $factory = $this->factory();
+        $factory->create(self::CLIENT_IP)->consume();
+
+        $event = new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create('/passkey/login/options', 'POST'),
+            HttpKernelInterface::SUB_REQUEST,
+        );
+
+        (new PasskeyRateLimitSubscriber($factory))->onKernelRequest($event);
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function factory(): RateLimiterFactory
+    {
+        return new RateLimiterFactory(
+            ['id' => 'passkey_test', 'policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'],
+            new InMemoryStorage(),
+        );
+    }
+
+    private function event(string $path): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            Request::create($path, 'POST'),
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+}


### PR DESCRIPTION
Zweiter von vier PRs. Baut auf #1464 auf — **Base-Branch ist `feature/passkeys-foundation`**, nicht `main`. Schaltet die Passkey-Endpunkte scharf; ein Frontend gibt es noch nicht, bedienbar ist das erst mit PR 3.

## Summary

- **`webauthn`-Key in der `main`-Firewall**, neben `login_link` und `oauth`. Kein eigener Firewall, der Session-Context bleibt.
- **Alle vier Pfade überschrieben.** Die Vorgaben des Bundles wären `/login/options`, `POST /login`, `/register/options` und `POST /register` — und `POST /login` gehört bereits `login_perform` (Priority 200). Jetzt liegt alles unter `/passkey/`.
- **Registrierung ausdrücklich eingeschaltet**, im Bundle ist sie per Default aus.
- **Drosselung pro Client-IP** über `PasskeyRateLimitSubscriber`. Ein Subscriber, weil die Controller vom Bundle kommen und uns nicht gehören; Symfonys `login_throttling` an der Firewall würde Magic Link und OAuth gleich mitdrosseln. Token Bucket (60, +20/min), damit die Conditional UI — die `/passkey/login/options` bei jedem Aufruf der Login-Seite trifft — hinter geteilten Adressen nicht im Alltagsbetrieb anschlägt. Passkeys lassen sich nicht erraten, hier geht es um Rechenlast, nicht um Brute Force.

## Sicherheitsrelevant: Kontobezug aus der Sitzung statt aus dem Request-Body

Der Firewall-Authenticator verdrahtet für den Registrierungs-Endpunkt fest den `RequestBodyUserEntityGuesser` (`WebauthnFactory::createAttestationRequestControllerAndRoute()`, Zeile 414). Der nimmt den Benutzernamen aus dem **Request-Body** — womit sich ein Angreifer seinen eigenen Authenticator als Passkey auf ein fremdes Konto legen könnte. Vollständige Kontoübernahme.

Der Klassenname ist in der Factory hart referenziert und über die Bundle-Konfiguration nicht austauschbar. Deshalb zeigt der Service-Alias jetzt auf den sitzungsbasierten `CurrentUserEntityGuesser`: Ein Passkey lässt sich damit ausschließlich für das eigene, eingeloggte Konto anlegen. `CurrentUserEntityGuesser` löst über `getUserIdentifier()` auf, und das liefert bei uns die E-Mail-Adresse — genau die Property, über die auch der Security-Provider geht.

Zweite Ebene: `access_control` verlangt `ROLE_USER` auf `^/passkey/register`. Nötig, aber allein nicht ausreichend, weil ein beliebiger eingeloggter Nutzer sonst immer noch einen fremden Benutzernamen in den Body schreiben könnte.

Gegen fremdes Auslösen aus anderen Origins schützt zusätzlich das Session-Cookie mit `samesite: lax`: Ein Cross-Site-POST bekommt es gar nicht erst mit.

## Test Plan

- [x] Alle vier Routen registriert und kollisionsfrei — `debug:router` zeigt `/passkey/login/options`, `/passkey/login`, `/passkey/register/options`, `/passkey/register`; `/login` und `/register` unverändert
- [x] Service-Alias greift — `debug:container RequestBodyUserEntityGuesser` löst auf `CurrentUserEntityGuesser` auf
- [x] `access_control` wie beabsichtigt — `debug:config security` zeigt `^/passkey/login` → `PUBLIC_ACCESS` und `^/passkey/register` → `ROLE_USER`
- [x] `lint:container` in dev **und** prod OK
- [x] PHPStan Level 6 über das gesamte Projekt ohne Fehler
- [x] 33 Unit-Tests grün, davon 5 neue für den Rate-Limit-Subscriber

Keine funktionalen Tests: die Testumgebung teilt sich laut `tests/bootstrap.php` die `DATABASE_URL` mit der Entwicklungsdatenbank, und die Suite würde lokale Daten überschreiben. Die Endpunkte sind deshalb per Konfigurationsprüfung verifiziert, das Zusammenspiel im Browser kommt in PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)