### PR TITLE
Passkeys: Discovery-Endpunkt und Hinweis im Konto (4/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,12 @@ entstehen dabei implizit in `LoginController::createNewUser()`, einen `/register
 gibt es nicht), über **OAuth** (Facebook/Strava, HWIOAuthBundle) oder über einen
 **Passkey**.
 
+**Der Anmeldelink per Mail bleibt für jedes Konto verfügbar.** Passkeys kommen additiv
+dazu, sie ersetzen den Rückfallweg nicht — ein Opt-out („Konten mit genug Passkeys dürfen
+den Mail-Login abschalten") ist ausdrücklich **nicht** gewollt und soll auch nicht
+vorgeschlagen werden. Die bewusst akzeptierte Folge: Die Sicherheitsuntergrenze eines
+Kontos ist dauerhaft die Mailbox. Der Gegenwert ist, dass niemand sich aussperren kann.
+
 **Passkeys (WebAuthn)** laufen über `web-auth/webauthn-symfony-bundle`. Was daran nicht
 selbsterklärend ist:
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -67,6 +67,9 @@ security:
         # mit RP ID criticalmass.one auf criticalmass.in zulässt.
         - { path: '^/\.well-known/webauthn$', role: PUBLIC_ACCESS }
 
+        # Verweist Passwortmanager auf die Passkey-Verwaltung im Konto.
+        - { path: '^/\.well-known/passkey-endpoints$', role: PUBLIC_ACCESS }
+
         # Anmelden per Passkey muss anonym möglich sein.
         - { path: ^/passkey/login, role: PUBLIC_ACCESS }
         # Einen Passkey anlegen dagegen nie: wer hier durchkäme, könnte sich einen

--- a/config/packages/webauthn.yaml
+++ b/config/packages/webauthn.yaml
@@ -24,3 +24,13 @@ webauthn:
         default:
             rp_id: 'localhost'
             user_verification: preferred
+
+    # /.well-known/passkey-endpoints nach der W3C-Passkey-Endpoints-Spezifikation. Sagt
+    # Passwortmanagern und Betriebssystemen, wo man bei uns einen Passkey anlegt und
+    # verwaltet, damit sie direkt dorthin verlinken können. Der Routenname wird zur
+    # Laufzeit über den Router zu einer absoluten URL aufgelöst — je nach angefragter
+    # Domain also criticalmass.in oder criticalmass.one.
+    passkey_endpoints:
+        enabled: true
+        enroll: 'criticalmass_user_profile_passkey_list'
+        manage: 'criticalmass_user_profile_passkey_list'

--- a/config/packages/webauthn.yaml
+++ b/config/packages/webauthn.yaml
@@ -20,6 +20,15 @@ webauthn:
                 resident_key: required
                 require_resident_key: true
 
+            # Ohne diese Liste schickt das Bundle ein leeres `pubKeyCredParams`, und der
+            # Browser fällt auf seine Vorgabe ES256/RS256 zurück. Verifizieren kann das
+            # Bundle deutlich mehr, also sagen wir es lieber selbst — absteigend nach
+            # Präferenz. COSE-Kennungen: EdDSA, ES256, RS256.
+            public_key_credential_parameters:
+                - -8
+                - -7
+                - -257
+
     request_profiles:
         default:
             rp_id: 'localhost'

--- a/src/Controller/Profile/ProfileManagementController.php
+++ b/src/Controller/Profile/ProfileManagementController.php
@@ -6,8 +6,10 @@ use App\Controller\AbstractController;
 use App\Entity\Participation;
 use App\Entity\Photo;
 use App\Entity\Track;
+use App\Entity\User;
 use App\Form\Type\UserEmailType;
 use App\Form\Type\UsernameType;
+use App\Repository\WebauthnCredentialRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Component\Form\FormError;
@@ -30,8 +32,10 @@ class ProfileManagementController extends AbstractController
         name: 'fos_user_profile_show',
         priority: 180
     )]
-    public function manageAction(?UserInterface $user = null): Response
-    {
+    public function manageAction(
+        WebauthnCredentialRepository $credentialRepository,
+        ?UserInterface $user = null
+    ): Response {
         $participationCounter = $this->managerRegistry->getRepository(Participation::class)->countByUser($user);
         $trackCounter = $this->managerRegistry->getRepository(Track::class)->countByUser($user);
         $photoCounter = $this->managerRegistry->getRepository(Photo::class)->countByUser($user);
@@ -40,6 +44,7 @@ class ProfileManagementController extends AbstractController
             'participationCounter' => $participationCounter,
             'trackCounter' => $trackCounter,
             'photoCounter' => $photoCounter,
+            'passkeyCounter' => $user instanceof User ? $credentialRepository->countForUser($user) : 0,
         ]);
     }
 

--- a/templates/ProfileManagement/manage.html.twig
+++ b/templates/ProfileManagement/manage.html.twig
@@ -33,6 +33,25 @@
             </div>
         {% endfor %}
 
+        {% if passkeyCounter == 0 %}
+            <div class="row">
+                <div class="col-md-10 offset-md-1">
+                    <div class="alert alert-info d-md-flex align-items-center gap-3" role="alert">
+                        <div>
+                            <i class="far fa-key me-2"></i>Mit einem Passkey meldest du dich per Fingerabdruck,
+                            Gesichtserkennung oder Geräte-PIN an, statt auf die Mail mit dem Anmeldelink zu warten.
+                            Der Anmeldelink funktioniert weiterhin.
+                        </div>
+
+                        <a class="btn btn-primary btn-sm text-nowrap ms-md-auto"
+                           href="{{ path('criticalmass_user_profile_passkey_list') }}">
+                            Passkey einrichten
+                        </a>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
         <div class="row">
             <div class="col-md-10 offset-md-1">
                 <div class="row g-3">


### PR DESCRIPTION
Vierter und letzter PR. Baut auf #1466 auf — **Base-Branch ist `feature/passkeys-ui`**.

## Summary

- **`/.well-known/passkey-endpoints`** nach der [W3C-Passkey-Endpoints-Spezifikation](https://w3c.github.io/webappsec-passkey-endpoints/). Passwortmanager und Betriebssysteme finden darüber, wo man bei uns einen Passkey anlegt und verwaltet, und können direkt dorthin verlinken. Der Routenname wird zur Laufzeit über den Router zu einer absoluten URL aufgelöst.
- **Hinweis in der Kontoübersicht**, solange das Konto keinen Passkey hat, mit Verweis auf die Einrichtung.
- **In der `CLAUDE.md` festgehalten:** Der Anmeldelink per Mail bleibt für jedes Konto verfügbar.

Verifizierte Ausgabe (lokal, deshalb 127.0.0.1):

```json
{"enroll":"http://127.0.0.1:8123/profile/passkeys","manage":"http://127.0.0.1:8123/profile/passkeys","prfUsageDetails":null}
```

## Der Mail-Login bleibt, für alle

Der ursprüngliche Plan führte als möglichen vierten Punkt auf, dass Konten mit mehreren Passkeys den Anmeldelink deaktivieren dürfen. **Das ist verworfen** — Passkeys kommen additiv dazu und ersetzen den Rückfallweg nicht.

Damit ist die Sicherheitsuntergrenze eines Kontos dauerhaft die Mailbox; Passkeys sind hier ein UX- und Phishing-Gewinn, kein Ersatz. Der Gegenwert ist, dass niemand sich aussperren kann. Die Vorgabe steht jetzt in der `CLAUDE.md`, damit sie nicht später versehentlich als Sicherheitsverbesserung zurückkommt.

Am Code war dafür nichts zu ändern: Der Mail-Login ist in allen vier PRs unangetastet.

## Warum der Hinweis nicht nach dem Login kommt

Im Plan stand „Onboarding-Hinweis nach erfolgreichem Magic-Link-Login". Das habe ich zuerst als `LoginSuccessEvent`-Subscriber mit Flash-Nachricht gebaut und wieder verworfen: **Flash-Nachrichten werden hier nicht global gerendert**, sondern von jedem Template einzeln über `Flash/_flash.html.twig` eingebunden — und die Startseite, auf der man nach dem Login landet, tut das nicht. Der Flash bliebe im Bag liegen und tauchte später zufällig auf irgendeiner Stadtseite auf.

Es sauber zu machen hieße, dem Layout einen globalen Banner-Bereich zu geben. Das ist eine Layout-Entscheidung, die über diesen PR hinausgeht. Die Kontoübersicht ist ohnehin der Ort, an dem man handelt, und sie lädt bereits Zähler über Repositories — ein weiterer `countForUser()` passt dort ins Bild.

## Test Plan

- [x] `/.well-known/passkey-endpoints` liefert die erwartete JSON-Struktur mit absoluten URLs (lokaler Server, echter HTTP-Aufruf)
- [x] Beide `.well-known`-Routen in prod registriert; `/.well-known/webauthn` fehlt in dev korrekt, weil die Origin-Liste dort leer ist
- [x] `lint:twig` und `lint:container` in dev **und** prod OK
- [x] PHPStan Level 6 über das gesamte Projekt ohne Fehler
- [x] 37 Unit-Tests grün

**Vor dem Merge des Stacks noch offen:** Die Passkey-Anmeldung ist bisher in keinem Browser gelaufen — dafür braucht es einen Secure Context und eine bespielte Datenbank. Einmal anlegen, abmelden, per Passkey anmelden, umbenennen, löschen wäre die Bestätigung, die noch fehlt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)