### PR TITLE
Passkeys: Frontend und Kontoverwaltung (3/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,22 @@ vendor/bin/phpunit --filter testMethodName                  # Single test method
 # Controller/DB tests need MariaDB up (docker-compose up); otherwise they fail with
 # "getaddrinfo for mysql failed". Pure unit tests (no DB) run standalone.
 # Use `php bin/console ...` (the bare `bin/console` may report "permission denied").
+# Console commands often need more memory: `php -d memory_limit=-1 bin/console ...`
 ```
+
+### Migrationen
+
+```bash
+php -d memory_limit=-1 bin/console doctrine:migrations:migrate
+```
+
+**Die Migrationskette ist nicht von null abspielbar:** `Version20170527205445` ruft
+`$platform->getName()`, das es in DBAL 4 nicht mehr gibt. Ein frisches Schema entsteht
+deshalb über `doctrine:schema:create` aus dem Mapping, nicht aus den Migrationen — und
+für eine neue Migration nimmt man die DDL aus `doctrine:schema:create --dump-sql` gegen
+eine Wegwerf-Datenbank, statt `migrations:diff` gegen eine unvollständige Dev-DB laufen
+zu lassen. Anschließend mit `doctrine:schema:update --dump-sql` gegenprüfen (muss leer
+sein) und `up`/`down` einmal durchspielen.
 
 ### Static Analysis
 ```bash
@@ -32,6 +47,9 @@ vendor/bin/phpstan analyse                  # PHPStan level 6
 
 ### Frontend Assets
 ```bash
+# Braucht Node 20+. Liegt eine ältere Version im PATH, bricht encore mit
+# "SyntaxError: Unexpected token '?'" ab — dann z. B.
+# export PATH="$HOME/.nvm/versions/node/v20.18.1/bin:$PATH"
 yarn dev          # Build once for development
 yarn watch        # Dev build with file watching
 yarn build        # Production build
@@ -72,9 +90,60 @@ Everything is confirmed on **one review page** at `/upload/review` (`UnifiedRevi
 
 **Frontend note:** the uploader is **Uppy** (`assets/controllers/unified_upload_controller.js`), no Compressor plugin so image EXIF survives. The `@uppy/*` packages are declared in `package.json`, but `package-lock.json` is **frozen** — `webpack`/`@babel/core` are not declared deps and survive only via the committed lock, so any re-resolution (`npm install`/`yarn install`) breaks the tree; use `npm ci`, and regenerate the lock deliberately when adding frontend deps. Frontend assets are **not** built in CI.
 
+### Anmeldung: passwortlos, drei Wege
+
+Die App kennt **kein Passwort** — `User::getPassword()` gibt fest `''` zurück, es gibt kein
+Passwortfeld in der Datenbank. Angemeldet wird über **Magic Link** (`login_link`, Konten
+entstehen dabei implizit in `LoginController::createNewUser()`, einen `/register`-Endpunkt
+gibt es nicht), über **OAuth** (Facebook/Strava, HWIOAuthBundle) oder über einen
+**Passkey**.
+
+**Passkeys (WebAuthn)** laufen über `web-auth/webauthn-symfony-bundle`. Was daran nicht
+selbsterklärend ist:
+
+- **RP ID ist `criticalmass.one`.** `criticalmass.in`, `www.criticalmass.in` und
+  `criticalmass.one` liefern dieselbe App ohne Redirect aus, sind aber teils
+  verschiedene registrierbare Domains. Die `.in`-Domains sind über **Related Origin
+  Requests** abgedeckt: `webauthn.allowed_origins` wird unter `/.well-known/webauthn`
+  ausgeliefert. **Eine Änderung der RP ID entwertet jeden registrierten Passkey.**
+- `allowed_origins` **muss literal** in der Config stehen (deshalb Produktionswerte in
+  `config/packages/prod/webauthn.yaml`, dev/test in `config/packages/webauthn.yaml`).
+  Der Compiler-Pass liest die Liste zur Container-Bauzeit und legt die
+  `/.well-known/webauthn`-Route nur an, wenn er ein echtes Array sieht — ein `%env()%`
+  wäre dort noch ein String. Aus demselben Grund lässt sich die Liste nicht per
+  `when@dev` leeren: Config-Merge ergänzt Listen, er ersetzt sie nicht.
+- Der Loader-Eintrag `type: webauthn` in `config/routes.yaml` ist Pflicht, sonst
+  existieren weder `/.well-known/webauthn` noch die vier `/passkey/`-Endpunkte.
+- **Alle vier Endpunkte sind auf `/passkey/…` umgebogen.** Die Vorgaben des Bundles wären
+  `/login/options`, `POST /login`, `/register/options`, `POST /register` — und `POST /login`
+  gehört bereits `login_perform`.
+- **Sicherheitsrelevant:** Der Firewall-Authenticator verdrahtet für die Registrierung fest
+  den `RequestBodyUserEntityGuesser`, der den Benutzernamen aus dem Request-Body nimmt.
+  Der Service ist in `config/services.yaml` per Alias auf den sitzungsbasierten
+  `CurrentUserEntityGuesser` umgebogen — **diesen Alias nicht entfernen**, sonst kann sich
+  jeder einen Passkey auf ein fremdes Konto legen.
+- Der **User-Handle** ist `User::$webauthnUserHandle` (UUID, lazy erzeugt), bewusst **nicht**
+  die E-Mail: die lässt sich im Profil ohne Re-Verifikation ändern, und mit ihr als Handle
+  wären danach alle Passkeys des Kontos tot.
+- `App\Entity\WebauthnCredential` erbt von der Mapped Superclass `Webauthn\CredentialRecord`,
+  deren XML-Zuordnung aus dem Bundle als eigenes Doctrine-Mapping eingebunden ist. Die
+  Credential-ID liegt **base64-kodiert** in der Datenbank (`findOneByCredentialId()` muss
+  selbst kodieren) und ist ein `LONGTEXT`, ihr UNIQUE-Index braucht deshalb eine
+  Präfixlänge.
+- `WebauthnCredentialVoter` hat bewusst **keine `ROLE_ADMIN`-Ausnahme**, anders als
+  `TrackVoter`/`PhotoVoter`: Wer fremde Passkeys löschen könnte, sperrt Nutzer aus ihren
+  Konten aus.
+
 ### Frontend (`assets/`)
 
 Single Webpack Encore entry point (`assets/app.js`). Stimulus controllers in `assets/controllers/` — maps (Leaflet + MapLibre GL), charts (Chart.js), datatables, search, geocoding, ride date checking.
+
+`passkey_controller.js` ist bewusst **ohne** `@simplewebauthn/browser` geschrieben: Die
+base64url-Umrechnung können die Browser über `parseCreationOptionsFromJSON()` / `toJSON()`
+inzwischen selbst, und eine neue Frontend-Dependency würde die eingefrorene
+`package-lock.json` neu auflösen (siehe Frontend note oben). Die Conditional UI hängt an
+`autocomplete="username webauthn"` in `LoginType` und ist über
+`data-passkey-conditional-value` nur auf der Login-Seite aktiv.
 
 ### Tests (`tests/`)
 

--- a/assets/controllers/passkey_controller.js
+++ b/assets/controllers/passkey_controller.js
@@ -1,0 +1,301 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Passkeys anlegen und sich damit anmelden.
+ *
+ * Bewusst ohne Fremdbibliothek: Was @simplewebauthn/browser vor allem abnahm, war die
+ * Umrechnung zwischen base64url und ArrayBuffer, und die erledigen die Browser inzwischen
+ * selbst über parseCreationOptionsFromJSON() / parseRequestOptionsFromJSON() / toJSON().
+ * Für ältere Browser steht die Umrechnung weiter unten, das ist billiger als eine
+ * Dependency (package-lock.json ist eingefroren).
+ */
+export default class extends Controller {
+    static targets = ['status', 'submit'];
+
+    static values = {
+        loginOptionsUrl: { type: String, default: '/passkey/login/options' },
+        loginUrl: { type: String, default: '/passkey/login' },
+        registerOptionsUrl: { type: String, default: '/passkey/register/options' },
+        registerUrl: { type: String, default: '/passkey/register' },
+        redirectUrl: { type: String, default: '/' },
+        // Nur auf der Login-Seite: dort soll der Browser den Passkey im Autofill
+        // anbieten. In der Kontoverwaltung ist der Nutzer längst angemeldet.
+        conditional: { type: Boolean, default: false },
+        confirmText: { type: String, default: 'Wirklich löschen?' },
+    };
+
+    connect() {
+        if (!this.isSupported()) {
+            this.element.hidden = true;
+
+            return;
+        }
+
+        if (this.conditionalValue) {
+            this.startConditionalMediation();
+        }
+    }
+
+    disconnect() {
+        this.abortConditionalMediation();
+    }
+
+    // ---------------------------------------------------------------- Registrierung
+
+    async register(event) {
+        event.preventDefault();
+
+        // Die Conditional UI hält einen offenen get()-Aufruf. Zwei gleichzeitige
+        // WebAuthn-Ceremonies verträgt der Browser nicht, also erst abräumen.
+        this.abortConditionalMediation();
+
+        try {
+            this.busy(true);
+
+            const optionsJson = await this.postJson(this.registerOptionsUrlValue, {});
+            const options = this.parseCreationOptions(optionsJson);
+            const credential = await navigator.credentials.create({ publicKey: options });
+
+            await this.postJson(this.registerUrlValue, this.serialize(credential));
+
+            window.location.reload();
+        } catch (error) {
+            this.busy(false);
+            this.fail(error, 'Der Passkey konnte nicht angelegt werden.');
+        }
+    }
+
+    // ---------------------------------------------------------------- Anmeldung
+
+    async login(event) {
+        event.preventDefault();
+
+        this.abortConditionalMediation();
+
+        try {
+            this.busy(true);
+
+            await this.assert();
+        } catch (error) {
+            this.busy(false);
+            this.fail(error, 'Die Anmeldung mit dem Passkey hat nicht geklappt.');
+        }
+    }
+
+    /**
+     * Bietet den Passkey im Autofill des E-Mail-Feldes an, ohne dass die Seite anders
+     * aussieht. Scheitert das still, bleibt der normale Weg über den Button.
+     */
+    async startConditionalMediation() {
+        if (typeof PublicKeyCredential.isConditionalMediationAvailable !== 'function') {
+            return;
+        }
+
+        try {
+            if (!(await PublicKeyCredential.isConditionalMediationAvailable())) {
+                return;
+            }
+
+            this.conditionalController = new AbortController();
+
+            await this.assert({
+                mediation: 'conditional',
+                signal: this.conditionalController.signal,
+            });
+        } catch (error) {
+            // Ein Abbruch ist der Normalfall: der Nutzer hat sich anders angemeldet oder
+            // die Seite verlassen. Alles andere ist hier nicht behandelbar, weil im
+            // Hintergrund niemand darauf wartet.
+            if (error.name !== 'AbortError' && error.name !== 'NotAllowedError') {
+                console.warn('[passkey] Conditional UI nicht verfügbar:', error);
+            }
+        }
+    }
+
+    abortConditionalMediation() {
+        if (this.conditionalController) {
+            this.conditionalController.abort();
+            this.conditionalController = null;
+        }
+    }
+
+    async assert(extraOptions = {}) {
+        const optionsJson = await this.postJson(this.loginOptionsUrlValue, {});
+        const options = this.parseRequestOptions(optionsJson);
+
+        const credential = await navigator.credentials.get({
+            publicKey: options,
+            ...extraOptions,
+        });
+
+        await this.postJson(this.loginUrlValue, this.serialize(credential));
+
+        window.location.href = this.redirectUrlValue;
+    }
+
+    /**
+     * Rückfrage vor dem Löschen. Als Stimulus-Action statt als Inline-onclick, weil die
+     * Content-Security-Policy `script-src` bewusst ohne `unsafe-inline` fährt.
+     */
+    confirmDelete(event) {
+        if (!window.confirm(this.confirmTextValue)) {
+            event.preventDefault();
+        }
+    }
+
+    // ---------------------------------------------------------------- Transport
+
+    async postJson(url, payload) {
+        const response = await fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            },
+            body: JSON.stringify(payload),
+        });
+
+        const body = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+            throw new Error(body.errorMessage || body.message || `Der Server hat mit ${response.status} geantwortet.`);
+        }
+
+        return body;
+    }
+
+    // ---------------------------------------------------------------- Kodierung
+
+    isSupported() {
+        return typeof window.PublicKeyCredential !== 'undefined'
+            && typeof navigator.credentials?.create === 'function';
+    }
+
+    parseCreationOptions(json) {
+        if (typeof PublicKeyCredential.parseCreationOptionsFromJSON === 'function') {
+            return PublicKeyCredential.parseCreationOptionsFromJSON(json);
+        }
+
+        return {
+            ...json,
+            challenge: base64UrlToBuffer(json.challenge),
+            user: { ...json.user, id: base64UrlToBuffer(json.user.id) },
+            excludeCredentials: (json.excludeCredentials || []).map(descriptorToBuffer),
+        };
+    }
+
+    parseRequestOptions(json) {
+        if (typeof PublicKeyCredential.parseRequestOptionsFromJSON === 'function') {
+            return PublicKeyCredential.parseRequestOptionsFromJSON(json);
+        }
+
+        return {
+            ...json,
+            challenge: base64UrlToBuffer(json.challenge),
+            allowCredentials: (json.allowCredentials || []).map(descriptorToBuffer),
+        };
+    }
+
+    /**
+     * Der Name des Passkeys läuft bewusst nicht hier mit: Den Registrierungs-Endpunkt
+     * stellt das Bundle, ein zusätzliches Feld im Body erreicht das Repository nie.
+     * Benannt wird serverseitig, umbenennen lässt sich in der Liste.
+     */
+    serialize(credential) {
+        return typeof credential.toJSON === 'function'
+            ? credential.toJSON()
+            : legacySerialize(credential);
+    }
+
+    // ---------------------------------------------------------------- Rückmeldung
+
+    busy(isBusy) {
+        if (this.hasSubmitTarget) {
+            this.submitTarget.disabled = isBusy;
+        }
+
+        if (isBusy) {
+            this.clearStatus();
+        }
+    }
+
+    fail(error, fallbackMessage) {
+        // Der Nutzer hat den Systemdialog weggeklickt — das ist keine Fehlermeldung wert.
+        if (error.name === 'NotAllowedError' || error.name === 'AbortError') {
+            return;
+        }
+
+        this.showStatus(error.message || fallbackMessage);
+    }
+
+    showStatus(message) {
+        if (!this.hasStatusTarget) {
+            return;
+        }
+
+        this.statusTarget.textContent = message;
+        this.statusTarget.hidden = false;
+    }
+
+    clearStatus() {
+        if (this.hasStatusTarget) {
+            this.statusTarget.textContent = '';
+            this.statusTarget.hidden = true;
+        }
+    }
+}
+
+function base64UrlToBuffer(value) {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/');
+    const binary = atob(padded.padEnd(padded.length + ((4 - (padded.length % 4)) % 4), '='));
+    const buffer = new Uint8Array(binary.length);
+
+    for (let i = 0; i < binary.length; i += 1) {
+        buffer[i] = binary.charCodeAt(i);
+    }
+
+    return buffer.buffer;
+}
+
+function bufferToBase64Url(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+
+    for (let i = 0; i < bytes.length; i += 1) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function descriptorToBuffer(descriptor) {
+    return { ...descriptor, id: base64UrlToBuffer(descriptor.id) };
+}
+
+function legacySerialize(credential) {
+    const response = credential.response;
+
+    const serialized = {
+        id: credential.id,
+        rawId: bufferToBase64Url(credential.rawId),
+        type: credential.type,
+        clientExtensionResults: credential.getClientExtensionResults(),
+        response: {
+            clientDataJSON: bufferToBase64Url(response.clientDataJSON),
+        },
+    };
+
+    if (response.attestationObject) {
+        serialized.response.attestationObject = bufferToBase64Url(response.attestationObject);
+        serialized.response.transports = typeof response.getTransports === 'function'
+            ? response.getTransports()
+            : [];
+    } else {
+        serialized.response.authenticatorData = bufferToBase64Url(response.authenticatorData);
+        serialized.response.signature = bufferToBase64Url(response.signature);
+        serialized.response.userHandle = response.userHandle ? bufferToBase64Url(response.userHandle) : null;
+    }
+
+    return serialized;
+}

--- a/src/Controller/Profile/PasskeyController.php
+++ b/src/Controller/Profile/PasskeyController.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller\Profile;
+
+use App\Controller\AbstractController;
+use App\Entity\User;
+use App\Entity\WebauthnCredential;
+use App\Repository\WebauthnCredentialRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * Verwaltung der eigenen Passkeys.
+ *
+ * Angelegt werden sie nicht hier, sondern über die Endpunkte des Bundles unter
+ * /passkey/register — die Ceremony muss der Browser fahren. Diese Seite listet auf, was
+ * dabei herauskam, und lässt es umbenennen und löschen.
+ */
+class PasskeyController extends AbstractController
+{
+    #[IsGranted('ROLE_USER')]
+    #[Route(
+        '/profile/passkeys',
+        name: 'criticalmass_user_profile_passkey_list',
+        methods: ['GET'],
+        priority: 180
+    )]
+    public function listAction(
+        WebauthnCredentialRepository $credentialRepository,
+        ?UserInterface $user = null
+    ): Response {
+        return $this->render('ProfileManagement/passkeys.html.twig', [
+            'credentials' => $credentialRepository->findAllForUser($this->requireUser($user)),
+        ]);
+    }
+
+    /**
+     * Das Credential kommt über seine ID aus der URL — ohne den Voter könnte jeder
+     * angemeldete Nutzer fremde Passkeys umbenennen.
+     */
+    #[IsGranted('edit', 'credential')]
+    #[Route(
+        '/profile/passkeys/{id}/rename',
+        name: 'criticalmass_user_profile_passkey_rename',
+        methods: ['POST'],
+        priority: 180
+    )]
+    public function renameAction(
+        Request $request,
+        ManagerRegistry $managerRegistry,
+        WebauthnCredential $credential
+    ): Response {
+        if (!$this->isCsrfTokenValid('passkey-rename-' . $credential->getId(), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Ungültiges CSRF-Token.');
+        }
+
+        $name = trim((string) $request->request->get('name'));
+
+        if ('' === $name) {
+            $this->addFlash('danger', 'Der Passkey braucht einen Namen.');
+
+            return $this->redirectToRoute('criticalmass_user_profile_passkey_list');
+        }
+
+        $credential->setName(mb_substr($name, 0, 255));
+
+        $managerRegistry->getManager()->flush();
+
+        $this->addFlash('success', sprintf('Der Passkey heißt jetzt %s.', $credential->getName()));
+
+        return $this->redirectToRoute('criticalmass_user_profile_passkey_list');
+    }
+
+    #[IsGranted('delete', 'credential')]
+    #[Route(
+        '/profile/passkeys/{id}/delete',
+        name: 'criticalmass_user_profile_passkey_delete',
+        methods: ['POST'],
+        priority: 180
+    )]
+    public function deleteAction(
+        Request $request,
+        WebauthnCredentialRepository $credentialRepository,
+        WebauthnCredential $credential
+    ): Response {
+        if (!$this->isCsrfTokenValid('passkey-delete-' . $credential->getId(), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Ungültiges CSRF-Token.');
+        }
+
+        $name = $credential->getName();
+
+        $credentialRepository->remove($credential);
+
+        $this->addFlash('success', sprintf('Der Passkey %s wurde gelöscht.', $name));
+
+        return $this->redirectToRoute('criticalmass_user_profile_passkey_list');
+    }
+
+    /**
+     * IsGranted('ROLE_USER') stellt bereits sicher, dass jemand angemeldet ist. Diese
+     * Einengung auf unsere User-Entity ist für die statische Analyse.
+     */
+    private function requireUser(?UserInterface $user): User
+    {
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException('Kein Benutzerkonto in der Sitzung.');
+        }
+
+        return $user;
+    }
+}

--- a/src/Form/Type/LoginType.php
+++ b/src/Form/Type/LoginType.php
@@ -14,7 +14,13 @@ class LoginType extends AbstractType
         $builder
             ->add('email', EmailType::class, [
                 'label' => 'E-Mail-Adresse',
-                'help' => 'Wenn du noch kein Benutzerkonto hast, wird automatisch ein neues mit deiner E-Mail-Adresse erstellt.'
+                'help' => 'Wenn du noch kein Benutzerkonto hast, wird automatisch ein neues mit deiner E-Mail-Adresse erstellt.',
+                'attr' => [
+                    // Der `webauthn`-Zusatz schaltet die Conditional UI frei: Der Browser
+                    // bietet einen vorhandenen Passkey direkt im Autofill dieses Feldes
+                    // an. Ohne Passkey verhält sich das Feld wie bisher.
+                    'autocomplete' => 'username webauthn',
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Link zusenden',

--- a/src/Security/Authorization/Voter/WebauthnCredentialVoter.php
+++ b/src/Security/Authorization/Voter/WebauthnCredentialVoter.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\Authorization\Voter;
+
+use App\Entity\User;
+use App\Entity\WebauthnCredential;
+
+/**
+ * Über die eigenen Passkeys entscheidet ausschließlich, wem sie gehören.
+ *
+ * Anders als TrackVoter und PhotoVoter gibt es hier bewusst **keine** Ausnahme für
+ * ROLE_ADMIN: Wer fremde Passkeys anlegen oder löschen könnte, könnte sich Zugang zu
+ * fremden Konten verschaffen oder Nutzer aus ihren aussperren. Administration hat an
+ * Anmeldedaten nichts zu suchen.
+ */
+class WebauthnCredentialVoter extends AbstractVoter
+{
+    protected function canEdit(WebauthnCredential $credential, User $user): bool
+    {
+        return $credential->getUser() === $user;
+    }
+
+    protected function canDelete(WebauthnCredential $credential, User $user): bool
+    {
+        return $this->canEdit($credential, $user);
+    }
+}

--- a/templates/ProfileManagement/manage.html.twig
+++ b/templates/ProfileManagement/manage.html.twig
@@ -208,6 +208,27 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="col-md-6">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-white">
+                                <i class="far fa-key text-primary me-2"></i>Passkeys verwalten
+                            </div>
+                            <div class="card-body d-flex flex-column">
+                                <p>
+                                    Melde dich per Fingerabdruck, Gesichtserkennung oder Geräte-PIN an, statt auf
+                                    die Mail mit dem Anmeldelink zu warten.
+                                </p>
+
+                                <div class="mt-auto text-center">
+                                    <a class="btn btn-outline-primary btn-sm"
+                                       href="{{ path('criticalmass_user_profile_passkey_list') }}">
+                                        <i class="far fa-key me-1"></i>Passkeys verwalten
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/templates/ProfileManagement/passkeys.html.twig
+++ b/templates/ProfileManagement/passkeys.html.twig
@@ -1,0 +1,131 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}Passkeys verwalten{% endblock %}
+
+{% block breadcrumb %}
+    {{ breadcrumb.item('Dein Benutzerkonto', path('criticalmass_user_usermanagement')) }}
+    {{ breadcrumb.active('Passkeys') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="row">
+            <div class="col-md-8 offset-md-2">
+                <h2>
+                    Passkeys
+                </h2>
+
+                <p class="lead">
+                    Mit einem Passkey meldest du dich per Fingerabdruck, Gesichtserkennung oder
+                    Geräte-PIN an &mdash; ohne auf die Mail mit dem Anmeldelink zu warten.
+                </p>
+
+                <p>
+                    Der Anmeldelink per E-Mail funktioniert weiterhin. Wenn du dein Gerät verlierst,
+                    kommst du also trotzdem in dein Konto.
+                </p>
+            </div>
+        </div>
+
+        {{ include('Flash/_flash.html.twig') }}
+
+        <div class="row">
+            <div class="col-md-8 offset-md-2">
+                <div class="card border-0 shadow-sm mb-4"
+                     data-controller="passkey"
+                     data-passkey-confirm-text-value="Diesen Passkey wirklich löschen?">
+                    <div class="card-header bg-white">
+                        <i class="far fa-key text-primary me-2"></i>Neuen Passkey anlegen
+                    </div>
+                    <div class="card-body">
+                        <p>
+                            Dein Gerät fragt gleich nach Fingerabdruck, Gesicht oder PIN. Anschließend
+                            kannst du den Passkey unten benennen.
+                        </p>
+
+                        <p class="text-muted small">
+                            Passkeys von criticalmass.in funktionieren auf criticalmass.in und auf
+                            criticalmass.one gleichermaßen.
+                        </p>
+
+                        <div class="alert alert-danger" data-passkey-target="status" hidden></div>
+
+                        <button type="button"
+                                class="btn btn-primary"
+                                data-action="passkey#register"
+                                data-passkey-target="submit">
+                            <i class="far fa-plus me-1"></i>Passkey anlegen
+                        </button>
+                    </div>
+                </div>
+
+                {% if credentials is empty %}
+                    <div class="alert alert-info">
+                        Du hast noch keinen Passkey angelegt.
+                    </div>
+                {% else %}
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-header bg-white">
+                            <i class="far fa-list text-secondary me-2"></i>Deine Passkeys
+                        </div>
+                        <ul class="list-group list-group-flush">
+                            {% for credential in credentials %}
+                                <li class="list-group-item"
+                                    data-controller="passkey"
+                                    data-passkey-confirm-text-value="Den Passkey „{{ credential.name }}“ wirklich löschen?">
+                                    <div class="row g-2 align-items-center">
+                                        <div class="col-md-7">
+                                            <form method="post"
+                                                  action="{{ path('criticalmass_user_profile_passkey_rename', {'id': credential.id}) }}"
+                                                  class="d-flex gap-2">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('passkey-rename-' ~ credential.id) }}">
+                                                <label class="visually-hidden" for="passkey-name-{{ credential.id }}">
+                                                    Name des Passkeys
+                                                </label>
+                                                <input type="text"
+                                                       class="form-control form-control-sm"
+                                                       id="passkey-name-{{ credential.id }}"
+                                                       name="name"
+                                                       maxlength="255"
+                                                       required
+                                                       value="{{ credential.name }}">
+                                                <button type="submit" class="btn btn-outline-secondary btn-sm text-nowrap">
+                                                    Umbenennen
+                                                </button>
+                                            </form>
+                                        </div>
+
+                                        <div class="col-md-3 small text-muted">
+                                            <div>Angelegt: {{ credential.createdAt|date('d.m.Y') }}</div>
+                                            <div>
+                                                {% if credential.lastUsedAt %}
+                                                    Zuletzt benutzt: {{ credential.lastUsedAt|date('d.m.Y') }}
+                                                {% else %}
+                                                    Noch nicht benutzt
+                                                {% endif %}
+                                            </div>
+                                        </div>
+
+                                        <div class="col-md-2 text-md-end">
+                                            <form method="post"
+                                                  action="{{ path('criticalmass_user_profile_passkey_delete', {'id': credential.id}) }}"
+                                                  data-action="submit->passkey#confirmDelete">
+                                                <input type="hidden" name="_token"
+                                                       value="{{ csrf_token('passkey-delete-' ~ credential.id) }}">
+                                                <button type="submit" class="btn btn-outline-danger btn-sm">
+                                                    <i class="far fa-trash me-1"></i>Löschen
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -5,54 +5,54 @@
 {% block content %}
     <div class="container">
         <div class="row">
-            <div class="col-md-10 col-md-offset-1">
+            <div class="col-md-10 offset-md-1">
                 <h1>Einloggen und losfahren!</h1>
 
                 <p class="lead">
-                    Du kannst dich entweder über ein gesellschaftliches Netzwerk oder über deine E-Mail-Adresse einloggen.
+                    Du kannst dich mit einem Passkey, über ein gesellschaftliches Netzwerk oder
+                    über deine E-Mail-Adresse einloggen.
                 </p>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-5 col-md-offset-1">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        Soziale Netzwerke
-                    </div>
-                    <div class="panel-body">
-                        <div class="row">
-                            <div class="col-md-12 text-center">
-                                <p>
-                                    Logge dich über eines dieser sozialen Netzwerke ein &mdash; es dauert nur einen Klick!
-                                </p>
+        {{ include('Flash/_flash.html.twig') }}
 
-                                <div class="btn-group" role="group" aria-label="...">
-                                    <a class="btn btn-secondary" style="background-color: rgb(60, 90, 150); color: white;"
-                                       href="{{ path('hwi_oauth_service_redirect', {'service': 'facebook' }) }}"
-                                       title="Sign in with Facebook">
-                                        <i class="fab fa-facebook-f" aria-hidden="true"></i>
-                                        Facebook
-                                    </a>
-                                    <a class="btn btn-secondary" style="background-color: rgb(249, 77, 31); color: white;"
-                                       href="{{ path('hwi_oauth_service_redirect', {'service': 'strava' }) }}"
-                                       title="Sign in with Strava">
-                                        <i class="fab fa-strava" aria-hidden="true"></i>
-                                        Strava
-                                    </a>
-                                </div>
-                            </div>
+        <div class="row g-3">
+            <div class="col-md-5 offset-md-1">
+                {# Blendet sich selbst aus, wenn der Browser kein WebAuthn kann. #}
+                <div class="card border-0 shadow-sm h-100"
+                     data-controller="passkey"
+                     data-passkey-conditional-value="true"
+                     data-passkey-redirect-url-value="{{ path('criticalmass_user_usermanagement') }}">
+                    <div class="card-header bg-white">
+                        <i class="far fa-key text-primary me-2"></i>Passkey
+                    </div>
+                    <div class="card-body d-flex flex-column text-center">
+                        <p>
+                            Melde dich per Fingerabdruck, Gesichtserkennung oder Geräte-PIN an &mdash;
+                            ohne auf eine Mail zu warten.
+                        </p>
+
+                        <div class="alert alert-danger text-start" data-passkey-target="status" hidden></div>
+
+                        <div class="mt-auto">
+                            <button type="button"
+                                    class="btn btn-primary"
+                                    data-action="passkey#login"
+                                    data-passkey-target="submit">
+                                <i class="far fa-key me-1"></i>Mit Passkey anmelden
+                            </button>
                         </div>
                     </div>
                 </div>
             </div>
 
             <div class="col-md-5">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        E-Mail-Adresse
+                <div class="card border-0 shadow-sm h-100">
+                    <div class="card-header bg-white">
+                        <i class="far fa-envelope text-warning me-2"></i>E-Mail-Adresse
                     </div>
-                    <div class="panel-body">
+                    <div class="card-body">
                         <p>
                             Bitte gib deine E-Mail-Adresse ein, wir senden dir einen Link zum Einloggen per Mail zu!
                         </p>
@@ -61,6 +61,34 @@
                         {{ form_row(login_form.email) }}
                         <div class="frc-captcha mb-3 mx-auto" data-sitekey="{{ app.request.server.get('FRIENDLYCAPTCHA_SITE_KEY') }}"></div>
                         {{ form_end(login_form) }}
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-10 offset-md-1">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-header bg-white">
+                        <i class="far fa-share-nodes text-secondary me-2"></i>Soziale Netzwerke
+                    </div>
+                    <div class="card-body text-center">
+                        <p>
+                            Logge dich über eines dieser sozialen Netzwerke ein &mdash; es dauert nur einen Klick!
+                        </p>
+
+                        <div class="btn-group" role="group" aria-label="Anmeldung über soziale Netzwerke">
+                            <a class="btn btn-secondary" style="background-color: rgb(60, 90, 150); color: white;"
+                               href="{{ path('hwi_oauth_service_redirect', {'service': 'facebook' }) }}"
+                               title="Sign in with Facebook">
+                                <i class="fab fa-facebook-f" aria-hidden="true"></i>
+                                Facebook
+                            </a>
+                            <a class="btn btn-secondary" style="background-color: rgb(249, 77, 31); color: white;"
+                               href="{{ path('hwi_oauth_service_redirect', {'service': 'strava' }) }}"
+                               title="Sign in with Strava">
+                                <i class="fab fa-strava" aria-hidden="true"></i>
+                                Strava
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/Security/Authorization/Voter/WebauthnCredentialVoterTest.php
+++ b/tests/Security/Authorization/Voter/WebauthnCredentialVoterTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Authorization\Voter;
+
+use App\Entity\User;
+use App\Entity\WebauthnCredential;
+use App\Security\Authorization\Voter\WebauthnCredentialVoter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\CredentialRecord;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+class WebauthnCredentialVoterTest extends TestCase
+{
+    public function testOwnerMayRenameAndDelete(): void
+    {
+        $owner = new User();
+        $credential = $this->createCredential($owner);
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $this->vote('edit', $credential, $owner));
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $this->vote('delete', $credential, $owner));
+    }
+
+    public function testStrangerMayNotTouchAForeignPasskey(): void
+    {
+        $credential = $this->createCredential(new User());
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $this->vote('edit', $credential, new User()));
+        self::assertSame(VoterInterface::ACCESS_DENIED, $this->vote('delete', $credential, new User()));
+    }
+
+    /**
+     * Anders als bei Tracks und Fotos gibt es hier keine Ausnahme für Administratoren:
+     * Wer fremde Passkeys löschen könnte, könnte Nutzer aus ihren Konten aussperren, und
+     * wer sie anlegen könnte, käme in fremde Konten hinein.
+     */
+    public function testAdministratorsHaveNoSpecialAccess(): void
+    {
+        $credential = $this->createCredential(new User());
+
+        $administrator = new User();
+        $administrator->setRoles(['ROLE_ADMIN']);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $this->vote('edit', $credential, $administrator));
+        self::assertSame(VoterInterface::ACCESS_DENIED, $this->vote('delete', $credential, $administrator));
+    }
+
+    public function testVoterAbstainsFromUnrelatedSubjects(): void
+    {
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, $this->vote('edit', new User(), new User()));
+    }
+
+    private function vote(string $attribute, object $subject, User $user): int
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->method('getUser')
+            ->willReturn($user);
+
+        return (new WebauthnCredentialVoter())->vote($token, $subject, [$attribute]);
+    }
+
+    private function createCredential(User $user): WebauthnCredential
+    {
+        $record = CredentialRecord::create(
+            'credential-id-raw',
+            'public-key',
+            ['internal'],
+            'none',
+            EmptyTrustPath::create(),
+            Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            'public-key-bytes',
+            'user-handle-uuid',
+            0,
+        );
+
+        return WebauthnCredential::createFromRecord($record, $user, 'Passkey 1');
+    }
+}


### PR DESCRIPTION
Dritter von vier PRs. Baut auf #1465 auf — **Base-Branch ist `feature/passkeys-firewall`**. Mit diesem PR sind Passkeys tatsächlich bedienbar.

## Entscheidung: eigener Stimulus-Controller statt `@simplewebauthn/browser`

Ausschlaggebend war die eingefrorene `package-lock.json`. Laut CLAUDE.md überleben `webpack` und `@babel/core` nur über den committeten Lock und sind gar keine deklarierten Dependencies — jede Neuauflösung zerlegt den Baum. Eine neue Frontend-Dependency hätte genau die erzwungen.

Dazu kommt, dass der Hauptwert der Bibliothek — die Umrechnung zwischen base64url und ArrayBuffer — inzwischen von den Browsern selbst kommt, über `parseCreationOptionsFromJSON()`, `parseRequestOptionsFromJSON()` und `toJSON()`. Was bleibt, sind rund 250 Zeilen inklusive Fallback für ältere Browser.

## Summary

- **`assets/controllers/passkey_controller.js`** — anlegen, anmelden, Conditional UI, Löschbestätigung. Blendet sich selbst aus, wenn der Browser kein WebAuthn kann.
- **Conditional UI** über `autocomplete="username webauthn"` am vorhandenen E-Mail-Feld: Der Browser bietet den Passkey direkt im Autofill an, die Seite sieht für alle anderen unverändert aus. Nur auf der Login-Seite eingeschaltet (`data-passkey-conditional-value`), in der Kontoverwaltung wäre eine Anmelde-Ceremony sinnlos — und zwei gleichzeitige Ceremonies verträgt der Browser ohnehin nicht, deshalb bricht `register()` die laufende Conditional UI vorher ab.
- **`/profile/passkeys`** mit Liste, Umbenennen und Löschen, dazu eine Karte in der Kontoübersicht.
- **Login-Template** von Bootstrap-3-Resten (`panel`, `col-md-offset-1`) auf Bootstrap 5 gezogen, wie im Plan angekündigt.

## Zwei Entwurfsentscheidungen

**Der Name läuft nicht durch die Registrierung.** Den Registrierungs-Endpunkt stellt das Bundle; ein zusätzliches Feld im Request-Body erreicht `saveCredentialRecord()` nie. Die Alternativen — den Namen über die Session schmuggeln oder nachträglich über ein „zuletzt angelegtes Credential" zuordnen — wären beide fragil. Deshalb vergibt das Repository `Passkey 1`, `Passkey 2`, … und die Liste bietet Umbenennen direkt daneben an.

**Voter statt Prüfung im Controller.** `WebauthnCredentialVoter` folgt dem vorhandenen Muster (`TrackVoter`, `PhotoVoter`) und ist ohne Kernel testbar. Bewusst **ohne** deren `ROLE_ADMIN`-Ausnahme: Wer fremde Passkeys löschen könnte, könnte Nutzer aus ihren Konten aussperren; wer sie anlegen könnte, käme in fremde Konten hinein. Administration hat an Anmeldedaten nichts zu suchen. Ein Test hält das fest.

Umbenennen und Löschen sind zusätzlich CSRF-token-geschützt. Die Löschbestätigung hängt als Stimulus-Action am Formular statt als Inline-`onclick`, weil die CSP `script-src` bewusst ohne `unsafe-inline` fährt.

## Test Plan

- [x] Webpack-Build läuft durch, der Controller landet in `app.js` (`isConditionalMediationAvailable` im Bundle nachweisbar), keine Warnung mit Passkey-Bezug
- [x] `lint:twig` über die geänderten Templates OK
- [x] Alle drei Verwaltungsrouten registriert
- [x] `lint:container` in dev **und** prod OK
- [x] PHPStan Level 6 über das gesamte Projekt ohne Fehler
- [x] 37 Unit-Tests grün, davon 4 neue für den Voter

Weiterhin keine funktionalen Tests, weil sich die Testumgebung die `DATABASE_URL` mit der Entwicklungsdatenbank teilt.

**Im Browser noch nicht durchgespielt** — dafür braucht es einen Secure Context und eine bespielte Datenbank. Das ist der Punkt, den ich vor dem Merge gern von dir bestätigt hätte: einmal Passkey anlegen, abmelden, per Passkey anmelden, umbenennen, löschen.

## Am Rande

Der aktive Node im PATH ist v12.22.7 und zu alt für die Toolchain (`encore` bricht mit `SyntaxError: Unexpected token '?'` ab). Gebaut habe ich mit v20.18.1 aus nvm. Betrifft nur die lokale Umgebung, CI baut die Assets ohnehin nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)