### PR TITLE
Add 237 unit tests for resolvers, voters, router, commands, forms

### DIFF
--- a/tests/Command/Cycles/ListCyclesCommandTest.php
+++ b/tests/Command/Cycles/ListCyclesCommandTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\Cycles;
+
+use App\Command\Cycles\ListCyclesCommand;
+use App\Entity\City;
+use App\Entity\CityCycle;
+use App\Entity\CitySlug;
+use App\Repository\CityCycleRepository;
+use App\Repository\CitySlugRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\Support\EntityIdHelper;
+
+final class ListCyclesCommandTest extends TestCase
+{
+    private City $city;
+
+    /**
+     * @param list<CityCycle> $cycles
+     */
+    private function tester(array $cycles, ?string $knownSlug = 'hamburg'): CommandTester
+    {
+        $this->city = (new City())->setCity('Hamburg');
+        $citySlug = (new CitySlug())->setSlug('hamburg')->setCity($this->city);
+
+        $citySlugRepository = $this->createMock(CitySlugRepository::class);
+        $citySlugRepository->method('__call')->willReturnCallback(
+            static fn (string $method, array $arguments): ?CitySlug => $arguments[0] === $knownSlug ? $citySlug : null
+        );
+
+        $cycleRepository = $this->createMock(CityCycleRepository::class);
+        $cycleRepository->method('findByCity')->with($this->city)->willReturn($cycles);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturnMap([
+            [CitySlug::class, null, $citySlugRepository],
+            [CityCycle::class, null, $cycleRepository],
+        ]);
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => '[' . $id . ']');
+
+        $application = new Application();
+        $application->addCommand(new ListCyclesCommand($registry, $translator));
+
+        return new CommandTester($application->find('criticalmass:cycles:list'));
+    }
+
+    #[Test]
+    public function rendersOneTableRowPerCycle(): void
+    {
+        $cycle = (new CityCycle())
+            ->setLocation('Rathausmarkt')
+            ->setLatitude(53.55)
+            ->setLongitude(9.99)
+            ->setDayOfWeek(5)
+            ->setWeekOfMonth(0)
+            ->setTime(new \DateTime('17:00'))
+            ->setValidFrom(new \DateTime('2020-01-01'))
+            ->setValidUntil(new \DateTime('2030-12-31'));
+        EntityIdHelper::setId($cycle, 42);
+
+        $tester = $this->tester([$cycle]);
+        $tester->execute(['citySlug' => 'hamburg']);
+
+        $display = $tester->getDisplay();
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('42', $display);
+        self::assertStringContainsString('Rathausmarkt (53.550000, 9.990000)', $display);
+        self::assertStringContainsString('[cycle.event_date.day.5]', $display);
+        self::assertStringContainsString('[cycle.event_date.month_week.0]', $display);
+        self::assertStringContainsString('17:00', $display);
+        self::assertStringContainsString('2020-01-01', $display);
+        self::assertStringContainsString('2030-12-31', $display);
+    }
+
+    #[Test]
+    public function missingOptionalValuesRenderAsEmptyCells(): void
+    {
+        $cycle = (new CityCycle())->setDayOfWeek(1)->setWeekOfMonth(1);
+        EntityIdHelper::setId($cycle, 7);
+
+        $tester = $this->tester([$cycle]);
+        $tester->execute(['citySlug' => 'hamburg']);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('| 7 ', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function cityWithoutCyclesRendersOnlyTheHeader(): void
+    {
+        $tester = $this->tester([]);
+        $tester->execute(['citySlug' => 'hamburg']);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('Valid until', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function unknownSlugIsReportedGracefully(): void
+    {
+        $tester = $this->tester([], null);
+
+        try {
+            $tester->execute(['citySlug' => 'atlantis']);
+        } catch (\Error $error) {
+            self::markTestIncomplete(
+                'ListCyclesCommand prints "No city found" but does not return, then calls getCity() on null: '
+                .$error->getMessage()
+            );
+        }
+
+        self::assertStringContainsString('No city found with slug "atlantis"', $tester->getDisplay());
+    }
+}

--- a/tests/Command/DuplicateRides/ListDuplicateRidesCommandTest.php
+++ b/tests/Command/DuplicateRides/ListDuplicateRidesCommandTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\DuplicateRides;
+
+use App\Command\DuplicateRides\ListDuplicateRidesCommand;
+use App\Criticalmass\RideDuplicates\DuplicateFinder\DuplicateFinderInterface;
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Repository\CitySlugRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\Support\EntityIdHelper;
+
+final class ListDuplicateRidesCommandTest extends TestCase
+{
+    private MockObject&DuplicateFinderInterface $finder;
+    private City $city;
+
+    private function tester(): CommandTester
+    {
+        $this->city = (new City())->setId(1)->setCity('Hamburg');
+        $citySlug = (new CitySlug())->setSlug('hamburg')->setCity($this->city);
+
+        $citySlugRepository = $this->createMock(CitySlugRepository::class);
+        $citySlugRepository->method('__call')->willReturnCallback(
+            static fn (string $method, array $arguments): ?CitySlug => 'hamburg' === $arguments[0] ? $citySlug : null
+        );
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(CitySlug::class)->willReturn($citySlugRepository);
+
+        $this->finder = $this->createMock(DuplicateFinderInterface::class);
+
+        $application = new Application();
+        $application->addCommand(new ListDuplicateRidesCommand($registry, $this->finder));
+
+        return new CommandTester($application->find('criticalmass:ride-duplicates:list'));
+    }
+
+    private function ride(int $id, string $dateTime, ?string $slug = null): Ride
+    {
+        $ride = (new Ride())
+            ->setCity($this->city)
+            ->setDateTime(new \DateTime($dateTime))
+            ->setSlug($slug)
+            ->setLocation('Rathausmarkt')
+            ->setDescription(str_repeat('x', 40));
+        $ride->setLatitude(53.55);
+        $ride->setLongitude(9.99);
+        EntityIdHelper::setId($ride, $id);
+
+        return $ride;
+    }
+
+    #[Test]
+    public function printsATablePerDuplicateGroup(): void
+    {
+        $tester = $this->tester();
+
+        $this->finder->expects(self::never())->method('setCity');
+        $this->finder->method('findDuplicates')->willReturn([
+            '1-2024-05-31' => [
+                10 => $this->ride(10, '2024-05-31 19:00:00'),
+                11 => $this->ride(11, '2024-05-31 19:30:00', 'second'),
+            ],
+        ]);
+
+        $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('Duplicates found for Hamburg in 2024-05-31', $display);
+        self::assertStringContainsString('2024-05-31 19:00:00', $display);
+        self::assertStringContainsString('2024-05-31 19:30:00', $display);
+        self::assertStringContainsString('second', $display);
+        self::assertStringContainsString('Rathausmarkt (53.550000, 9.990000)', $display);
+        // Description is truncated to 32 characters.
+        self::assertStringContainsString(str_repeat('x', 32), $display);
+        self::assertStringNotContainsString(str_repeat('x', 33), $display);
+    }
+
+    #[Test]
+    public function citySlugRestrictsTheFinderToThatCity(): void
+    {
+        $tester = $this->tester();
+
+        $this->finder->expects(self::once())->method('setCity')->with($this->city)->willReturnSelf();
+        $this->finder->method('findDuplicates')->willReturn([]);
+
+        $tester->execute(['citySlug' => 'hamburg']);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertSame('', trim($tester->getDisplay()));
+    }
+
+    #[Test]
+    public function unknownSlugIsReportedGracefully(): void
+    {
+        $tester = $this->tester();
+        $this->finder->method('findDuplicates')->willReturn([]);
+
+        try {
+            $tester->execute(['citySlug' => 'atlantis']);
+        } catch (\Error $error) {
+            self::markTestIncomplete(
+                'ListDuplicateRidesCommand prints "No city found" but does not return, then calls getCity() on null: '
+                .$error->getMessage()
+            );
+        }
+
+        self::assertStringContainsString('No city found with slug "atlantis"', $tester->getDisplay());
+    }
+}

--- a/tests/Command/Photo/PhotoTimeshiftCommandTest.php
+++ b/tests/Command/Photo/PhotoTimeshiftCommandTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\Photo;
+
+use App\Command\Photo\PhotoTimeshiftCommand;
+use App\Entity\Photo;
+use App\Entity\Ride;
+use App\Entity\User;
+use App\Event\Photo\PhotoUpdatedEvent;
+use App\Repository\PhotoRepository;
+use App\Repository\RideRepository;
+use App\Repository\UserRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Tests\Support\EntityIdHelper;
+
+final class PhotoTimeshiftCommandTest extends TestCase
+{
+    private MockObject&RideRepository $rideRepository;
+    private MockObject&EventDispatcherInterface $dispatcher;
+    private MockObject&ObjectManager $manager;
+    /** @var list<Photo> */
+    private array $photos = [];
+    private CommandTester $tester;
+    private Ride $ride;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $this->ride = new Ride();
+        $this->user = new User();
+
+        foreach (['2024-05-31 19:00:00', '2024-05-31 20:30:00'] as $i => $exifDate) {
+            $photo = (new Photo())->setExifCreationDate(new \DateTime($exifDate));
+            $photo->setLatitude(53.5);
+            $photo->setLongitude(9.9);
+            EntityIdHelper::setId($photo, $i + 1);
+            $this->photos[] = $photo;
+        }
+
+        $this->rideRepository = $this->createMock(RideRepository::class);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('__call')->willReturnCallback(
+            fn (string $method, array $arguments): ?User => 'findOneByUsername' === $method && 'malte' === $arguments[0] ? $this->user : null
+        );
+
+        $photoRepository = $this->createMock(PhotoRepository::class);
+        $photoRepository->method('findPhotosByUserAndRide')->with($this->user, $this->ride)->willReturn($this->photos);
+
+        $this->manager = $this->createMock(ObjectManager::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturnMap([
+            [Ride::class, null, $this->rideRepository],
+            [User::class, null, $userRepository],
+            [Photo::class, null, $photoRepository],
+        ]);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $application = new Application();
+        $application->addCommand(new PhotoTimeshiftCommand($registry, $this->dispatcher));
+
+        $this->tester = new CommandTester($application->find('criticalmass:photos:timeshift'));
+    }
+
+    #[Test]
+    public function shiftsExifDatesForwardByDefault(): void
+    {
+        $this->rideRepository->method('findByCitySlugAndRideDate')->with('hamburg', '2024-05-31')->willReturn($this->ride);
+        $this->dispatcher->expects(self::exactly(2))
+            ->method('dispatch')
+            ->with(self::isInstanceOf(PhotoUpdatedEvent::class), PhotoUpdatedEvent::NAME)
+            ->willReturnArgument(0);
+        $this->manager->expects(self::once())->method('flush');
+
+        $this->tester->execute([
+            'citySlug' => 'hamburg',
+            'rideIdentifier' => '2024-05-31',
+            'username' => 'malte',
+            'dateInterval' => 'PT2H',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertSame('2024-05-31 21:00:00', $this->photos[0]->getExifCreationDate()->format('Y-m-d H:i:s'));
+        self::assertSame('2024-05-31 22:30:00', $this->photos[1]->getExifCreationDate()->format('Y-m-d H:i:s'));
+        self::assertStringContainsString('2024-05-31 21:00:00', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function subDirectionShiftsBackwards(): void
+    {
+        $this->rideRepository->method('findByCitySlugAndRideDate')->willReturn($this->ride);
+        $this->dispatcher->method('dispatch')->willReturnArgument(0);
+
+        $this->tester->execute([
+            'citySlug' => 'hamburg',
+            'rideIdentifier' => '2024-05-31',
+            'username' => 'malte',
+            'dateInterval' => 'P1D',
+            'direction' => 'sub',
+        ]);
+
+        self::assertSame('2024-05-30 19:00:00', $this->photos[0]->getExifCreationDate()->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
+    public function fallsBackToRideSlugWhenIdentifierIsNoDate(): void
+    {
+        $this->rideRepository->method('findByCitySlugAndRideDate')->willReturn(null);
+        $this->rideRepository->expects(self::once())->method('findOneByCitySlugAndSlug')->with('hamburg', 'kidical-mass')->willReturn($this->ride);
+        $this->dispatcher->method('dispatch')->willReturnArgument(0);
+
+        $this->tester->execute([
+            'citySlug' => 'hamburg',
+            'rideIdentifier' => 'kidical-mass',
+            'username' => 'malte',
+            'dateInterval' => 'PT30M',
+        ]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertSame('2024-05-31 19:30:00', $this->photos[0]->getExifCreationDate()->format('Y-m-d H:i:s'));
+    }
+}

--- a/tests/Command/Statistic/CalculateRideEstimatesCommandTest.php
+++ b/tests/Command/Statistic/CalculateRideEstimatesCommandTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\Statistic;
+
+use App\Command\Statistic\CalculateRideEstimatesCommand;
+use App\Criticalmass\Statistic\RideEstimateHandler\RideEstimateHandlerInterface;
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class CalculateRideEstimatesCommandTest extends TestCase
+{
+    #[Test]
+    public function recalculatesEveryRideWithoutIntermediateFlushes(): void
+    {
+        $city = (new City())->setCity('Hamburg');
+        $rides = [
+            (new Ride())->setCity($city)->setDateTime(new \DateTime('2024-05-31 19:00:00'))->setEstimatedParticipants(120),
+            (new Ride())->setCity($city)->setDateTime(new \DateTime('2024-06-28 19:00:00'))->setEstimatedParticipants(80),
+        ];
+
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('findAll')->willReturn($rides);
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Ride::class)->willReturn($repository);
+        $registry->method('getManager')->willReturn($manager);
+
+        $handledRides = [];
+        $handler = $this->createMock(RideEstimateHandlerInterface::class);
+        $handler->method('setRide')->willReturnCallback(function (Ride $ride) use (&$handledRides, $handler): RideEstimateHandlerInterface {
+            $handledRides[] = $ride;
+
+            return $handler;
+        });
+        $handler->expects(self::exactly(2))->method('flushEstimates')->with(false)->willReturnSelf();
+        $handler->expects(self::exactly(2))->method('calculateEstimates')->with(false)->willReturnSelf();
+
+        $application = new Application();
+        $application->addCommand(new CalculateRideEstimatesCommand($handler, $registry));
+        $tester = new CommandTester($application->find('criticalmass:rideestimate:recalculate'));
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertSame($rides, $handledRides);
+        self::assertStringContainsString('2024-05-31 19:00', $tester->getDisplay());
+        self::assertStringContainsString('120', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function noRidesStillFlushesAndSucceeds(): void
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('findAll')->willReturn([]);
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturn($repository);
+        $registry->method('getManager')->willReturn($manager);
+
+        $handler = $this->createMock(RideEstimateHandlerInterface::class);
+        $handler->expects(self::never())->method('setRide');
+
+        $application = new Application();
+        $application->addCommand(new CalculateRideEstimatesCommand($handler, $registry));
+        $tester = new CommandTester($application->find('criticalmass:rideestimate:recalculate'));
+
+        $tester->execute([]);
+
+        self::assertSame(0, $tester->getStatusCode());
+    }
+}

--- a/tests/Command/Track/TrackGeneratePolylinesCommandTest.php
+++ b/tests/Command/Track/TrackGeneratePolylinesCommandTest.php
@@ -1,0 +1,166 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\Track;
+
+use App\Command\Track\TrackGeneratePolylinesCommand;
+use App\Criticalmass\Geo\GpxService\GpxServiceInterface;
+use App\Entity\Track;
+use App\Entity\TrackPolyline;
+use App\Enum\PolylineResolution;
+use App\Repository\TrackRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Tests\Support\EntityIdHelper;
+
+final class TrackGeneratePolylinesCommandTest extends TestCase
+{
+    private MockObject&TrackRepository $repository;
+    private MockObject&GpxServiceInterface $gpxService;
+    private MockObject&ObjectManager $manager;
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(TrackRepository::class);
+        $this->gpxService = $this->createMock(GpxServiceInterface::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Track::class)->willReturn($this->repository);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        $application = new Application();
+        $application->addCommand(new TrackGeneratePolylinesCommand($registry, $this->gpxService));
+
+        $this->tester = new CommandTester($application->find('criticalmass:track:generate-polylines'));
+    }
+
+    private function track(int $id, ?string $filename = 'tracks/ride.gpx'): Track
+    {
+        $track = new Track();
+        $track->setTrackFilename($filename);
+        EntityIdHelper::setId($track, $id);
+
+        return $track;
+    }
+
+    #[Test]
+    public function requiresEitherAllOrTrackId(): void
+    {
+        $this->tester->execute([]);
+
+        self::assertSame(1, $this->tester->getStatusCode());
+        self::assertStringContainsString('Please specify --all or --track-id=N', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function unknownTrackIdFails(): void
+    {
+        $this->repository->method('find')->with('999')->willReturn(null);
+
+        $this->tester->execute(['--track-id' => '999']);
+
+        self::assertSame(1, $this->tester->getStatusCode());
+        self::assertStringContainsString('Track #999 not found', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function generatesOnePolylinePerResolution(): void
+    {
+        $track = $this->track(5);
+        $this->repository->method('find')->willReturn($track);
+
+        // An empty polyline decodes to zero points without touching the (deprecated) decoder internals.
+        $this->gpxService->expects(self::exactly(count(PolylineResolution::cases())))
+            ->method('generatePolylineAtResolution')
+            ->with($track, self::isInstanceOf(PolylineResolution::class))
+            ->willReturn('');
+        $this->manager->expects(self::atLeastOnce())->method('flush');
+
+        $this->tester->execute(['--track-id' => '5']);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertCount(3, $track->getTrackPolylines());
+
+        $resolutions = array_map(
+            static fn (TrackPolyline $polyline): PolylineResolution => $polyline->getResolution(),
+            $track->getTrackPolylines()->toArray()
+        );
+        self::assertEqualsCanonicalizing(PolylineResolution::cases(), $resolutions);
+        self::assertStringContainsString('Processed 1 tracks, skipped 0 tracks', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function tracksWithoutGpxFileAreSkipped(): void
+    {
+        $this->repository->method('findAll')->willReturn([$this->track(1, null)]);
+        $this->gpxService->expects(self::never())->method('generatePolylineAtResolution');
+
+        $this->tester->execute(['--all' => true]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('No GPX file, skipping', $this->tester->getDisplay());
+        self::assertStringContainsString('Processed 0 tracks, skipped 1 tracks', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function existingPolylinesAreKeptUnlessForced(): void
+    {
+        $track = $this->track(2);
+        $existing = (new TrackPolyline())->setResolution(PolylineResolution::COARSE)->setPolyline('abc')->setNumPoints(1);
+        $track->addTrackPolyline($existing);
+
+        $this->repository->method('findAll')->willReturn([$track]);
+        $this->gpxService->expects(self::never())->method('generatePolylineAtResolution');
+
+        $this->tester->execute(['--all' => true]);
+
+        self::assertStringContainsString('Already has polylines, skipping', $this->tester->getDisplay());
+        self::assertSame([$existing], $track->getTrackPolylines()->toArray());
+    }
+
+    #[Test]
+    public function forceRegeneratesExistingPolylines(): void
+    {
+        $track = $this->track(2);
+        $track->addTrackPolyline((new TrackPolyline())->setResolution(PolylineResolution::COARSE)->setPolyline('abc')->setNumPoints(1));
+
+        $this->repository->method('findAll')->willReturn([$track]);
+        $this->gpxService->method('generatePolylineAtResolution')->willReturn('');
+
+        $this->tester->execute(['--all' => true, '--force' => true]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertCount(3, $track->getTrackPolylines());
+        self::assertStringContainsString('Processed 1 tracks, skipped 0 tracks', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function generatorErrorsAreReportedPerTrackAndDoNotAbort(): void
+    {
+        $broken = $this->track(1);
+        $fine = $this->track(2);
+
+        $this->repository->method('findAll')->willReturn([$broken, $fine]);
+        $this->gpxService->method('generatePolylineAtResolution')->willReturnCallback(
+            static function (Track $track): string {
+                if (1 === $track->getId()) {
+                    throw new \RuntimeException('corrupt gpx');
+                }
+
+                return '';
+            }
+        );
+
+        $this->tester->execute(['--all' => true]);
+
+        self::assertSame(0, $this->tester->getStatusCode());
+        self::assertStringContainsString('Error: corrupt gpx', $this->tester->getDisplay());
+        self::assertStringContainsString('Processed 1 tracks, skipped 1 tracks', $this->tester->getDisplay());
+    }
+}

--- a/tests/Criticalmass/Calendar/RideEventTest.php
+++ b/tests/Criticalmass/Calendar/RideEventTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Calendar;
+
+use App\Criticalmass\Calendar\Event\RideEvent;
+use App\Criticalmass\Calendar\EventProvider\RideProvider;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use CalendR\Event\EventInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class RideEventTest extends TestCase
+{
+    private function ride(int $id, string $dateTime = '2024-05-31 19:00:00'): Ride
+    {
+        $ride = (new Ride())->setDateTime(new \DateTime($dateTime));
+        EntityIdHelper::setId($ride, $id);
+
+        return $ride;
+    }
+
+    #[Test]
+    public function eventIsAPointInTimeAtTheRideStart(): void
+    {
+        $ride = $this->ride(5);
+        $event = new RideEvent($ride);
+
+        self::assertSame($ride, $event->getRide());
+        self::assertSame('ride-5', $event->getUid());
+        self::assertEquals(new \DateTime('2024-05-31 19:00:00'), $event->getBegin());
+        self::assertEquals($event->getBegin(), $event->getEnd());
+    }
+
+    #[Test]
+    public function eventsAreEqualWhenRideAndTimesMatch(): void
+    {
+        $a = new RideEvent($this->ride(5));
+        $b = new RideEvent($this->ride(5));
+
+        self::assertTrue($a->isEqualTo($b));
+    }
+
+    #[Test]
+    public function eventsOfDifferentRidesOrTimesAreNotEqual(): void
+    {
+        $a = new RideEvent($this->ride(5));
+
+        self::assertFalse($a->isEqualTo(new RideEvent($this->ride(6))));
+        self::assertFalse($a->isEqualTo(new RideEvent($this->ride(5, '2024-06-28 19:00:00'))));
+        self::assertFalse($a->isEqualTo($this->createMock(EventInterface::class)));
+    }
+
+    #[Test]
+    public function providerWrapsEveryRideInTheIntervalIntoAnEvent(): void
+    {
+        $begin = new \DateTimeImmutable('2024-05-01');
+        $end = new \DateTimeImmutable('2024-05-31');
+        $rides = [$this->ride(1), $this->ride(2)];
+
+        $repository = $this->createMock(RideRepository::class);
+        $repository->expects(self::once())->method('findRides')->with($begin, $end)->willReturn($rides);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Ride::class)->willReturn($repository);
+
+        $events = (new RideProvider($registry))->getEvents($begin, $end);
+
+        self::assertCount(2, $events);
+        self::assertContainsOnlyInstancesOf(RideEvent::class, $events);
+        self::assertSame(['ride-1', 'ride-2'], array_map(static fn (RideEvent $e): string => $e->getUid(), $events));
+    }
+}

--- a/tests/Criticalmass/MassTrackImport/TrackDecider/RideResultTest.php
+++ b/tests/Criticalmass/MassTrackImport/TrackDecider/RideResultTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\MassTrackImport\TrackDecider;
+
+use App\Criticalmass\MassTrackImport\TrackDecider\RideResult;
+use App\Criticalmass\MassTrackImport\Voter\DurationVoter;
+use App\Criticalmass\MassTrackImport\Voter\NameVoter;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RideResultTest extends TestCase
+{
+    #[Test]
+    public function voterResultsAreKeyedByVoterShortName(): void
+    {
+        $result = new RideResult(new Ride(), new TrackImportCandidate());
+
+        $result
+            ->addVoterResult(new NameVoter(), 0.8)
+            ->addVoterResult(new DurationVoter(), 0.5);
+
+        self::assertSame(['NameVoter' => 0.8, 'DurationVoter' => 0.5], $result->getVoterResults());
+    }
+
+    #[Test]
+    public function addingTheSameVoterTwiceOverwritesItsResult(): void
+    {
+        $result = new RideResult(new Ride(), new TrackImportCandidate());
+
+        $result
+            ->addVoterResult(new NameVoter(), 0.8)
+            ->addVoterResult(new NameVoter(), 0.1);
+
+        self::assertSame(['NameVoter' => 0.1], $result->getVoterResults());
+    }
+
+    #[Test]
+    public function isNotAMatchUntilMarked(): void
+    {
+        $ride = new Ride();
+        $candidate = new TrackImportCandidate();
+        $result = new RideResult($ride, $candidate);
+
+        self::assertFalse($result->isMatch());
+        self::assertSame($ride, $result->getRide());
+        self::assertSame($candidate, $result->getActivity());
+
+        $result->setMatch(true)->setResult(0.9);
+
+        self::assertTrue($result->isMatch());
+        self::assertSame(0.9, $result->getResult());
+    }
+}

--- a/tests/Criticalmass/MassTrackImport/Voter/DateTimeVoterTest.php
+++ b/tests/Criticalmass/MassTrackImport/Voter/DateTimeVoterTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\MassTrackImport\Voter;
+
+use App\Criticalmass\MassTrackImport\Voter\DateTimeVoter;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeVoterTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: float}>
+     */
+    public static function offsets(): iterable
+    {
+        yield 'exact start' => ['2024-05-31 19:00:00', 1.0];
+        yield '10 minutes late' => ['2024-05-31 19:10:00', 1.0];
+        yield '15 minutes early' => ['2024-05-31 18:45:00', 1.0];
+        yield '16 minutes late' => ['2024-05-31 19:16:00', 0.9];
+        yield '30 minutes late' => ['2024-05-31 19:30:00', 0.9];
+        yield '45 minutes late' => ['2024-05-31 19:45:00', 0.8];
+        yield '90 minutes early' => ['2024-05-31 17:30:00', 0.7];
+        yield '3 hours late' => ['2024-05-31 22:00:00', 0.5];
+        yield '4 hours early' => ['2024-05-31 15:00:00', 0.3];
+        yield 'same day but far apart' => ['2024-05-31 06:00:00', 0.25];
+        yield 'next day' => ['2024-06-01 19:00:00', -1.0];
+        yield 'previous day just before midnight' => ['2024-05-30 23:59:00', -1.0];
+    }
+
+    #[Test]
+    #[DataProvider('offsets')]
+    public function scoreDependsOnDistanceToRideStart(string $candidateStart, float $expected): void
+    {
+        $ride = (new Ride())->setDateTime(new \DateTime('2024-05-31 19:00:00'));
+        $candidate = (new TrackImportCandidate())->setStartDateTime(new \DateTime($candidateStart));
+
+        self::assertEqualsWithDelta($expected, (new DateTimeVoter())->vote($ride, $candidate), 0.0001);
+    }
+}

--- a/tests/Criticalmass/MassTrackImport/Voter/DurationVoterTest.php
+++ b/tests/Criticalmass/MassTrackImport/Voter/DurationVoterTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\MassTrackImport\Voter;
+
+use App\Criticalmass\MassTrackImport\Voter\DurationVoter;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DurationVoterTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: int, 1: float}>
+     */
+    public static function durations(): iterable
+    {
+        yield 'zero' => [0, 0.0];
+        yield 'ten minutes' => [10 * 60, 0.0];
+        yield 'exactly 15 minutes is still too short' => [15 * 60, 0.0];
+        yield 'just over 15 minutes' => [15 * 60 + 1, 0.5];
+        yield 'exactly 45 minutes is plausible only' => [45 * 60, 0.5];
+        yield 'just over 45 minutes is typical' => [45 * 60 + 1, 0.75];
+        yield 'two hours' => [2 * 3600, 0.75];
+        yield 'just under three hours' => [3 * 3600 - 1, 0.75];
+        yield 'exactly three hours' => [3 * 3600, 0.5];
+        yield 'just under six hours' => [6 * 3600 - 1, 0.5];
+        yield 'six hours' => [6 * 3600, 0.0];
+        yield 'a whole day' => [24 * 3600, 0.0];
+    }
+
+    #[Test]
+    #[DataProvider('durations')]
+    public function scoreReflectsTypicalRideLength(int $elapsedSeconds, float $expected): void
+    {
+        $candidate = (new TrackImportCandidate())->setElapsedTime($elapsedSeconds);
+
+        self::assertSame($expected, (new DurationVoter())->vote(new Ride(), $candidate));
+    }
+}

--- a/tests/Criticalmass/MassTrackImport/Voter/LocationVoterTest.php
+++ b/tests/Criticalmass/MassTrackImport/Voter/LocationVoterTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\MassTrackImport\Voter;
+
+use App\Criticalmass\Geo\Coord\Coord;
+use App\Criticalmass\MassTrackImport\Voter\LocationVoter;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocationVoterTest extends TestCase
+{
+    private const RIDE_LATITUDE = 53.55;
+    private const RIDE_LONGITUDE = 9.99;
+
+    /**
+     * GeoUtil approximates 1° latitude with 111.3 km, so the latitude offsets below map
+     * to well-defined distances from the ride's meeting point.
+     *
+     * @return iterable<string, array{0: float, 1: float}>
+     */
+    public static function latitudeOffsets(): iterable
+    {
+        yield 'same spot' => [0.0, 1.0];
+        yield '500 m away' => [0.0045, 1.0];
+        yield '2 km away' => [0.018, 0.9];
+        yield '10 km away' => [0.09, 0.8];
+        yield '30 km away' => [0.27, 0.5];
+        yield '60 km away' => [0.54, -1.0];
+        yield 'other side of the country' => [3.0, -1.0];
+    }
+
+    #[Test]
+    #[DataProvider('latitudeOffsets')]
+    public function scoreDropsWithDistanceFromMeetingPoint(float $latitudeOffset, float $expected): void
+    {
+        $ride = new Ride();
+        $ride->setLatitude(self::RIDE_LATITUDE);
+        $ride->setLongitude(self::RIDE_LONGITUDE);
+        $candidate = (new TrackImportCandidate())->setStartCoord(new Coord(self::RIDE_LATITUDE + $latitudeOffset, self::RIDE_LONGITUDE));
+
+        self::assertSame($expected, (new LocationVoter())->vote($ride, $candidate));
+    }
+
+    #[Test]
+    public function rideWithoutCoordinatesIsVetoed(): void
+    {
+        $candidate = (new TrackImportCandidate())->setStartCoord(new Coord(self::RIDE_LATITUDE, self::RIDE_LONGITUDE));
+
+        $latitudeOnly = new Ride();
+        $latitudeOnly->setLatitude(self::RIDE_LATITUDE);
+
+        self::assertSame(-1.0, (new LocationVoter())->vote(new Ride(), $candidate));
+        self::assertSame(-1.0, (new LocationVoter())->vote($latitudeOnly, $candidate));
+    }
+}

--- a/tests/Criticalmass/MassTrackImport/Voter/NameVoterTest.php
+++ b/tests/Criticalmass/MassTrackImport/Voter/NameVoterTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\MassTrackImport\Voter;
+
+use App\Criticalmass\MassTrackImport\Voter\NameVoter;
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NameVoterTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: float}>
+     */
+    public static function names(): iterable
+    {
+        yield 'identical to ride title' => ['Critical Mass Hamburg Mai 2024', 1.0];
+        yield 'contains "Critical Mass"' => ['Critical Mass with friends', 0.95];
+        yield 'contains both words separately' => ['Critical ride of the Mass', 0.95];
+        yield 'contains only "Critical"' => ['Critical evening', 0.8];
+        yield 'contains only "Mass"' => ['Massive ride', 0.8];
+        yield 'mentions the city' => ['Feierabendrunde Hamburg', 0.5];
+        yield 'nothing matches' => ['Morning ride', 0.0];
+        yield 'lower-case is not recognised' => ['critical mass', 0.0];
+        yield 'empty name' => ['', 0.0];
+    }
+
+    #[Test]
+    #[DataProvider('names')]
+    public function scoreReflectsHowMuchTheActivityNameLooksLikeACriticalMass(string $name, float $expected): void
+    {
+        $city = (new City())->setCity('Hamburg');
+        $ride = (new Ride())->setCity($city)->setTitle('Critical Mass Hamburg Mai 2024');
+        $candidate = (new TrackImportCandidate())->setName($name);
+
+        self::assertSame($expected, (new NameVoter())->vote($ride, $candidate));
+    }
+}

--- a/tests/Criticalmass/RideDuplicates/DuplicateFinderTest.php
+++ b/tests/Criticalmass/RideDuplicates/DuplicateFinderTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\RideDuplicates;
+
+use App\Criticalmass\RideDuplicates\DuplicateFinder\DuplicateFinder;
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class DuplicateFinderTest extends TestCase
+{
+    private function ride(int $id, City $city, string $dateTime): Ride
+    {
+        $ride = (new Ride())->setCity($city)->setDateTime(new \DateTime($dateTime));
+        EntityIdHelper::setId($ride, $id);
+
+        return $ride;
+    }
+
+    /**
+     * @param list<Ride> $allRides
+     * @param list<Ride> $cityRides
+     */
+    private function finder(array $allRides, array $cityRides = []): DuplicateFinder
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('findAll')->willReturn($allRides);
+        $repository->method('findRidesForCity')->willReturn($cityRides);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Ride::class)->willReturn($repository);
+
+        return new DuplicateFinder($registry);
+    }
+
+    #[Test]
+    public function ridesOfTheSameCityOnTheSameDayAreGroupedAsDuplicates(): void
+    {
+        $hamburg = (new City())->setId(1);
+        $berlin = (new City())->setId(2);
+
+        $rides = [
+            $this->ride(10, $hamburg, '2024-05-31 19:00:00'),
+            $this->ride(11, $hamburg, '2024-05-31 19:30:00'),
+            $this->ride(12, $hamburg, '2024-06-28 19:00:00'),
+            $this->ride(20, $berlin, '2024-05-31 19:00:00'),
+        ];
+
+        $duplicates = $this->finder($rides)->findDuplicates();
+
+        self::assertSame(['1-2024-05-31'], array_keys($duplicates));
+        self::assertEqualsCanonicalizing([10, 11], array_keys($duplicates['1-2024-05-31']));
+    }
+
+    #[Test]
+    public function threeRidesOnOneDayFormASingleGroup(): void
+    {
+        $city = (new City())->setId(1);
+        $rides = [
+            $this->ride(1, $city, '2024-05-31 18:00:00'),
+            $this->ride(2, $city, '2024-05-31 19:00:00'),
+            $this->ride(3, $city, '2024-05-31 20:00:00'),
+        ];
+
+        $duplicates = $this->finder($rides)->findDuplicates();
+
+        self::assertCount(1, $duplicates);
+        self::assertEqualsCanonicalizing([1, 2, 3], array_keys($duplicates['1-2024-05-31']));
+    }
+
+    #[Test]
+    public function noDuplicatesYieldsEmptyArray(): void
+    {
+        $city = (new City())->setId(1);
+        $rides = [
+            $this->ride(1, $city, '2024-05-31 19:00:00'),
+            $this->ride(2, $city, '2024-06-01 19:00:00'),
+        ];
+
+        self::assertSame([], $this->finder($rides)->findDuplicates());
+        self::assertSame([], $this->finder([])->findDuplicates());
+    }
+
+    #[Test]
+    public function restrictingToACityUsesTheCityQuery(): void
+    {
+        $city = (new City())->setId(3);
+        $cityRides = [
+            $this->ride(1, $city, '2024-05-31 19:00:00'),
+            $this->ride(2, $city, '2024-05-31 21:00:00'),
+        ];
+
+        $repository = $this->createMock(RideRepository::class);
+        $repository->expects(self::never())->method('findAll');
+        $repository->expects(self::once())->method('findRidesForCity')->with($city)->willReturn($cityRides);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturn($repository);
+
+        $duplicates = (new DuplicateFinder($registry))->setCity($city)->findDuplicates();
+
+        self::assertSame(['3-2024-05-31'], array_keys($duplicates));
+    }
+}

--- a/tests/Criticalmass/RideDuplicates/RideMergerTest.php
+++ b/tests/Criticalmass/RideDuplicates/RideMergerTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\RideDuplicates;
+
+use App\Criticalmass\RideDuplicates\RideMerger\RideMerger;
+use App\Entity\Photo;
+use App\Entity\Post;
+use App\Entity\Ride;
+use App\Entity\RideEstimate;
+use App\Entity\SocialNetworkProfile;
+use App\Entity\Subride;
+use App\Entity\Track;
+use App\Entity\Weather;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class RideMergerTest extends TestCase
+{
+    private function ride(int $id): Ride
+    {
+        $ride = new Ride();
+        EntityIdHelper::setId($ride, $id);
+
+        return $ride;
+    }
+
+    #[Test]
+    public function movesAllRelationsFromSourceRidesToTheTarget(): void
+    {
+        $target = $this->ride(1);
+        $source = $this->ride(2);
+
+        $track = (new Track())->setRide($source);
+        $photo = (new Photo())->setRide($source);
+        $post = (new Post())->setRide($source);
+        $subride = (new Subride())->setRide($source);
+        $estimate = (new RideEstimate())->setRide($source);
+        $weather = (new Weather())->setRide($source);
+        $profile = (new SocialNetworkProfile())->setRide($source);
+
+        $source
+            ->addTrack($track)
+            ->addPhoto($photo)
+            ->addPost($post)
+            ->addSubride($subride)
+            ->addEstimate($estimate)
+            ->addWeather($weather)
+            ->addSocialNetworkProfile($profile);
+
+        $merged = (new RideMerger())->setTargetRide($target)->addSourceRide($source)->merge();
+
+        self::assertSame($target, $merged);
+
+        self::assertSame([$track], $target->getTracks()->toArray());
+        self::assertSame([$photo], $target->getPhotos()->toArray());
+        self::assertSame([$post], $target->getPosts()->toArray());
+        self::assertSame([$subride], $target->getSubrides()->toArray());
+        self::assertSame([$estimate], $target->getEstimates()->toArray());
+        self::assertSame([$weather], $target->getWeathers()->toArray());
+        self::assertSame([$profile], $target->getSocialNetworkProfiles()->toArray());
+
+        foreach ([$track, $photo, $post, $subride, $estimate, $weather, $profile] as $relation) {
+            self::assertSame($target, $relation->getRide());
+        }
+
+        self::assertCount(0, $source->getTracks());
+        self::assertCount(0, $source->getPhotos());
+        self::assertCount(0, $source->getPosts());
+    }
+
+    #[Test]
+    public function sourceRidesAreDeduplicatedById(): void
+    {
+        $target = $this->ride(1);
+        $source = $this->ride(2);
+        $source->addTrack((new Track())->setRide($source));
+
+        $merged = (new RideMerger())
+            ->setTargetRide($target)
+            ->addSourceRides([$source, $source])
+            ->addSourceRide($source)
+            ->merge();
+
+        self::assertCount(1, $merged->getTracks());
+    }
+
+    #[Test]
+    public function mergingSeveralSourcesKeepsExistingTargetRelations(): void
+    {
+        $target = $this->ride(1);
+        $ownTrack = (new Track())->setRide($target);
+        $target->addTrack($ownTrack);
+
+        $a = $this->ride(2);
+        $a->addTrack((new Track())->setRide($a));
+        $b = $this->ride(3);
+        $b->addTrack((new Track())->setRide($b));
+
+        $merged = (new RideMerger())->setTargetRide($target)->addSourceRides([$a, $b])->merge();
+
+        self::assertCount(3, $merged->getTracks());
+        self::assertContains($ownTrack, $merged->getTracks()->toArray());
+    }
+}

--- a/tests/Criticalmass/SeoPage/SeoPageTest.php
+++ b/tests/Criticalmass/SeoPage/SeoPageTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\SeoPage;
+
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Criticalmass\SeoPage\SeoPage;
+use App\Entity\City;
+use App\Entity\Photo;
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\SeoBundle\Seo\SeoPage as SonataSeoPage;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Vich\UploaderBundle\Storage\StorageInterface;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+final class SeoPageTest extends TestCase
+{
+    private SonataSeoPage $sonataPage;
+    private MockObject&StorageInterface $storage;
+    private MockObject&CacheManager $cacheManager;
+    private MockObject&ObjectRouterInterface $objectRouter;
+    private SeoPage $seoPage;
+
+    protected function setUp(): void
+    {
+        $this->sonataPage = new SonataSeoPage('criticalmass.in');
+        $this->storage = $this->createMock(StorageInterface::class);
+        $this->cacheManager = $this->createMock(CacheManager::class);
+        $this->objectRouter = $this->createMock(ObjectRouterInterface::class);
+
+        $this->seoPage = new SeoPage($this->sonataPage, new UploaderHelper($this->storage), $this->cacheManager, $this->objectRouter);
+    }
+
+    #[Test]
+    public function titleIsMirroredIntoOpenGraph(): void
+    {
+        $this->seoPage->setTitle('Critical Mass Hamburg');
+
+        self::assertSame('Critical Mass Hamburg', $this->sonataPage->getTitle());
+        self::assertSame('Critical Mass Hamburg', $this->sonataPage->getMetas()['property']['og:title'][0]);
+    }
+
+    #[Test]
+    public function descriptionFeedsBothMetaAndOpenGraph(): void
+    {
+        $this->seoPage->setDescription('Monthly ride');
+
+        $metas = $this->sonataPage->getMetas();
+        self::assertSame('Monthly ride', $metas['name']['description'][0]);
+        self::assertSame('Monthly ride', $metas['property']['og:description'][0]);
+    }
+
+    #[Test]
+    public function canonicalLinkAlsoSetsOgUrl(): void
+    {
+        $this->seoPage->setCanonicalLink('https://criticalmass.in/hamburg');
+
+        self::assertSame('https://criticalmass.in/hamburg', $this->sonataPage->getLinkCanonical());
+        self::assertSame('https://criticalmass.in/hamburg', $this->sonataPage->getMetas()['property']['og:url'][0]);
+    }
+
+    #[Test]
+    public function canonicalForObjectUsesAbsoluteObjectUrl(): void
+    {
+        $city = new City();
+        $this->objectRouter->expects(self::once())
+            ->method('generate')
+            ->with($city, null, [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://criticalmass.in/hamburg');
+
+        $this->seoPage->setCanonicalForObject($city);
+
+        self::assertSame('https://criticalmass.in/hamburg', $this->sonataPage->getLinkCanonical());
+    }
+
+    #[Test]
+    public function previewPhotoRegistersFacebookAndTwitterImages(): void
+    {
+        $photo = (new Photo())->setImageName('ride.jpg');
+
+        $this->storage->method('resolveUri')->with($photo, 'imageFile')->willReturn('/uploads/ride.jpg');
+        $this->cacheManager->method('getBrowserPath')->willReturnCallback(
+            static fn (string $path, string $filter): string => sprintf('https://cdn/%s%s', $filter, $path)
+        );
+
+        $this->seoPage->setPreviewPhoto($photo);
+
+        $metas = $this->sonataPage->getMetas();
+        self::assertSame('https://cdn/facebook_preview_image/uploads/ride.jpg', $metas['property']['og:image'][0]);
+        self::assertSame('https://cdn/twitter_summary_large_image/uploads/ride.jpg', $metas['name']['twitter:image'][0]);
+        self::assertSame('summary_large_image', $metas['name']['twitter:card'][0]);
+    }
+
+    #[Test]
+    public function previewPhotoWithoutImageIsIgnored(): void
+    {
+        $this->cacheManager->expects(self::never())->method('getBrowserPath');
+
+        $this->seoPage->setPreviewPhoto(new Photo());
+
+        self::assertArrayNotHasKey('og:image', $this->sonataPage->getMetas()['property'] ?? []);
+    }
+
+    #[Test]
+    public function settersAreFluent(): void
+    {
+        self::assertSame($this->seoPage, $this->seoPage->setTitle('t'));
+        self::assertSame($this->seoPage, $this->seoPage->setDescription('d'));
+        self::assertSame($this->seoPage, $this->seoPage->setCanonicalLink('l'));
+    }
+}

--- a/tests/Criticalmass/TextParser/CriticalParserTest.php
+++ b/tests/Criticalmass/TextParser/CriticalParserTest.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\TextParser;
+
+use App\Criticalmass\TextParser\CriticalParser;
+use App\Criticalmass\TextParser\Embedder\EmbedderInterface;
+use App\Criticalmass\TextParser\TextCache\TextCacheInterface;
+use Flagception\Manager\FeatureManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CriticalParserTest extends TestCase
+{
+    /** @var array<string, string> */
+    private array $cache = [];
+
+    private function parser(bool $oembedActive = false): CriticalParser
+    {
+        $featureManager = $this->createMock(FeatureManagerInterface::class);
+        $featureManager->method('isActive')->willReturnCallback(static fn (string $feature): bool => 'oembed' === $feature && $oembedActive);
+
+        $textCache = new class($this->cache) implements TextCacheInterface {
+            /** @param array<string, string> $store */
+            public function __construct(private array &$store)
+            {
+            }
+
+            public function has(string $rawText): bool
+            {
+                return array_key_exists($rawText, $this->store);
+            }
+
+            public function get(string $rawText): string
+            {
+                return $this->store[$rawText];
+            }
+
+            public function set(string $rawText, string $parsedText): TextCacheInterface
+            {
+                $this->store[$rawText] = $parsedText;
+
+                return $this;
+            }
+        };
+
+        return new CriticalParser($featureManager, $this->createMock(EmbedderInterface::class), $textCache);
+    }
+
+    #[Test]
+    public function convertsMarkdownToHtml(): void
+    {
+        self::assertSame("<p><strong>bold</strong> and <em>italic</em></p>\n", $this->parser()->parse('**bold** and *italic*'));
+    }
+
+    #[Test]
+    public function rawHtmlIsStripped(): void
+    {
+        $html = $this->parser()->parse('hello <script>alert(1)</script> world');
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('hello', $html);
+        self::assertStringContainsString('world', $html);
+    }
+
+    #[Test]
+    public function unsafeLinksLoseTheirHref(): void
+    {
+        $html = $this->parser()->parse('[click](javascript:alert(1))');
+
+        self::assertStringNotContainsString('javascript:', $html);
+        self::assertStringContainsString('<a>click</a>', $html);
+    }
+
+    #[Test]
+    public function explicitLinksAreKept(): void
+    {
+        self::assertSame(
+            "<p><a href=\"https://criticalmass.in/\">CM</a></p>\n",
+            $this->parser()->parse('[CM](https://criticalmass.in/)')
+        );
+    }
+
+    #[Test]
+    public function parsedTextIsCached(): void
+    {
+        $parser = $this->parser();
+
+        $parser->parse('# Title');
+
+        self::assertSame(["# Title" => "<h1>Title</h1>\n"], $this->cache);
+    }
+
+    #[Test]
+    public function cachedTextIsReturnedWithoutReparsing(): void
+    {
+        $this->cache['# Title'] = '<p>from cache</p>';
+
+        self::assertSame('<p>from cache</p>', $this->parser()->parse('# Title'));
+    }
+
+    #[Test]
+    public function bareUrlsAreAutolinked(): void
+    {
+        $html = $this->parser()->parse('see https://criticalmass.in/hamburg now');
+
+        if (!str_contains($html, '<a href="https://criticalmass.in/hamburg">')) {
+            self::markTestIncomplete(
+                'CriticalParser::configure() builds an Environment with the AutolinkExtension (and the '
+                .'EmbedExtension) but then instantiates CommonMarkConverter($config), which creates its own '
+                .'environment — the configured extensions are never used, so bare URLs stay plain text.'
+            );
+        }
+
+        self::assertStringContainsString('<a href="https://criticalmass.in/hamburg">', $html);
+    }
+}

--- a/tests/Criticalmass/Timeline/CollectorTest.php
+++ b/tests/Criticalmass/Timeline/CollectorTest.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Timeline;
+
+use App\Criticalmass\Timeline\Collector\CityCreatedCollector;
+use App\Criticalmass\Timeline\Collector\RidePhotoCollector;
+use App\Criticalmass\Timeline\Collector\ThreadCollector;
+use App\Criticalmass\Timeline\Item\CityCreatedItem;
+use App\Criticalmass\Timeline\Item\RidePhotoItem;
+use App\Criticalmass\Timeline\Item\ThreadItem;
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Photo;
+use App\Entity\Post;
+use App\Entity\Ride;
+use App\Entity\Thread;
+use App\Entity\User;
+use App\Repository\CityRepository;
+use App\Repository\PhotoRepository;
+use App\Repository\ThreadRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class CollectorTest extends TestCase
+{
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $repositoryClass
+     * @param list<object> $entities
+     */
+    private function registry(string $entityClass, string $repositoryClass, string $method, array $entities): ManagerRegistry
+    {
+        $repository = $this->createMock($repositoryClass);
+        $repository->expects(self::once())->method($method)->willReturn($entities);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with($entityClass)->willReturn($repository);
+
+        return $registry;
+    }
+
+    #[Test]
+    public function threadCollectorBuildsOneItemPerThreadKeyedByFirstPostTime(): void
+    {
+        $user = new User();
+        $post = (new Post())->setUser($user)->setMessage('Hello')->setDateTime(new \DateTime('2024-05-31 19:00:00'));
+        $thread = (new Thread())->setTitle('Meeting point')->setFirstPost($post);
+
+        $collector = new ThreadCollector($this->registry(Thread::class, ThreadRepository::class, 'findForTimelineThreadCollector', [$thread]));
+        $collector->setDateRange(new \DateTime('2024-05-01'), new \DateTime('2024-06-01'))->execute();
+
+        $items = $collector->getItems();
+
+        self::assertCount(1, $items);
+        $key = array_key_first($items);
+        self::assertStringStartsWith('2024-05-31-19-00-00-', $key);
+
+        $item = $items[$key];
+        self::assertInstanceOf(ThreadItem::class, $item);
+        self::assertSame('Meeting point', $item->getTitle());
+        self::assertSame('Hello', $item->getText());
+        self::assertSame($user, $item->getUser());
+        self::assertSame($thread, $item->getThread());
+        self::assertSame('standard', $item->getTabName());
+    }
+
+    #[Test]
+    public function collectorsDeclareNoRequiredFeaturesByDefault(): void
+    {
+        self::assertSame([], (new ThreadCollector($this->createMock(ManagerRegistry::class)))->getRequiredFeatures());
+        self::assertSame(['photos'], (new RidePhotoCollector($this->createMock(ManagerRegistry::class)))->getRequiredFeatures());
+    }
+
+    #[Test]
+    public function cityCreatedCollectorConvertsCitiesWithSlugs(): void
+    {
+        $user = new User();
+        $city = (new City())->setCity('Hamburg')->setUser($user)->setCreatedAt(new \DateTime('2024-01-02 03:04:05'));
+        $city->addSlug((new CitySlug())->setSlug('hamburg'));
+
+        $collector = new CityCreatedCollector($this->registry(City::class, CityRepository::class, 'findForTimelineCityCreatedCollector', [$city]));
+        $collector->execute();
+
+        $items = array_values($collector->getItems());
+
+        self::assertCount(1, $items);
+        self::assertInstanceOf(CityCreatedItem::class, $items[0]);
+        self::assertSame('Hamburg', $items[0]->getCityName());
+        self::assertSame($city, $items[0]->getCity());
+        self::assertSame($user, $items[0]->getUser());
+        self::assertSame('2024-01-02 03:04:05', $items[0]->getDateTime()->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
+    public function cityCreatedCollectorSkipsCitiesWithoutSlugs(): void
+    {
+        $city = (new City())->setCity('Nowhere')->setUser(new User())->setCreatedAt(new \DateTime('2024-01-02'));
+
+        $collector = new CityCreatedCollector($this->registry(City::class, CityRepository::class, 'findForTimelineCityCreatedCollector', [$city]));
+        $collector->execute();
+
+        if (1 === count($collector->getItems())) {
+            self::markTestIncomplete(
+                'CityCreatedCollector checks "if ($city->getSlugs())", but getSlugs() returns a Collection '
+                .'object which is always truthy — cities without any slug are not filtered out.'
+            );
+        }
+
+        self::assertSame([], $collector->getItems());
+    }
+
+    #[Test]
+    public function ridePhotoCollectorGroupsPhotosPerUserAndRide(): void
+    {
+        $alice = new User();
+        EntityIdHelper::setId($alice, 1);
+        $bob = new User();
+        EntityIdHelper::setId($bob, 2);
+
+        $ride = (new Ride())->setEnabled(true);
+        EntityIdHelper::setId($ride, 10);
+        $otherRide = (new Ride())->setEnabled(false);
+        EntityIdHelper::setId($otherRide, 11);
+
+        $photos = [];
+        foreach ([[$alice, $ride, 1], [$alice, $ride, 2], [$alice, $ride, 3], [$alice, $ride, 4], [$bob, $ride, 5], [$alice, $otherRide, 6]] as [$user, $photoRide, $id]) {
+            $photo = (new Photo())->setUser($user)->setRide($photoRide)->setCreationDateTime(new \DateTime('2024-05-31 20:00:00'));
+            EntityIdHelper::setId($photo, $id);
+            $photos[] = $photo;
+        }
+
+        // A photo without a ride is ignored entirely.
+        $orphan = (new Photo())->setUser($alice)->setCreationDateTime(new \DateTime('2024-05-31 20:00:00'));
+        EntityIdHelper::setId($orphan, 99);
+        $photos[] = $orphan;
+
+        $collector = new RidePhotoCollector($this->registry(Photo::class, PhotoRepository::class, 'findForTimelineRidePhotoCollector', $photos));
+        $collector->execute();
+
+        /** @var list<RidePhotoItem> $items */
+        $items = array_values($collector->getItems());
+
+        self::assertCount(3, $items);
+
+        $byKey = [];
+        foreach ($items as $item) {
+            $byKey[$item->getUser()->getId() . '-' . $item->getRide()->getId()] = $item;
+        }
+
+        self::assertSame(4, $byKey['1-10']->getCounter());
+        self::assertCount(3, $byKey['1-10']->getPreviewPhotoList());
+        self::assertTrue($byKey['1-10']->isRideEnabled());
+
+        self::assertSame(1, $byKey['2-10']->getCounter());
+        self::assertCount(1, $byKey['2-10']->getPreviewPhotoList());
+
+        self::assertSame(1, $byKey['1-11']->getCounter());
+        self::assertFalse($byKey['1-11']->isRideEnabled());
+
+        foreach ($byKey['1-10']->getPreviewPhotoList() as $preview) {
+            self::assertContains($preview->getId(), [1, 2, 3, 4]);
+        }
+    }
+}

--- a/tests/Criticalmass/Timeline/TimelineTest.php
+++ b/tests/Criticalmass/Timeline/TimelineTest.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Timeline;
+
+use App\Criticalmass\Timeline\Collector\TimelineCollectorInterface;
+use App\Criticalmass\Timeline\Item\CityCreatedItem;
+use App\Criticalmass\Timeline\Item\ItemInterface;
+use App\Criticalmass\Timeline\Item\RidePhotoItem;
+use App\Criticalmass\Timeline\Item\ThreadItem;
+use App\Criticalmass\Timeline\Timeline;
+use Doctrine\Persistence\ManagerRegistry;
+use Flagception\Manager\FeatureManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+final class TimelineTest extends TestCase
+{
+    /** @var list<string> */
+    private array $activeFeatures = [];
+
+    private function timeline(): Timeline
+    {
+        $twig = new Environment(new ArrayLoader([
+            'Timeline/Items/thread.html.twig' => 'thread:{{ item.title }}',
+            'Timeline/Items/cityCreated.html.twig' => 'city:{{ item.cityName }}',
+            'Timeline/Items/ridePhoto.html.twig' => 'photos:{{ item.counter }}',
+        ]));
+
+        $featureManager = $this->createMock(FeatureManagerInterface::class);
+        $featureManager->method('isActive')->willReturnCallback(fn (string $feature): bool => in_array($feature, $this->activeFeatures, true));
+
+        $timeline = new Timeline($this->createMock(ManagerRegistry::class), $twig, $featureManager);
+        $timeline->setDateRange(new \DateTime('-1 month'), new \DateTime());
+
+        return $timeline;
+    }
+
+    /**
+     * @param array<string, ItemInterface> $items
+     * @param list<string> $requiredFeatures
+     */
+    private function collector(array $items, array $requiredFeatures = []): MockObject&TimelineCollectorInterface
+    {
+        $collector = $this->createMock(TimelineCollectorInterface::class);
+        $collector->method('setDateRange')->willReturnSelf();
+        $collector->method('execute')->willReturnSelf();
+        $collector->method('getItems')->willReturn($items);
+        $collector->method('getRequiredFeatures')->willReturn($requiredFeatures);
+
+        return $collector;
+    }
+
+    private function threadItem(string $title, string $dateTime): ThreadItem
+    {
+        $item = (new ThreadItem())->setTitle($title);
+        $item->setDateTime(new \DateTime($dateTime));
+
+        return $item;
+    }
+
+    #[Test]
+    public function itemsAreRenderedNewestFirstAcrossCollectors(): void
+    {
+        $older = $this->threadItem('older', '-3 days');
+        $newer = $this->threadItem('newer', '-1 day');
+        $city = (new CityCreatedItem())->setCityName('Hamburg')->setDateTime(new \DateTime('-2 days'));
+
+        $timeline = $this->timeline()
+            ->addCollector($this->collector(['2020-01-01-00-00-00-a' => $older, '2020-01-03-00-00-00-c' => $newer]))
+            ->addCollector($this->collector(['2020-01-02-00-00-00-b' => $city]))
+            ->execute();
+
+        self::assertSame(['standard' => ['thread:newer', 'city:Hamburg', 'thread:older']], $timeline->getTimelineContentList());
+    }
+
+    #[Test]
+    public function collectorsWithInactiveFeaturesAreIgnored(): void
+    {
+        $this->activeFeatures = ['threads'];
+
+        $shown = $this->collector(['k1' => $this->threadItem('shown', '-1 day')], ['threads']);
+        $hidden = $this->collector(['k2' => (new RidePhotoItem())->setCounter(3)->setDateTime(new \DateTime('-1 day'))], ['photos']);
+        $hidden->expects(self::never())->method('execute');
+
+        $timeline = $this->timeline()->addCollector($shown)->addCollector($hidden)->execute();
+
+        self::assertSame(['standard' => ['thread:shown']], $timeline->getTimelineContentList());
+    }
+
+    #[Test]
+    public function collectorRequiringSeveralFeaturesNeedsAllOfThem(): void
+    {
+        $this->activeFeatures = ['threads'];
+
+        $collector = $this->collector(['k1' => $this->threadItem('x', '-1 day')], ['threads', 'photos']);
+        $collector->expects(self::never())->method('execute');
+
+        self::assertSame([], $this->timeline()->addCollector($collector)->execute()->getTimelineContentList());
+    }
+
+    #[Test]
+    public function itemsOlderThanThreeMonthsAreDropped(): void
+    {
+        $items = [
+            'b' => $this->threadItem('recent', '-2 months'),
+            'a' => $this->threadItem('ancient', '-4 months'),
+        ];
+
+        $timeline = $this->timeline()->addCollector($this->collector($items))->execute();
+
+        self::assertSame(['standard' => ['thread:recent']], $timeline->getTimelineContentList());
+    }
+
+    #[Test]
+    public function atMostHundredItemsPerTabSurvive(): void
+    {
+        $items = [];
+        for ($i = 0; $i < 120; ++$i) {
+            $items[sprintf('item-%03d', $i)] = $this->threadItem((string) $i, '-1 day');
+        }
+
+        $timeline = $this->timeline()->addCollector($this->collector($items))->execute();
+
+        $rendered = $timeline->getTimelineContentList()['standard'];
+
+        self::assertCount(Timeline::MAX_ITEMS, $rendered);
+        self::assertSame('thread:119', $rendered[0]);
+        self::assertSame('thread:20', $rendered[99]);
+    }
+
+    #[Test]
+    public function emptyTimelineHasNoContent(): void
+    {
+        self::assertSame([], $this->timeline()->execute()->getTimelineContentList());
+    }
+}

--- a/tests/Criticalmass/Upload/Handler/PhotoUploadHandlerTest.php
+++ b/tests/Criticalmass/Upload/Handler/PhotoUploadHandlerTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Upload\Handler;
+
+use App\Criticalmass\PhotoImport\PhotoCandidate\ParsedPhotoUpload;
+use App\Criticalmass\PhotoImport\PhotoCandidate\PhotoCandidateFactory;
+use App\Criticalmass\Upload\Handler\PhotoUploadHandler;
+use App\Criticalmass\Upload\UploadResult;
+use App\Entity\PhotoImportCandidate;
+use App\Entity\User;
+use App\Repository\PhotoImportCandidateRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PhotoUploadHandlerTest extends TestCase
+{
+    private MockObject&FilesystemOperator $filesystem;
+    private MockObject&PhotoImportCandidateRepository $repository;
+    private MockObject&ObjectManager $manager;
+    private PhotoImportCandidate $candidate;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new User();
+        $this->candidate = (new PhotoImportCandidate())->setUser($this->user)->setFileHash('deadbeef')->setStagedFilename('deadbeef.jpg');
+
+        $this->filesystem = $this->createMock(FilesystemOperator::class);
+        $this->repository = $this->createMock(PhotoImportCandidateRepository::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+    }
+
+    private function handler(string $imageBytes): PhotoUploadHandler
+    {
+        $factory = $this->createMock(PhotoCandidateFactory::class);
+        $factory->method('createFromUpload')->willReturn(new ParsedPhotoUpload($this->candidate, $imageBytes));
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        return new PhotoUploadHandler($factory, $this->filesystem, $this->repository, $registry);
+    }
+
+    private function onePixelPng(): string
+    {
+        return (string) base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==', true);
+    }
+
+    #[Test]
+    public function undecodableBytesAreRejectedBeforeAnyLookup(): void
+    {
+        $this->repository->expects(self::never())->method('findOneByUserAndFileHash');
+        $this->filesystem->expects(self::never())->method('write');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('kein gültiges Bild');
+
+        $this->handler('not an image')->handle('/tmp/x.jpg', 'x.jpg', $this->user);
+    }
+
+    #[Test]
+    public function duplicateImageIsReportedWithoutStaging(): void
+    {
+        $this->repository->method('findOneByUserAndFileHash')->with($this->user, 'deadbeef')->willReturn(new PhotoImportCandidate());
+        $this->filesystem->expects(self::never())->method('write');
+        $this->manager->expects(self::never())->method('persist');
+
+        $result = $this->handler($this->onePixelPng())->handle('/tmp/x.png', 'x.png', $this->user);
+
+        self::assertSame(UploadResult::KIND_PHOTO, $result->kind);
+        self::assertSame(UploadResult::STATUS_DUPLICATE, $result->status);
+    }
+
+    #[Test]
+    public function newImageIsStagedAndPersisted(): void
+    {
+        $bytes = $this->onePixelPng();
+
+        $this->repository->method('findOneByUserAndFileHash')->willReturn(null);
+        $this->filesystem->expects(self::once())->method('write')->with('deadbeef.jpg', $bytes);
+        $this->manager->expects(self::once())->method('persist')->with($this->candidate);
+        $this->manager->expects(self::once())->method('flush');
+
+        $result = $this->handler($bytes)->handle('/tmp/x.png', 'x.png', $this->user);
+
+        self::assertSame(UploadResult::STATUS_STAGED, $result->status);
+    }
+}

--- a/tests/Criticalmass/Upload/Handler/TrackUploadHandlerTest.php
+++ b/tests/Criticalmass/Upload/Handler/TrackUploadHandlerTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Upload\Handler;
+
+use App\Criticalmass\MassTrackImport\ProposalPersister\ProposalPersisterInterface;
+use App\Criticalmass\MassTrackImport\TrackDecider\RideResult;
+use App\Criticalmass\MassTrackImport\TrackDecider\TrackDeciderInterface;
+use App\Criticalmass\MassTrackImport\UploadedTrackCandidate\ParsedTrackUpload;
+use App\Criticalmass\MassTrackImport\UploadedTrackCandidate\UploadedTrackCandidateFactory;
+use App\Criticalmass\Upload\Handler\TrackUploadHandler;
+use App\Criticalmass\Upload\UploadResult;
+use App\Entity\Ride;
+use App\Entity\TrackImportCandidate;
+use App\Entity\User;
+use App\Repository\TrackImportCandidateRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class TrackUploadHandlerTest extends TestCase
+{
+    private MockObject&TrackDeciderInterface $decider;
+    private MockObject&ProposalPersisterInterface $persister;
+    private MockObject&FilesystemOperator $filesystem;
+    private MockObject&TrackImportCandidateRepository $repository;
+    private MockObject&ObjectManager $manager;
+    private TrackImportCandidate $candidate;
+    private TrackUploadHandler $handler;
+    private User $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new User();
+        $this->candidate = (new TrackImportCandidate())->setFileHash('abc123')->setUser($this->user);
+
+        $factory = $this->createMock(UploadedTrackCandidateFactory::class);
+        $factory->method('createFromUpload')->willReturn(new ParsedTrackUpload($this->candidate, '<gpx/>'));
+
+        $this->decider = $this->createMock(TrackDeciderInterface::class);
+        $this->persister = $this->createMock(ProposalPersisterInterface::class);
+        $this->filesystem = $this->createMock(FilesystemOperator::class);
+        $this->repository = $this->createMock(TrackImportCandidateRepository::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(TrackImportCandidate::class)->willReturn($this->repository);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        $this->handler = new TrackUploadHandler($factory, $this->decider, $this->persister, $this->filesystem, $registry);
+    }
+
+    #[Test]
+    public function duplicateUploadIsReportedWithoutStoringAnything(): void
+    {
+        $this->repository->method('findOneBy')->with(['user' => $this->user, 'fileHash' => 'abc123'])->willReturn(new TrackImportCandidate());
+        $this->filesystem->expects(self::never())->method('write');
+        $this->decider->expects(self::never())->method('decide');
+        $this->manager->expects(self::never())->method('persist');
+
+        $result = $this->handler->handle('/tmp/ride.gpx', 'ride.gpx', $this->user);
+
+        self::assertSame(UploadResult::KIND_TRACK, $result->kind);
+        self::assertSame(UploadResult::STATUS_DUPLICATE, $result->status);
+    }
+
+    #[Test]
+    public function matchedTrackIsStoredAndPersistedAsProposal(): void
+    {
+        $ride = (new Ride())->setTitle('Critical Mass Hamburg');
+        $rideResult = new RideResult($ride, $this->candidate);
+
+        $this->repository->method('findOneBy')->willReturn(null);
+        $this->filesystem->expects(self::once())->method('write')->with('candidates/abc123.gpx', '<gpx/>');
+        $this->decider->method('decide')->with($this->candidate)->willReturn($rideResult);
+        $this->persister->expects(self::once())->method('persist')->with($rideResult)->willReturn($rideResult);
+        $this->manager->expects(self::never())->method('persist');
+
+        $result = $this->handler->handle('/tmp/ride.gpx', 'ride.gpx', $this->user);
+
+        self::assertSame(UploadResult::STATUS_MATCHED, $result->status);
+        self::assertStringContainsString('Critical Mass Hamburg', $result->message);
+        self::assertSame('candidates/abc123.gpx', $this->candidate->getTrackFilename());
+    }
+
+    #[Test]
+    public function unmatchedTrackIsParkedWithoutRide(): void
+    {
+        $this->candidate->setRide(new Ride());
+
+        $this->repository->method('findOneBy')->willReturn(null);
+        $this->decider->method('decide')->willReturn(null);
+        $this->persister->expects(self::never())->method('persist');
+        $this->manager->expects(self::once())->method('persist')->with($this->candidate);
+        $this->manager->expects(self::once())->method('flush');
+
+        $result = $this->handler->handle('/tmp/ride.gpx', 'ride.gpx', $this->user);
+
+        self::assertSame(UploadResult::STATUS_PARKED, $result->status);
+        self::assertNull($this->candidate->getRide());
+    }
+}

--- a/tests/DQL/DqlFunctionsTest.php
+++ b/tests/DQL/DqlFunctionsTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Tests\DQL;
+
+use App\Entity\Ride;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The custom DQL functions are registered in config/packages/doctrine.yaml; this
+ * checks they parse and translate to the expected SQL (no query is executed).
+ */
+final class DqlFunctionsTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function dateFunctions(): iterable
+    {
+        yield 'YEAR' => ['YEAR', 'YEAR('];
+        yield 'MONTH' => ['MONTH', 'MONTH('];
+        yield 'DAY' => ['DAY', 'DAY('];
+        yield 'DATE' => ['DATE', 'DATE('];
+        yield 'DAYOFWEEK' => ['DAYOFWEEK', 'DAYOFWEEK('];
+    }
+
+    #[Test]
+    #[DataProvider('dateFunctions')]
+    public function dateFunctionsWrapTheColumn(string $dqlFunction, string $sqlPrefix): void
+    {
+        $sql = $this->entityManager
+            ->createQuery(sprintf('SELECT %s(r.dateTime) AS v FROM %s r', $dqlFunction, Ride::class))
+            ->getSQL();
+
+        self::assertMatchesRegularExpression('/SELECT ' . preg_quote($sqlPrefix, '/') . '\w+\.dateTime\) AS/', $sql);
+    }
+
+    #[Test]
+    public function dateFunctionsCanBeUsedInWhereClausesWithParameters(): void
+    {
+        $sql = $this->entityManager
+            ->createQuery(sprintf('SELECT r FROM %s r WHERE YEAR(r.dateTime) = :year AND MONTH(r.dateTime) = :month', Ride::class))
+            ->getSQL();
+
+        self::assertStringContainsString('WHERE YEAR(', $sql);
+        self::assertStringContainsString(' AND MONTH(', $sql);
+    }
+
+    #[Test]
+    public function randOrdersRandomly(): void
+    {
+        $sql = $this->entityManager
+            ->createQuery(sprintf('SELECT r FROM %s r ORDER BY RAND()', Ride::class))
+            ->getSQL();
+
+        self::assertStringEndsWith('ORDER BY RAND() ASC', $sql);
+    }
+
+    #[Test]
+    public function dateFunctionsRequireExactlyOneArgument(): void
+    {
+        $this->expectException(\Doctrine\ORM\Query\QueryException::class);
+
+        $this->entityManager->createQuery(sprintf('SELECT YEAR(r.dateTime, r.createdAt) FROM %s r', Ride::class))->getSQL();
+    }
+}

--- a/tests/Entity/RegionTest.php
+++ b/tests/Entity/RegionTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\Region;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class RegionTest extends TestCase
+{
+    private function world(): Region
+    {
+        $world = (new Region())->setName('World')->setSlug('world');
+        EntityIdHelper::setId($world, 1);
+
+        return $world;
+    }
+
+    #[Test]
+    public function onlyRegionWithIdOneIsTheWorld(): void
+    {
+        $other = (new Region())->setName('Europe');
+        EntityIdHelper::setId($other, 2);
+
+        self::assertTrue($this->world()->isWorld());
+        self::assertFalse($other->isWorld());
+        self::assertFalse((new Region())->isWorld());
+    }
+
+    #[Test]
+    public function levelIsTheDistanceToTheWorld(): void
+    {
+        $world = $this->world();
+        $europe = (new Region())->setName('Europe')->setParent($world);
+        $germany = (new Region())->setName('Germany')->setParent($europe);
+        $hamburg = (new Region())->setName('Hamburg')->setParent($germany);
+
+        self::assertTrue($world->isLevel(0));
+        self::assertFalse($world->isLevel(1));
+
+        self::assertTrue($europe->isLevel(1));
+        self::assertFalse($europe->isLevel(0));
+        self::assertFalse($europe->isLevel(2));
+
+        self::assertTrue($germany->isLevel(2));
+        self::assertTrue($hamburg->isLevel(3));
+        self::assertFalse($hamburg->isLevel(2));
+        self::assertFalse($hamburg->isLevel(4));
+    }
+
+    #[Test]
+    public function detachedRegionIsNoLevelAtAll(): void
+    {
+        $orphan = (new Region())->setName('Orphan');
+        EntityIdHelper::setId($orphan, 99);
+
+        foreach ([0, 1, 2, 3] as $level) {
+            self::assertFalse($orphan->isLevel($level), (string) $level);
+        }
+    }
+
+    #[Test]
+    public function stringRepresentationIsTheName(): void
+    {
+        self::assertSame('Europe', (string) (new Region())->setName('Europe'));
+    }
+}

--- a/tests/Entity/RideTest.php
+++ b/tests/Entity/RideTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\EntityIdHelper;
+
+final class RideTest extends TestCase
+{
+    private function city(int $id, string $title): City
+    {
+        $city = (new City())->setId($id)->setCity($title);
+        $city->setTitle($title);
+        $city->setMainSlug((new CitySlug())->setSlug(strtolower($title))->setCity($city));
+
+        return $city;
+    }
+
+    #[Test]
+    public function hasSlugOnlyWhenSlugIsSet(): void
+    {
+        self::assertFalse((new Ride())->hasSlug());
+        self::assertTrue((new Ride())->setSlug('kidical-mass')->hasSlug());
+        self::assertFalse((new Ride())->setSlug('x')->setSlug(null)->hasSlug());
+    }
+
+    #[Test]
+    public function sameRideMeansSameCityAndSameDay(): void
+    {
+        $hamburg = $this->city(1, 'Hamburg');
+        $berlin = $this->city(2, 'Berlin');
+
+        $ride = (new Ride())->setCity($hamburg)->setDateTime(new \DateTime('2024-05-31 19:00:00'));
+
+        self::assertTrue($ride->isSameRide((new Ride())->setCity($hamburg)->setDateTime(new \DateTime('2024-05-31 08:00:00'))));
+        self::assertFalse($ride->isSameRide((new Ride())->setCity($hamburg)->setDateTime(new \DateTime('2024-06-01 19:00:00'))));
+        self::assertFalse($ride->isSameRide((new Ride())->setCity($berlin)->setDateTime(new \DateTime('2024-05-31 19:00:00'))));
+    }
+
+    #[Test]
+    public function isEqualComparesIds(): void
+    {
+        $a = new Ride();
+        EntityIdHelper::setId($a, 5);
+        $b = new Ride();
+        EntityIdHelper::setId($b, 5);
+        $c = new Ride();
+        EntityIdHelper::setId($c, 6);
+
+        self::assertTrue($a->isEqual($b));
+        self::assertTrue($a->equals($b));
+        self::assertFalse($a->isEqual($c));
+    }
+
+    #[Test]
+    public function stringRepresentationCombinesCityAndDate(): void
+    {
+        $ride = (new Ride())->setCity($this->city(1, 'Hamburg'))->setDateTime(new \DateTime('2024-05-31 19:00:00'));
+
+        self::assertSame('Hamburg - 2024-05-31', (string) $ride);
+        self::assertSame('2024-05-31', (string) (new Ride())->setDateTime(new \DateTime('2024-05-31')));
+        self::assertSame('Hamburg - unknown', (string) (new Ride())->setCity($this->city(1, 'Hamburg'))->setDateTime(null));
+    }
+
+    #[Test]
+    public function coordAssignsLatitudeAndLongitude(): void
+    {
+        $ride = (new Ride())->setCoord(new \App\Criticalmass\Geo\Coord\Coord(53.55, 9.99));
+
+        self::assertSame(53.55, $ride->getLatitude());
+        self::assertSame(9.99, $ride->getLongitude());
+    }
+
+    #[Test]
+    public function newRideIsEnabledAndDatedNow(): void
+    {
+        $ride = new Ride();
+
+        self::assertTrue($ride->isEnabled());
+        self::assertNull($ride->getDisabledReason());
+        self::assertEqualsWithDelta(time(), $ride->getDateTime()->getTimestamp(), 5);
+        self::assertEqualsWithDelta(time(), $ride->getCreatedAt()->getTimestamp(), 5);
+    }
+}

--- a/tests/Entity/UserTest.php
+++ b/tests/Entity/UserTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\User;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class UserTest extends TestCase
+{
+    #[Test]
+    public function everyUserGetsRoleUserExactlyOnce(): void
+    {
+        self::assertSame(['ROLE_USER'], (new User())->getRoles());
+        self::assertSame(['ROLE_USER'], (new User())->setRoles(['ROLE_USER'])->getRoles());
+        self::assertSame(['ROLE_ADMIN', 'ROLE_USER'], (new User())->setRoles(['ROLE_ADMIN'])->getRoles());
+    }
+
+    #[Test]
+    public function hasRoleOnlyLooksAtExplicitlyAssignedRoles(): void
+    {
+        $user = (new User())->setRoles(['ROLE_ADMIN']);
+
+        self::assertTrue($user->hasRole('ROLE_ADMIN'));
+        self::assertFalse($user->hasRole('ROLE_MODERATOR'));
+        // The implicit ROLE_USER from getRoles() is not visible to hasRole().
+        self::assertFalse($user->hasRole('ROLE_USER'));
+    }
+
+    #[Test]
+    public function oauthAccountsAreDetectedByProviderIds(): void
+    {
+        self::assertFalse((new User())->isOauthAccount());
+        self::assertTrue((new User())->setFacebookId('123')->isFacebookAccount());
+        self::assertTrue((new User())->setFacebookId('123')->isOauthAccount());
+        self::assertTrue((new User())->setStravaId('456')->isStravaAccount());
+        self::assertTrue((new User())->setStravaId('456')->isOauthAccount());
+    }
+
+    #[Test]
+    public function userIdentifierIsTheEmailNotTheUsername(): void
+    {
+        $user = (new User())->setUsername('malte')->setEmail('malte@example.org');
+
+        self::assertSame('malte@example.org', $user->getUserIdentifier());
+        self::assertSame('', (new User())->setUsername('malte')->getUserIdentifier());
+    }
+}

--- a/tests/Enum/EnumTest.php
+++ b/tests/Enum/EnumTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Enum;
+
+use App\Enum\PolylineResolution;
+use App\Enum\RideDisabledReasonEnum;
+use App\Enum\RideTypeEnum;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EnumTest extends TestCase
+{
+    #[Test]
+    public function rideTypeChoicesMapValuesToLabels(): void
+    {
+        $choices = RideTypeEnum::choices();
+
+        self::assertCount(count(RideTypeEnum::cases()), $choices);
+        self::assertSame('Critical Mass', $choices['CRITICAL_MASS']);
+        self::assertSame('Kidical Mass', $choices['KIDICAL_MASS']);
+
+        foreach (RideTypeEnum::cases() as $case) {
+            self::assertSame($case->label(), $choices[$case->value]);
+        }
+    }
+
+    #[Test]
+    public function disabledReasonChoicesMapValuesToLabels(): void
+    {
+        $choices = RideDisabledReasonEnum::choices();
+
+        self::assertCount(count(RideDisabledReasonEnum::cases()), $choices);
+        self::assertSame('diese Tour wurde abgesagt', $choices['CANCELLED']);
+
+        foreach (RideDisabledReasonEnum::cases() as $case) {
+            self::assertNotSame('', $case->label());
+        }
+    }
+
+    #[Test]
+    public function polylineResolutionsGetFinerWithSmallerTolerance(): void
+    {
+        self::assertGreaterThan(PolylineResolution::MEDIUM->tolerance(), PolylineResolution::COARSE->tolerance());
+        self::assertGreaterThan(PolylineResolution::FINE->tolerance(), PolylineResolution::MEDIUM->tolerance());
+
+        self::assertSame('100 m', PolylineResolution::COARSE->label());
+        self::assertSame('10 m', PolylineResolution::MEDIUM->label());
+        self::assertSame('2 m', PolylineResolution::FINE->label());
+    }
+
+    #[Test]
+    public function polylineResolutionValuesMatchTheirLabelsInMetres(): void
+    {
+        foreach (PolylineResolution::cases() as $case) {
+            self::assertSame(sprintf('%d m', $case->value), $case->label());
+        }
+    }
+}

--- a/tests/EventSubscriber/CorsEventSubscriberTest.php
+++ b/tests/EventSubscriber/CorsEventSubscriberTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\CorsEventSubscriber;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class CorsEventSubscriberTest extends TestCase
+{
+    private function dispatch(Request $request, ?Response $response = null): Response
+    {
+        $response ??= new Response('payload');
+
+        $event = new ResponseEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $response,
+        );
+
+        (new CorsEventSubscriber())->onResponse($event);
+
+        return $response;
+    }
+
+    #[Test]
+    public function subscribesToResponseEvent(): void
+    {
+        self::assertSame([KernelEvents::RESPONSE => 'onResponse'], CorsEventSubscriber::getSubscribedEvents());
+    }
+
+    #[Test]
+    public function addsCorsHeadersToApiGetRequests(): void
+    {
+        $response = $this->dispatch(Request::create('/api/city'));
+
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Origin'));
+        self::assertSame('GET, OPTIONS', $response->headers->get('Access-Control-Allow-Methods'));
+        self::assertSame('Content-Type', $response->headers->get('Access-Control-Allow-Headers'));
+        self::assertSame('3600', $response->headers->get('Access-Control-Max-Age'));
+        self::assertSame('payload', $response->getContent());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function preflightRequestsGetAnEmptyNoContentResponse(): void
+    {
+        $response = $this->dispatch(Request::create('/api/city', 'OPTIONS'));
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame('', $response->getContent());
+        self::assertSame('*', $response->headers->get('Access-Control-Allow-Origin'));
+    }
+
+    #[Test]
+    public function nonApiPathsAreLeftAlone(): void
+    {
+        $response = $this->dispatch(Request::create('/hamburg'));
+
+        self::assertFalse($response->headers->has('Access-Control-Allow-Origin'));
+    }
+
+    #[Test]
+    public function apiPrefixMustBeAFullPathSegment(): void
+    {
+        $response = $this->dispatch(Request::create('/apiary'));
+
+        self::assertFalse($response->headers->has('Access-Control-Allow-Origin'));
+    }
+
+    #[Test]
+    public function writingMethodsGetNoCorsHeaders(): void
+    {
+        foreach (['POST', 'PUT', 'DELETE', 'PATCH'] as $method) {
+            $response = $this->dispatch(Request::create('/api/city', $method));
+
+            self::assertFalse($response->headers->has('Access-Control-Allow-Origin'), $method);
+        }
+    }
+}

--- a/tests/EventSubscriber/KernelEventSubscriberTest.php
+++ b/tests/EventSubscriber/KernelEventSubscriberTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\SeoPage\SeoPageInterface;
+use App\EventSubscriber\KernelEventSubscriber;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class KernelEventSubscriberTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function httpUrls(): iterable
+    {
+        yield 'plain http' => ['http://criticalmass.in/hamburg', 'https://criticalmass.in/hamburg'];
+        yield 'www is stripped' => ['http://www.criticalmass.in/hamburg', 'https://criticalmass.in/hamburg'];
+        yield 'query string survives' => ['http://criticalmass.in/api/ride?citySlug=hamburg', 'https://criticalmass.in/api/ride?citySlug=hamburg'];
+    }
+
+    private function canonicalFor(string $uri): string
+    {
+        $canonical = null;
+
+        $seoPage = $this->createMock(SeoPageInterface::class);
+        $seoPage->expects(self::once())->method('setCanonicalLink')->willReturnCallback(
+            static function (string $link) use (&$canonical, $seoPage): SeoPageInterface {
+                $canonical = $link;
+
+                return $seoPage;
+            }
+        );
+
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static fn () => null,
+            Request::create($uri),
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+
+        (new KernelEventSubscriber($seoPage))->onController($event);
+
+        return (string) $canonical;
+    }
+
+    #[Test]
+    #[DataProvider('httpUrls')]
+    public function httpUrlIsUpgradedToHttpsWithoutWww(string $uri, string $expectedCanonical): void
+    {
+        self::assertSame($expectedCanonical, $this->canonicalFor($uri));
+    }
+
+    #[Test]
+    public function httpsUrlStaysHttps(): void
+    {
+        $canonical = $this->canonicalFor('https://www.criticalmass.in/hamburg');
+
+        if ('httpss://criticalmass.in/hamburg' === $canonical) {
+            self::markTestIncomplete(
+                'KernelEventSubscriber::generateCanonicalUrl() does str_replace("http", "https") and thereby '
+                .'turns an https request URI into "httpss://…" — every canonical link / og:url generated for '
+                .'an HTTPS request is broken.'
+            );
+        }
+
+        self::assertSame('https://criticalmass.in/hamburg', $canonical);
+    }
+
+    #[Test]
+    public function subRequestsDoNotTouchTheCanonicalLink(): void
+    {
+        $seoPage = $this->createMock(SeoPageInterface::class);
+        $seoPage->expects(self::never())->method('setCanonicalLink');
+
+        $event = new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static fn () => null,
+            Request::create('http://criticalmass.in/_fragment'),
+            HttpKernelInterface::SUB_REQUEST,
+        );
+
+        (new KernelEventSubscriber($seoPage))->onController($event);
+    }
+
+    #[Test]
+    public function subscribesToControllerEvent(): void
+    {
+        self::assertSame([KernelEvents::CONTROLLER => 'onController'], KernelEventSubscriber::getSubscribedEvents());
+    }
+}

--- a/tests/EventSubscriber/ParticipationEventSubscriberTest.php
+++ b/tests/EventSubscriber/ParticipationEventSubscriberTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Participation\Calculator\RideParticipationCalculator;
+use App\Entity\Participation;
+use App\Entity\Ride;
+use App\Event\Participation\ParticipationCreatedEvent;
+use App\Event\Participation\ParticipationDeletedEvent;
+use App\Event\Participation\ParticipationUpdatedEvent;
+use App\EventSubscriber\ParticipationEventSubscriber;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ParticipationEventSubscriberTest extends TestCase
+{
+    #[Test]
+    public function listensToAllThreeParticipationEvents(): void
+    {
+        self::assertSame([
+            'participation.created' => 'onParticipationCreated',
+            'participation.updated' => 'onParticipationUpdated',
+            'participation.deleted' => 'onParticipationDeleted',
+        ], ParticipationEventSubscriber::getSubscribedEvents());
+    }
+
+    #[Test]
+    public function everyEventRecalculatesTheRideOfTheParticipation(): void
+    {
+        $ride = new Ride();
+        $participation = (new Participation())->setRide($ride);
+
+        $calculator = $this->createMock(RideParticipationCalculator::class);
+        $calculator->expects(self::exactly(3))->method('setRide')->with($ride)->willReturnSelf();
+        $calculator->expects(self::exactly(3))->method('calculate')->willReturnSelf();
+
+        $subscriber = new ParticipationEventSubscriber($calculator);
+        $subscriber->onParticipationCreated(new ParticipationCreatedEvent($participation));
+        $subscriber->onParticipationUpdated(new ParticipationUpdatedEvent($participation));
+        $subscriber->onParticipationDeleted(new ParticipationDeletedEvent($participation));
+    }
+}

--- a/tests/EventSubscriber/ProfilePhotoEventSubscriberTest.php
+++ b/tests/EventSubscriber/ProfilePhotoEventSubscriberTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\ProfilePhotoGenerator\ProfilePhotoGenerator;
+use App\Entity\User;
+use App\Event\User\UserColorChangedEvent;
+use App\EventSubscriber\ProfilePhotoEventSubscriber;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ProfilePhotoEventSubscriberTest extends TestCase
+{
+    #[Test]
+    public function colorChangeRegeneratesGeneratedProfilePhoto(): void
+    {
+        $user = (new User())->setOwnProfilePhoto(false);
+
+        $generator = $this->createMock(ProfilePhotoGenerator::class);
+        $generator->expects(self::once())->method('setUser')->with($user)->willReturnSelf();
+        $generator->expects(self::once())->method('generate')->willReturn('avatar.png');
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        (new ProfilePhotoEventSubscriber($generator, $registry))->onUserColorChange(new UserColorChangedEvent($user));
+    }
+
+    #[Test]
+    public function colorChangeKeepsUploadedProfilePhoto(): void
+    {
+        $user = (new User())->setOwnProfilePhoto(true);
+
+        $generator = $this->createMock(ProfilePhotoGenerator::class);
+        $generator->expects(self::never())->method('generate');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects(self::never())->method('getManager');
+
+        (new ProfilePhotoEventSubscriber($generator, $registry))->onUserColorChange(new UserColorChangedEvent($user));
+    }
+
+    #[Test]
+    public function subscribesToColorChangeEvent(): void
+    {
+        self::assertSame('onUserColorChange', ProfilePhotoEventSubscriber::getSubscribedEvents()[UserColorChangedEvent::NAME]);
+    }
+}

--- a/tests/EventSubscriber/RideEstimateEventSubscriberTest.php
+++ b/tests/EventSubscriber/RideEstimateEventSubscriberTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Statistic\RideEstimateHandler\RideEstimateHandler;
+use App\Entity\Ride;
+use App\Entity\RideEstimate;
+use App\Event\RideEstimate\RideEstimateCreatedEvent;
+use App\Event\RideEstimate\RideEstimateDeletedEvent;
+use App\Event\RideEstimate\RideEstimateUpdatedEvent;
+use App\EventSubscriber\RideEstimateEventSubscriber;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class RideEstimateEventSubscriberTest extends TestCase
+{
+    private MockObject&RideEstimateHandler $handler;
+    private RideEstimateEventSubscriber $subscriber;
+    private RideEstimate $estimate;
+    private Ride $ride;
+
+    protected function setUp(): void
+    {
+        $this->ride = new Ride();
+        $this->estimate = (new RideEstimate())->setRide($this->ride);
+
+        $this->handler = $this->createMock(RideEstimateHandler::class);
+        $this->handler->method('setRide')->willReturnSelf();
+        $this->handler->method('flushEstimates')->willReturnSelf();
+        $this->handler->method('calculateEstimates')->willReturnSelf();
+
+        $this->subscriber = new RideEstimateEventSubscriber($this->createMock(ManagerRegistry::class), $this->handler);
+    }
+
+    #[Test]
+    public function createdEstimateOnlyRecalculates(): void
+    {
+        $this->handler->expects(self::once())->method('setRide')->with($this->ride);
+        $this->handler->expects(self::never())->method('flushEstimates');
+        $this->handler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onRideEstimateCreated(new RideEstimateCreatedEvent($this->estimate));
+    }
+
+    #[Test]
+    public function updatedEstimateFlushesBeforeRecalculating(): void
+    {
+        $this->handler->expects(self::once())->method('flushEstimates');
+        $this->handler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onRideEstimateUpdated(new RideEstimateUpdatedEvent($this->estimate));
+    }
+
+    #[Test]
+    public function deletedEstimateFlushesBeforeRecalculating(): void
+    {
+        $this->handler->expects(self::once())->method('flushEstimates');
+        $this->handler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onRideEstimateDeleted(new RideEstimateDeletedEvent($this->estimate));
+    }
+
+    #[Test]
+    public function subscribesToEstimateEvents(): void
+    {
+        self::assertSame([
+            'ride_estimate.created' => 'onRideEstimateCreated',
+            'ride_estimate.updated' => 'onRideEstimateUpdated',
+            'ride_estimate.deleted' => 'onRideEstimateDeleted',
+        ], RideEstimateEventSubscriber::getSubscribedEvents());
+    }
+}

--- a/tests/EventSubscriber/SitemapEventSubscriberTest.php
+++ b/tests/EventSubscriber/SitemapEventSubscriberTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\City;
+use App\Entity\Ride;
+use App\EventSubscriber\SitemapEventSubscriber;
+use App\Repository\CityRepository;
+use App\Repository\RideRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Presta\SitemapBundle\Event\SitemapPopulateEvent;
+use Presta\SitemapBundle\Service\UrlContainerInterface;
+use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class SitemapEventSubscriberTest extends TestCase
+{
+    #[Test]
+    public function registersEveryRideAndCityInItsOwnSection(): void
+    {
+        $city = new City();
+        $ride = new Ride();
+
+        $cityRepository = $this->createMock(CityRepository::class);
+        $cityRepository->method('findCities')->willReturn([$city]);
+
+        $rideRepository = $this->createMock(RideRepository::class);
+        $rideRepository->method('findRides')->willReturn([$ride]);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturnMap([
+            [City::class, null, $cityRepository],
+            [Ride::class, null, $rideRepository],
+        ]);
+
+        $router = $this->createMock(ObjectRouterInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static fn (object $object): string => $object instanceof Ride ? 'https://criticalmass.in/hamburg/2024-05-31' : 'https://criticalmass.in/hamburg'
+        );
+
+        $added = [];
+        $urlContainer = $this->createMock(UrlContainerInterface::class);
+        $urlContainer->method('addUrl')->willReturnCallback(function (UrlConcrete $url, string $section) use (&$added): void {
+            $added[] = [$section, $url->getLoc()];
+        });
+
+        $event = new SitemapPopulateEvent($urlContainer, $this->createMock(UrlGeneratorInterface::class));
+
+        (new SitemapEventSubscriber($router, $registry))->populate($event);
+
+        self::assertSame([
+            ['ride', 'https://criticalmass.in/hamburg/2024-05-31'],
+            ['city', 'https://criticalmass.in/hamburg'],
+        ], $added);
+    }
+
+    #[Test]
+    public function subscribesToSitemapPopulateEvent(): void
+    {
+        self::assertSame([SitemapPopulateEvent::class => 'populate'], SitemapEventSubscriber::getSubscribedEvents());
+    }
+}

--- a/tests/EventSubscriber/TrackEventSubscriberTest.php
+++ b/tests/EventSubscriber/TrackEventSubscriberTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Criticalmass\Geo\GpxService\GpxServiceInterface;
+use App\Criticalmass\Participation\Manager\ParticipationManagerInterface;
+use App\Criticalmass\Statistic\RideEstimateConverter\RideEstimateConverterInterface;
+use App\Criticalmass\Statistic\RideEstimateHandler\RideEstimateHandler;
+use App\Entity\Ride;
+use App\Entity\RideEstimate;
+use App\Entity\Track;
+use App\Event\Track\TrackDeletedEvent;
+use App\Event\Track\TrackHiddenEvent;
+use App\Event\Track\TrackShownEvent;
+use App\Event\Track\TrackTimeEvent;
+use App\EventSubscriber\TrackEventSubscriber;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class TrackEventSubscriberTest extends TestCase
+{
+    private MockObject&GpxServiceInterface $gpxService;
+    private MockObject&ObjectManager $manager;
+    private MockObject&RideEstimateHandler $estimateHandler;
+    private MockObject&RideEstimateConverterInterface $estimateConverter;
+    private MockObject&ParticipationManagerInterface $participationManager;
+    private TrackEventSubscriber $subscriber;
+    private Ride $ride;
+
+    protected function setUp(): void
+    {
+        $this->ride = new Ride();
+
+        $this->gpxService = $this->createMock(GpxServiceInterface::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+        $this->estimateHandler = $this->createMock(RideEstimateHandler::class);
+        $this->estimateHandler->method('setRide')->willReturnSelf();
+        $this->estimateHandler->method('flushEstimates')->willReturnSelf();
+        $this->estimateHandler->method('calculateEstimates')->willReturnSelf();
+        $this->estimateConverter = $this->createMock(RideEstimateConverterInterface::class);
+        $this->participationManager = $this->createMock(ParticipationManagerInterface::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        $this->subscriber = new TrackEventSubscriber(
+            $this->gpxService,
+            $registry,
+            $this->estimateHandler,
+            $this->estimateConverter,
+            $this->participationManager,
+        );
+    }
+
+    #[Test]
+    public function hidingATrackRemovesItsEstimateAndRecalculatesTheRide(): void
+    {
+        $estimate = new RideEstimate();
+        $track = (new Track())->setRide($this->ride)->setRideEstimate($estimate);
+
+        $this->manager->expects(self::once())->method('remove')->with($estimate);
+        $this->manager->expects(self::atLeastOnce())->method('flush');
+        $this->estimateHandler->expects(self::once())->method('setRide')->with($this->ride);
+        $this->estimateHandler->expects(self::once())->method('flushEstimates');
+        $this->estimateHandler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onTrackHidden(new TrackHiddenEvent($track));
+
+        self::assertNull($track->getRideEstimate());
+    }
+
+    #[Test]
+    public function deletingATrackWithoutEstimateDoesNotRemoveAnything(): void
+    {
+        $track = (new Track())->setRide($this->ride);
+
+        $this->manager->expects(self::never())->method('remove');
+        $this->estimateHandler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onTrackDeleted(new TrackDeletedEvent($track));
+    }
+
+    #[Test]
+    public function showingATrackAddsAnEstimateFromIt(): void
+    {
+        $track = (new Track())->setRide($this->ride);
+
+        $this->estimateConverter->expects(self::once())->method('addEstimateFromTrack')->with($track)->willReturnSelf();
+        $this->estimateHandler->expects(self::once())->method('setRide')->with($this->ride);
+        $this->estimateHandler->expects(self::never())->method('flushEstimates');
+        $this->estimateHandler->expects(self::once())->method('calculateEstimates');
+
+        $this->subscriber->onTrackShown(new TrackShownEvent($track));
+    }
+
+    #[Test]
+    public function timeChangeUpdatesStartAndEndFromGpx(): void
+    {
+        $track = (new Track())->setRide($this->ride);
+        $start = new \DateTime('2024-05-31 19:00:00');
+        $end = new \DateTime('2024-05-31 21:00:00');
+
+        $this->gpxService->method('getStartDateTime')->with($track)->willReturn($start);
+        $this->gpxService->method('getEndDateTime')->with($track)->willReturn($end);
+        $this->manager->expects(self::once())->method('flush');
+
+        $this->subscriber->onTrackTime(new TrackTimeEvent($track));
+
+        self::assertEquals($start, $track->getStartDateTime());
+        self::assertEquals($end, $track->getEndDateTime());
+    }
+
+    #[Test]
+    public function timeChangeKeepsExistingValuesWhenGpxHasNone(): void
+    {
+        $start = new \DateTime('2024-05-31 19:00:00');
+        $track = (new Track())->setRide($this->ride);
+        $track->setStartDateTime($start);
+
+        $this->gpxService->method('getStartDateTime')->willReturn(null);
+        $this->gpxService->method('getEndDateTime')->willReturn(null);
+
+        $this->subscriber->onTrackTime(new TrackTimeEvent($track));
+
+        self::assertSame($start, $track->getStartDateTime());
+        self::assertNull($track->getEndDateTime());
+    }
+
+    #[Test]
+    public function subscribesToAllTrackEvents(): void
+    {
+        $events = TrackEventSubscriber::getSubscribedEvents();
+
+        self::assertSame([
+            'track.deleted', 'track.hidden', 'track.shown', 'track.time', 'track.trimmed', 'track.updated', 'track.uploaded',
+        ], array_keys($events));
+    }
+}

--- a/tests/Form/Type/CityCycleTypeTest.php
+++ b/tests/Form/Type/CityCycleTypeTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Form\Type;
+
+use App\Entity\City;
+use App\Entity\CityCycle;
+use App\Form\Type\CityCycleType;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+final class CityCycleTypeTest extends TypeTestCase
+{
+    private function cycle(?string $calculatorFqcn = null): CityCycle
+    {
+        $city = (new City())->setCity('Hamburg')->setTimezone('Europe/Berlin');
+
+        return (new CityCycle())->setCity($city)->setRideCalculatorFqcn($calculatorFqcn);
+    }
+
+    #[Test]
+    public function regularCyclesChooseDayAndWeek(): void
+    {
+        $cycle = $this->cycle();
+        $form = $this->factory->create(CityCycleType::class, $cycle);
+
+        self::assertInstanceOf(ChoiceType::class, $form->get('dayOfWeek')->getConfig()->getType()->getInnerType());
+        self::assertSame(['Montag' => 1, 'Dienstag' => 2, 'Mittwoch' => 3, 'Donnerstag' => 4, 'Freitag' => 5, 'Sonnabend' => 6, 'Sonntag' => 0], $form->get('dayOfWeek')->getConfig()->getOption('choices'));
+        self::assertSame(0, $form->get('weekOfMonth')->getConfig()->getOption('choices')['Letzte Woche im Monat']);
+
+        $form->submit([
+            'dayOfWeek' => '5',
+            'weekOfMonth' => '0',
+            'location' => 'Rathausmarkt',
+            'time' => '17:00',
+            'validFrom' => '2024-01-01',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame(5, $cycle->getDayOfWeek());
+        self::assertSame(0, $cycle->getWeekOfMonth());
+        self::assertSame('Rathausmarkt', $cycle->getLocation());
+        self::assertSame('17:00', $cycle->getTime()->format('H:i'));
+        self::assertSame('2024-01-01', $cycle->getValidFrom()->format('Y-m-d'));
+        self::assertNull($cycle->getValidUntil());
+    }
+
+    #[Test]
+    public function calculatedCyclesShowReadOnlyDayAndWeek(): void
+    {
+        $cycle = $this->cycle('App\\Criticalmass\\RideGenerator\\SomeCalculator')
+            ->setSpecialDayOfWeek('third thursday')
+            ->setSpecialWeekOfMonth('n/a');
+        $form = $this->factory->create(CityCycleType::class, $cycle);
+
+        self::assertInstanceOf(TextType::class, $form->get('dayOfWeek')->getConfig()->getType()->getInnerType());
+        self::assertTrue($form->get('dayOfWeek')->isDisabled());
+        self::assertTrue($form->get('weekOfMonth')->isDisabled());
+        self::assertSame('third thursday', $form->get('dayOfWeek')->getData());
+        self::assertSame('n/a', $form->get('weekOfMonth')->getData());
+    }
+}

--- a/tests/Form/Type/RideTypeTest.php
+++ b/tests/Form/Type/RideTypeTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Form\Type;
+
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Enum\RideTypeEnum;
+use App\Form\Type\RideType;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class RideTypeTest extends TypeTestCase
+{
+    /** @var list<string> */
+    private array $roles = ['ROLE_USER'];
+
+    protected function getExtensions(): array
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getRoleNames')->willReturnCallback(fn (): array => $this->roles);
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        return [new PreloadedExtension([new RideType($tokenStorage)], [])];
+    }
+
+    private function ride(bool $enabled = true): Ride
+    {
+        $city = (new City())->setCity('Hamburg')->setTimezone('Europe/Berlin');
+
+        return (new Ride())->setCity($city)->setEnabled($enabled)->setDateTime(new \DateTime('2024-05-31 17:00:00', new \DateTimeZone('UTC')));
+    }
+
+    #[Test]
+    public function regularUsersCannotEditTheSlug(): void
+    {
+        $form = $this->factory->create(RideType::class, $this->ride());
+
+        self::assertFalse($form->has('slug'));
+        self::assertFalse($form->has('enabled'));
+        self::assertTrue($form->has('save'));
+    }
+
+    #[Test]
+    public function adminsGetASlugField(): void
+    {
+        $this->roles = ['ROLE_USER', 'ROLE_ADMIN'];
+
+        $form = $this->factory->create(RideType::class, $this->ride());
+
+        self::assertTrue($form->has('slug'));
+    }
+
+    #[Test]
+    public function disabledRidesOfferAnEnabledCheckbox(): void
+    {
+        $form = $this->factory->create(RideType::class, $this->ride(false));
+
+        self::assertTrue($form->has('enabled'));
+    }
+
+    #[Test]
+    public function dateTimeIsEnteredInCityTimezoneAndStoredInUtc(): void
+    {
+        $ride = $this->ride();
+        $form = $this->factory->create(RideType::class, $ride);
+
+        self::assertSame('Europe/Berlin', $form->get('dateTime')->getConfig()->getOption('view_timezone'));
+        self::assertSame('UTC', $form->get('dateTime')->getConfig()->getOption('model_timezone'));
+
+        // 17:00 UTC is 19:00 in Berlin during DST.
+        self::assertSame('19:00', $form->get('dateTime')->get('time')->getViewData());
+
+        $form->submit([
+            'title' => 'Critical Mass Hamburg',
+            'dateTime' => ['date' => '2024-06-28', 'time' => '19:30'],
+            'rideType' => 'CRITICAL_MASS',
+            'latitude' => '53.55',
+            'longitude' => '9.99',
+        ]);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('Critical Mass Hamburg', $ride->getTitle());
+        self::assertSame(RideTypeEnum::CRITICAL_MASS, $ride->getRideType());
+        self::assertSame('2024-06-28 17:30:00', $ride->getDateTime()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'));
+        self::assertSame(53.55, $ride->getLatitude());
+        self::assertSame(9.99, $ride->getLongitude());
+    }
+
+    #[Test]
+    public function unknownRideTypeIsRejected(): void
+    {
+        $form = $this->factory->create(RideType::class, $this->ride());
+
+        $form->submit(['title' => 'x', 'dateTime' => ['date' => '2024-06-28', 'time' => '19:30'], 'rideType' => 'PARTY']);
+
+        self::assertFalse($form->get('rideType')->isSynchronized());
+    }
+}

--- a/tests/Form/Type/SimpleFormTypesTest.php
+++ b/tests/Form/Type/SimpleFormTypesTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Form\Type;
+
+use App\Enum\RideDisabledReasonEnum;
+use App\Form\Type\LoginType;
+use App\Form\Type\PhotoCoordType;
+use App\Form\Type\PostType;
+use App\Form\Type\ProfileColorType;
+use App\Form\Type\RideDisableType;
+use App\Form\Type\RideEstimateType;
+use App\Form\Type\TrackRangeType;
+use App\Form\Type\UsernameType;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+final class SimpleFormTypesTest extends TypeTestCase
+{
+    #[Test]
+    public function loginFormAsksForEmailAndSubmit(): void
+    {
+        $form = $this->factory->create(LoginType::class);
+
+        self::assertInstanceOf(EmailType::class, $form->get('email')->getConfig()->getType()->getInnerType());
+        self::assertInstanceOf(SubmitType::class, $form->get('submit')->getConfig()->getType()->getInnerType());
+        self::assertSame('E-Mail-Adresse', $form->get('email')->getConfig()->getOption('label'));
+
+        $form->submit(['email' => 'malte@example.org']);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('malte@example.org', $form->getData()['email']);
+    }
+
+    #[Test]
+    public function postMessageIsOptional(): void
+    {
+        $form = $this->factory->create(PostType::class);
+
+        self::assertFalse($form->get('message')->isRequired());
+
+        $form->submit(['message' => '']);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertNull($form->getData()['message']);
+    }
+
+    #[Test]
+    public function rideEstimateRequiresParticipants(): void
+    {
+        $form = $this->factory->create(RideEstimateType::class);
+
+        self::assertTrue($form->get('estimatedParticipants')->isRequired());
+
+        $form->submit(['estimatedParticipants' => '250']);
+
+        self::assertSame('250', $form->getData()['estimatedParticipants']);
+    }
+
+    #[Test]
+    public function rideDisableMapsReasonToEnum(): void
+    {
+        $form = $this->factory->create(RideDisableType::class);
+
+        self::assertTrue($form->get('disabledReason')->getConfig()->getOption('expanded'));
+        self::assertFalse($form->get('disabledReasonMessage')->isRequired());
+
+        $form->submit(['disabledReason' => 'CANCELLED_WEATHER', 'disabledReasonMessage' => 'Sturm']);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame(RideDisabledReasonEnum::CANCELLED_WEATHER, $form->getData()['disabledReason']);
+        self::assertSame('Sturm', $form->getData()['disabledReasonMessage']);
+    }
+
+    #[Test]
+    public function rideDisableRejectsUnknownReason(): void
+    {
+        $form = $this->factory->create(RideDisableType::class);
+
+        $form->submit(['disabledReason' => 'NOT_A_REASON']);
+
+        self::assertFalse($form->get('disabledReason')->isSynchronized());
+    }
+
+    #[Test]
+    public function trackRangeConsistsOfHiddenFieldsOnly(): void
+    {
+        $form = $this->factory->create(TrackRangeType::class);
+
+        foreach (['startPoint', 'endPoint', 'points', 'polyline', 'reducedPolyline'] as $field) {
+            self::assertInstanceOf(HiddenType::class, $form->get($field)->getConfig()->getType()->getInnerType(), $field);
+        }
+
+        $form->submit(['startPoint' => '10', 'endPoint' => '200', 'points' => '250', 'polyline' => 'abc', 'reducedPolyline' => 'ab']);
+
+        self::assertSame(['startPoint' => '10', 'endPoint' => '200', 'points' => '250', 'polyline' => 'abc', 'reducedPolyline' => 'ab'], $form->getData());
+    }
+
+    #[Test]
+    public function photoCoordinatesAreHiddenLatitudeAndLongitude(): void
+    {
+        $form = $this->factory->create(PhotoCoordType::class);
+
+        self::assertInstanceOf(HiddenType::class, $form->get('latitude')->getConfig()->getType()->getInnerType());
+        self::assertInstanceOf(HiddenType::class, $form->get('longitude')->getConfig()->getType()->getInnerType());
+
+        $form->submit(['latitude' => '53.55', 'longitude' => '9.99']);
+
+        self::assertSame(['latitude' => '53.55', 'longitude' => '9.99'], $form->getData());
+    }
+
+    #[Test]
+    public function profileColorAcceptsHexColors(): void
+    {
+        $form = $this->factory->create(ProfileColorType::class);
+
+        self::assertSame('Profilfarbe wählen', $form->get('color')->getConfig()->getOption('label'));
+
+        $form->submit(['color' => '#ff8800']);
+
+        self::assertTrue($form->isSynchronized());
+        self::assertSame('#ff8800', $form->getData()['color']);
+    }
+
+    #[Test]
+    public function usernameFormHasASingleTextField(): void
+    {
+        $form = $this->factory->create(UsernameType::class);
+
+        self::assertSame(['username'], array_keys($form->all()));
+
+        $form->submit(['username' => 'malte']);
+
+        self::assertSame('malte', $form->getData()['username']);
+    }
+}

--- a/tests/Participation/ParticipationCityListFactoryTest.php
+++ b/tests/Participation/ParticipationCityListFactoryTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Participation;
+
+use App\Criticalmass\Participation\CityList\ParticipationCityListFactory;
+use App\Entity\City;
+use App\Entity\Participation;
+use App\Entity\Ride;
+use App\Entity\User;
+use App\Repository\ParticipationRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ParticipationCityListFactoryTest extends TestCase
+{
+    private function city(int $id, string $name): City
+    {
+        return (new City())->setId($id)->setCity($name);
+    }
+
+    /**
+     * @param list<City> $cities one entry per participation
+     */
+    private function factory(array $cities): ParticipationCityListFactory
+    {
+        $participations = array_map(
+            static fn (City $city): Participation => (new Participation())->setRide((new Ride())->setCity($city)),
+            $cities
+        );
+
+        $repository = $this->createMock(ParticipationRepository::class);
+        $repository->method('findByUser')->willReturn($participations);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Participation::class)->willReturn($repository);
+
+        return new ParticipationCityListFactory($registry);
+    }
+
+    #[Test]
+    public function participationsAreCountedPerCity(): void
+    {
+        $hamburg = $this->city(1, 'Hamburg');
+        $berlin = $this->city(2, 'Berlin');
+
+        $list = $this->factory([$hamburg, $berlin, $hamburg])->buildForUser(new User())->getParticipationCityList();
+
+        self::assertSame(2, $list->count());
+        self::assertSame(2, $list->getList()[1]->getCounter());
+        self::assertSame(1, $list->getList()[2]->getCounter());
+    }
+
+    #[Test]
+    public function sortOrdersByCounterDescendingThenCityNameAscending(): void
+    {
+        $hamburg = $this->city(1, 'Hamburg');
+        $berlin = $this->city(2, 'Berlin');
+        $aachen = $this->city(3, 'Aachen');
+        $zwickau = $this->city(4, 'Zwickau');
+
+        $list = $this->factory([$zwickau, $hamburg, $berlin, $aachen, $zwickau, $berlin])
+            ->buildForUser(new User())
+            ->sort()
+            ->getParticipationCityList();
+
+        $names = array_map(static fn ($item): string => $item->getCity()->getCity(), $list->getList());
+
+        self::assertSame(['Berlin', 'Zwickau', 'Aachen', 'Hamburg'], $names);
+    }
+
+    #[Test]
+    public function userWithoutParticipationsGetsAnEmptyList(): void
+    {
+        $list = $this->factory([])->buildForUser(new User())->sort()->getParticipationCityList();
+
+        self::assertSame(0, $list->count());
+        self::assertSame([], $list->getList());
+    }
+}

--- a/tests/Participation/ParticipationManagerTest.php
+++ b/tests/Participation/ParticipationManagerTest.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Participation;
+
+use App\Criticalmass\Participation\Manager\ParticipationManager;
+use App\Entity\Participation;
+use App\Entity\Ride;
+use App\Entity\User;
+use App\Event\Participation\ParticipationCreatedEvent;
+use App\Repository\ParticipationRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class ParticipationManagerTest extends TestCase
+{
+    private User $user;
+    private Ride $ride;
+    private MockObject&ParticipationRepository $repository;
+    private MockObject&ObjectManager $manager;
+    private MockObject&EventDispatcherInterface $dispatcher;
+    private ParticipationManager $participationManager;
+
+    protected function setUp(): void
+    {
+        $this->user = new User();
+        $this->ride = new Ride();
+
+        $this->repository = $this->createMock(ParticipationRepository::class);
+        $this->manager = $this->createMock(ObjectManager::class);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Participation::class)->willReturn($this->repository);
+        $registry->method('getManager')->willReturn($this->manager);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($this->user);
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        $this->participationManager = new ParticipationManager($registry, $tokenStorage, $this->dispatcher);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool, 2: bool, 3: bool}>
+     */
+    public static function statuses(): iterable
+    {
+        yield 'yes' => ['yes', true, false, false];
+        yield 'maybe' => ['maybe', false, true, false];
+        yield 'no' => ['no', false, false, true];
+        yield 'unknown status clears everything' => ['perhaps', false, false, false];
+    }
+
+    #[Test]
+    #[DataProvider('statuses')]
+    public function createsParticipationForCurrentUserWithGivenStatus(string $status, bool $yes, bool $maybe, bool $no): void
+    {
+        $this->repository->method('findParticipationForUserAndRide')->with($this->user, $this->ride)->willReturn(null);
+        $this->manager->expects(self::once())->method('persist')->with(self::isInstanceOf(Participation::class));
+        $this->manager->expects(self::once())->method('flush');
+
+        $participation = $this->participationManager->participate($this->ride, $status);
+
+        self::assertSame($this->ride, $participation->getRide());
+        self::assertSame($this->user, $participation->getUser());
+        self::assertSame($yes, $participation->getGoingYes());
+        self::assertSame($maybe, $participation->getGoingMaybe());
+        self::assertSame($no, $participation->getGoingNo());
+    }
+
+    #[Test]
+    public function updatesExistingParticipationInsteadOfCreatingANewOne(): void
+    {
+        $existing = (new Participation())->setRide($this->ride)->setUser($this->user)->setGoingYes(true)->setGoingMaybe(false)->setGoingNo(false);
+        $this->repository->method('findParticipationForUserAndRide')->willReturn($existing);
+
+        $participation = $this->participationManager->participate($this->ride, 'no');
+
+        self::assertSame($existing, $participation);
+        self::assertFalse($participation->getGoingYes());
+        self::assertTrue($participation->getGoingNo());
+    }
+
+    #[Test]
+    public function dispatchesCreatedEventAfterFlushing(): void
+    {
+        $this->repository->method('findParticipationForUserAndRide')->willReturn(null);
+
+        $this->dispatcher->expects(self::once())
+            ->method('dispatch')
+            ->with(self::isInstanceOf(ParticipationCreatedEvent::class), ParticipationCreatedEvent::NAME)
+            ->willReturnArgument(0);
+
+        $this->participationManager->participate($this->ride, 'yes');
+    }
+}

--- a/tests/Participation/RideParticipationCalculatorTest.php
+++ b/tests/Participation/RideParticipationCalculatorTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Participation;
+
+use App\Criticalmass\Participation\Calculator\RideParticipationCalculator;
+use App\Entity\Participation;
+use App\Entity\Ride;
+use App\Repository\ParticipationRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RideParticipationCalculatorTest extends TestCase
+{
+    #[Test]
+    public function storesCountsPerStatusOnTheRideAndFlushes(): void
+    {
+        $ride = new Ride();
+
+        $repository = $this->createMock(ParticipationRepository::class);
+        $repository->method('countParticipationsForRide')->willReturnCallback(
+            static fn (Ride $r, string $status): int => match ($status) {
+                'yes' => 12,
+                'maybe' => 3,
+                'no' => 1,
+                default => throw new \LogicException('unexpected status ' . $status),
+            }
+        );
+
+        $manager = $this->createMock(ObjectManager::class);
+        $manager->expects(self::once())->method('flush');
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Participation::class)->willReturn($repository);
+        $registry->method('getManager')->willReturn($manager);
+
+        $calculator = (new RideParticipationCalculator($registry))->setRide($ride);
+
+        self::assertSame($calculator, $calculator->calculate());
+        self::assertSame(12, $ride->getParticipationsNumberYes());
+        self::assertSame(3, $ride->getParticipationsNumberMaybe());
+        self::assertSame(1, $ride->getParticipationsNumberNo());
+    }
+}

--- a/tests/RideNamer/CountingRideNamerTest.php
+++ b/tests/RideNamer/CountingRideNamerTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Tests\RideNamer;
+
+use App\Criticalmass\RideNamer\CountingEnglishRideNamer;
+use App\Criticalmass\RideNamer\CountingGermanRideNamer;
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CountingRideNamerTest extends TestCase
+{
+    private function registry(int $existingRides): ManagerRegistry
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('countRidesByCity')->willReturn($existingRides);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Ride::class)->willReturn($repository);
+
+        return $registry;
+    }
+
+    private function ride(): Ride
+    {
+        $city = (new City())->setCity('Hamburg');
+        $city->setTitle('Critical Mass Hamburg');
+
+        return (new Ride())->setCity($city);
+    }
+
+    /**
+     * @return iterable<string, array{0: int, 1: string, 2: string}>
+     */
+    public static function counts(): iterable
+    {
+        yield 'first ride' => [0, '1. Critical Mass Hamburg', '1th Critical Mass Hamburg'];
+        yield 'second ride' => [1, '2. Critical Mass Hamburg', '2th Critical Mass Hamburg'];
+        yield 'hundredth ride' => [99, '100. Critical Mass Hamburg', '100th Critical Mass Hamburg'];
+    }
+
+    #[Test]
+    #[DataProvider('counts')]
+    public function titleIsTheNextOrdinalOfTheCityTitle(int $existingRides, string $german, string $english): void
+    {
+        $registry = $this->registry($existingRides);
+
+        // The English namer always appends "th" (no 1st/2nd/3rd handling) — pinned here as-is.
+        self::assertSame($german, (new CountingGermanRideNamer($registry))->generateTitle($this->ride()));
+        self::assertSame($english, (new CountingEnglishRideNamer($registry))->generateTitle($this->ride()));
+    }
+
+    #[Test]
+    public function countIsTakenFromTheRideCity(): void
+    {
+        $ride = $this->ride();
+
+        $repository = $this->createMock(RideRepository::class);
+        $repository->expects(self::once())->method('countRidesByCity')->with($ride->getCity())->willReturn(4);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturn($repository);
+
+        self::assertSame('5. Critical Mass Hamburg', (new CountingGermanRideNamer($registry))->generateTitle($ride));
+    }
+}

--- a/tests/Router/DelegatedRouterTest.php
+++ b/tests/Router/DelegatedRouterTest.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Router;
+
+use App\Criticalmass\Router\DelegatedRouter\BoardRouter;
+use App\Criticalmass\Router\DelegatedRouter\RegionRouter;
+use App\Criticalmass\Router\DelegatedRouter\RideRouter;
+use App\Criticalmass\Router\DelegatedRouter\ThreadRouter;
+use App\Criticalmass\Router\DelegatedRouterManager\DelegatedRouterManager;
+use App\Criticalmass\Router\ObjectRouter;
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Criticalmass\Router\ParameterResolver\ClassParameterResolver;
+use App\Criticalmass\Router\ParameterResolver\PropertyParameterResolver;
+use App\Entity\Board;
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Photo;
+use App\Entity\Region;
+use App\Entity\Ride;
+use App\Entity\Thread;
+use App\Entity\Track;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Tests\Support\EntityIdHelper;
+use Tests\Support\StubRouter;
+
+final class DelegatedRouterTest extends TestCase
+{
+    private StubRouter $router;
+    private ClassParameterResolver $classResolver;
+    private PropertyParameterResolver $propertyResolver;
+    private DelegatedRouterManager $manager;
+    private ObjectRouter $objectRouter;
+
+    protected function setUp(): void
+    {
+        $this->router = new StubRouter([
+            'caldera_criticalmass_city_show' => '/{citySlug}',
+            'caldera_criticalmass_ride_show' => '/{citySlug}/{rideIdentifier}',
+            'caldera_criticalmass_photo_show_ride' => '/{citySlug}/{rideIdentifier}/photo/{id}',
+            'caldera_criticalmass_track_view' => '/track/{id}',
+            'caldera_criticalmass_board_listthreads' => '/boards/{boardSlug}',
+            'caldera_criticalmass_board_listcitythreads' => '/{citySlug}/listthreads',
+            'caldera_criticalmass_board_viewthread' => '/boards/{boardSlug}/thread/{threadSlug}',
+            'caldera_criticalmass_board_viewcitythread' => '/{citySlug}/thread/{threadSlug}',
+            'caldera_criticalmass_region_world' => '/world',
+            'caldera_criticalmass_region_world_region_1' => '/world/{slug1}',
+            'caldera_criticalmass_region_world_region_2' => '/world/{slug1}/{slug2}',
+            'caldera_criticalmass_region_world_region_3' => '/world/{slug1}/{slug2}/{slug3}',
+        ]);
+
+        $this->manager = new DelegatedRouterManager();
+        $this->classResolver = new ClassParameterResolver(new ParameterBag());
+        $this->propertyResolver = new PropertyParameterResolver($this->manager, $this->classResolver);
+
+        foreach ([RideRouter::class, ThreadRouter::class, BoardRouter::class, RegionRouter::class] as $routerClass) {
+            $this->manager->addDelegatedRouter(new $routerClass($this->router, $this->classResolver, $this->propertyResolver));
+        }
+
+        $this->objectRouter = new ObjectRouter($this->router, $this->classResolver, $this->propertyResolver, $this->manager);
+    }
+
+    private function city(string $slug): City
+    {
+        $city = new City();
+        $city->setMainSlug((new CitySlug())->setSlug($slug)->setCity($city));
+
+        return $city;
+    }
+
+    #[Test]
+    public function cityUsesItsDefaultRouteAndMainSlug(): void
+    {
+        self::assertSame('/hamburg', $this->objectRouter->generate($this->city('hamburg')));
+        self::assertSame('https://criticalmass.in/hamburg', $this->objectRouter->generate($this->city('hamburg'), null, [], UrlGeneratorInterface::ABSOLUTE_URL));
+    }
+
+    #[Test]
+    public function rideWithoutSlugIsAddressedByDate(): void
+    {
+        $ride = (new Ride())->setCity($this->city('hamburg'))->setDateTime(new \DateTime('2024-05-31 19:00:00'));
+
+        self::assertSame('/hamburg/2024-05-31', $this->objectRouter->generate($ride));
+    }
+
+    #[Test]
+    public function rideWithSlugPrefersTheSlug(): void
+    {
+        $ride = (new Ride())->setCity($this->city('hamburg'))->setDateTime(new \DateTime('2024-05-31'))->setSlug('kidical-mass');
+
+        self::assertSame('/hamburg/kidical-mass', $this->objectRouter->generate($ride));
+    }
+
+    #[Test]
+    public function rideRouterResolvesRideIdentifierAndFallsBackForOtherParameters(): void
+    {
+        $rideRouter = new RideRouter($this->router, $this->classResolver, $this->propertyResolver);
+        $ride = (new Ride())->setCity($this->city('berlin'))->setDateTime(new \DateTime('2024-05-31'));
+
+        self::assertSame('2024-05-31', $rideRouter->getRouteParameter($ride, 'rideIdentifier'));
+        self::assertSame('berlin', $rideRouter->getRouteParameter($ride, 'citySlug'));
+        self::assertNull($rideRouter->getRouteParameter($ride, 'unknown'));
+    }
+
+    #[Test]
+    public function extraParametersAreAppendedAsQueryString(): void
+    {
+        self::assertSame('/hamburg?page=2', $this->objectRouter->generate($this->city('hamburg'), null, ['page' => 2]));
+    }
+
+    #[Test]
+    public function photoRouteCombinesCityRideAndId(): void
+    {
+        $city = $this->city('hamburg');
+        $ride = (new Ride())->setCity($city)->setDateTime(new \DateTime('2024-05-31'));
+        $photo = (new Photo())->setRide($ride)->setCity($city);
+        EntityIdHelper::setId($photo, 77);
+
+        self::assertSame('/hamburg/2024-05-31/photo/77', $this->objectRouter->generate($photo));
+    }
+
+    #[Test]
+    public function trackRouteUsesItsId(): void
+    {
+        $track = new Track();
+        EntityIdHelper::setId($track, 12);
+
+        self::assertSame('/track/12', $this->objectRouter->generate($track));
+    }
+
+    #[Test]
+    public function boardThreadsAndCityThreadsHaveDifferentRoutes(): void
+    {
+        $board = (new Board())->setSlug('general');
+
+        self::assertSame('/boards/general', $this->objectRouter->generate($board));
+
+        $boardRouter = new BoardRouter($this->router, $this->classResolver, $this->propertyResolver);
+        self::assertSame('/hamburg/listthreads', $boardRouter->generate($this->city('hamburg')));
+    }
+
+    #[Test]
+    public function threadRouteDependsOnWhetherItBelongsToACity(): void
+    {
+        $cityThread = (new Thread())->setSlug('meeting-point')->setCity($this->city('hamburg'));
+        $boardThread = (new Thread())->setSlug('rules')->setBoard((new Board())->setSlug('general'));
+
+        self::assertSame('/hamburg/thread/meeting-point', $this->objectRouter->generate($cityThread));
+        self::assertSame('/boards/general/thread/rules', $this->objectRouter->generate($boardThread));
+    }
+
+    #[Test]
+    public function regionRouteReflectsTheHierarchyDepth(): void
+    {
+        $world = (new Region())->setSlug('world');
+        $europe = (new Region())->setSlug('europe')->setParent($world);
+        $germany = (new Region())->setSlug('germany')->setParent($europe);
+        $north = (new Region())->setSlug('north')->setParent($germany);
+        $tooDeep = (new Region())->setSlug('deep')->setParent($north);
+
+        self::assertSame('/world', $this->objectRouter->generate($world));
+        self::assertSame('/world/europe', $this->objectRouter->generate($europe));
+        self::assertSame('/world/europe/germany', $this->objectRouter->generate($germany));
+        self::assertSame('/world/europe/germany/north', $this->objectRouter->generate($north));
+        self::assertSame('', $this->objectRouter->generate($tooDeep));
+    }
+
+    #[Test]
+    public function managerReturnsTheFirstSupportingRouterWiredToTheObjectRouter(): void
+    {
+        $manager = new DelegatedRouterManager();
+        $rideRouter = new RideRouter($this->router, $this->classResolver, $this->propertyResolver);
+        $manager->addDelegatedRouter($rideRouter);
+
+        $objectRouter = $this->createMock(ObjectRouterInterface::class);
+        $manager->setObjectRouter($objectRouter);
+
+        self::assertSame($rideRouter, $manager->findDelegatedRouter(new Ride()));
+        self::assertNull($manager->findDelegatedRouter(new City()));
+    }
+
+    #[Test]
+    public function delegatedRouterSupportIsDerivedFromItsClassName(): void
+    {
+        $rideRouter = new RideRouter($this->router, $this->classResolver, $this->propertyResolver);
+        $threadRouter = new ThreadRouter($this->router, $this->classResolver, $this->propertyResolver);
+
+        self::assertTrue($rideRouter->supports(new Ride()));
+        self::assertFalse($rideRouter->supports(new Thread()));
+        self::assertTrue($threadRouter->supports(new Thread()));
+        self::assertFalse($threadRouter->supports(new Ride()));
+    }
+
+    #[Test]
+    public function unknownRouteNameThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Route does_not_exist not found');
+
+        $this->objectRouter->generate($this->city('hamburg'), 'does_not_exist');
+    }
+
+    #[Test]
+    public function missingMandatoryParameterYieldsEmptyStringInsteadOfException(): void
+    {
+        // Ride without city → citySlug cannot be resolved → InvalidParameterException is swallowed.
+        $ride = (new Ride())->setDateTime(new \DateTime('2024-05-31'));
+
+        self::assertSame('', $this->objectRouter->generate($ride));
+    }
+}

--- a/tests/Router/ParameterResolverTest.php
+++ b/tests/Router/ParameterResolverTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Router;
+
+use App\Criticalmass\Router\Attribute\DefaultParameter;
+use App\Criticalmass\Router\Attribute\RouteParameter;
+use App\Criticalmass\Router\DelegatedRouterManager\DelegatedRouterManager;
+use App\Criticalmass\Router\ParameterResolver\ClassParameterResolver;
+use App\Criticalmass\Router\ParameterResolver\PropertyParameterResolver;
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\EntityInterface\RouteableInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+#[DefaultParameter(routeParameterName: 'citySlug', parameterName: 'app.default_city_slug')]
+final class RouteableWithDefaultParameter implements RouteableInterface
+{
+}
+
+final class RouteableWithDate implements RouteableInterface
+{
+    #[RouteParameter(name: 'year', dateFormat: 'Y')]
+    public \DateTime $when;
+
+    #[RouteParameter(name: 'label')]
+    public ?string $label = null;
+
+    public function __construct()
+    {
+        $this->when = new \DateTime('2024-05-31 19:00:00');
+    }
+}
+
+final class ParameterResolverTest extends TestCase
+{
+    private function propertyResolver(): PropertyParameterResolver
+    {
+        $classResolver = new ClassParameterResolver(new ParameterBag());
+
+        return new PropertyParameterResolver(new DelegatedRouterManager(), $classResolver);
+    }
+
+    #[Test]
+    public function resolvesScalarPropertiesByRouteParameterName(): void
+    {
+        $object = new RouteableWithDate();
+        $object->label = 'hello';
+
+        self::assertSame('hello', $this->propertyResolver()->resolve($object, 'label'));
+    }
+
+    #[Test]
+    public function formatsDateTimePropertiesWithTheConfiguredFormat(): void
+    {
+        try {
+            $value = $this->propertyResolver()->resolve(new RouteableWithDate(), 'year');
+        } catch (\Error $error) {
+            self::markTestIncomplete(
+                'PropertyParameterResolver calls ->getDateFormat() on the ReflectionAttribute instead of the '
+                .'RouteParameter instance, so any DateTime-typed route parameter crashes with: ' . $error->getMessage()
+            );
+        }
+
+        self::assertSame('2024', $value);
+    }
+
+    #[Test]
+    public function nullPropertyBecomesEmptyString(): void
+    {
+        self::assertSame('', $this->propertyResolver()->resolve(new RouteableWithDate(), 'label'));
+    }
+
+    #[Test]
+    public function unknownParameterNameResolvesToNull(): void
+    {
+        self::assertNull($this->propertyResolver()->resolve(new RouteableWithDate(), 'nope'));
+    }
+
+    #[Test]
+    public function walksNestedRouteableObjects(): void
+    {
+        $city = new City();
+        $city->setMainSlug((new CitySlug())->setSlug('hamburg')->setCity($city));
+        $ride = (new Ride())->setCity($city);
+
+        self::assertSame('hamburg', $this->propertyResolver()->resolve($ride, 'citySlug'));
+    }
+
+    #[Test]
+    public function classResolverReadsDefaultParameterFromTheParameterBag(): void
+    {
+        $resolver = new ClassParameterResolver(new ParameterBag(['app.default_city_slug' => 'hamburg']));
+
+        $value = $resolver->resolve(new RouteableWithDefaultParameter(), 'citySlug');
+
+        if (null === $value) {
+            self::markTestIncomplete(
+                'ClassParameterResolver::resolve() checks "$classAttribute instanceof DefaultParameter" on a '
+                .'ReflectionAttribute (never true, it would need ->newInstance() or ->getName()), so '
+                .'#[DefaultParameter] attributes are silently ignored and the resolver always returns null.'
+            );
+        }
+
+        self::assertSame('hamburg', $value);
+    }
+
+    #[Test]
+    public function classResolverIgnoresObjectsWithoutDefaultParameter(): void
+    {
+        $resolver = new ClassParameterResolver(new ParameterBag(['app.default_city_slug' => 'hamburg']));
+
+        self::assertNull($resolver->resolve(new RouteableWithDate(), 'citySlug'));
+    }
+}

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -3,9 +3,16 @@
 namespace Tests\Router;
 
 use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\Board;
 use App\Entity\City;
 use App\Entity\CitySlug;
+use App\Entity\Photo;
+use App\Entity\Region;
 use App\Entity\Ride;
+use App\Entity\Thread;
+use App\Entity\Track;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Tests\Support\EntityIdHelper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class RouterTest extends KernelTestCase
@@ -73,5 +80,75 @@ class RouterTest extends KernelTestCase
         $route = $this->getObjectRouter()->generate($city, 'caldera_criticalmass_city_show');
 
         $this->assertEquals('/hamburg', $route);
+    }
+
+    private function city(string $slug): City
+    {
+        $city = new City();
+        $city->setMainSlug((new CitySlug())->setSlug($slug)->setCity($city));
+
+        return $city;
+    }
+
+    public function testRideWithSlugUsesTheSlug(): void
+    {
+        $ride = (new Ride())->setCity($this->city('hamburg'))->setDateTime(new \DateTime('2024-05-31'))->setSlug('kidical-mass');
+
+        $this->assertEquals('/hamburg/kidical-mass', $this->getObjectRouter()->generate($ride));
+    }
+
+    public function testAbsoluteUrlUsesConfiguredHost(): void
+    {
+        $route = $this->getObjectRouter()->generate($this->city('hamburg'), null, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $this->assertStringEndsWith('/hamburg', $route);
+        $this->assertMatchesRegularExpression('#^https?://#', $route);
+    }
+
+    public function testPhotoRoute(): void
+    {
+        $city = $this->city('hamburg');
+        $ride = (new Ride())->setCity($city)->setDateTime(new \DateTime('2024-05-31'));
+        $photo = (new Photo())->setRide($ride)->setCity($city);
+        EntityIdHelper::setId($photo, 4711);
+
+        $this->assertEquals('/hamburg/2024-05-31/photo/4711', $this->getObjectRouter()->generate($photo));
+    }
+
+    public function testTrackRoute(): void
+    {
+        $track = new Track();
+        EntityIdHelper::setId($track, 12);
+
+        $this->assertEquals('/track/view/12', $this->getObjectRouter()->generate($track));
+    }
+
+    public function testCityThreadAndBoardThreadRoutes(): void
+    {
+        $cityThread = (new Thread())->setSlug('treffpunkt')->setCity($this->city('hamburg'));
+        $boardThread = (new Thread())->setSlug('regeln')->setBoard((new Board())->setSlug('allgemein'));
+
+        $this->assertEquals('/hamburg/thread/treffpunkt', $this->getObjectRouter()->generate($cityThread));
+        $this->assertEquals('/boards/allgemein/thread/regeln', $this->getObjectRouter()->generate($boardThread));
+    }
+
+    public function testBoardRoute(): void
+    {
+        $this->assertEquals('/boards/allgemein', $this->getObjectRouter()->generate((new Board())->setSlug('allgemein')));
+    }
+
+    public function testRegionRoutesFollowTheHierarchy(): void
+    {
+        $world = (new Region())->setSlug('world');
+        $europe = (new Region())->setSlug('europe')->setParent($world);
+        $germany = (new Region())->setSlug('germany')->setParent($europe);
+        $north = (new Region())->setSlug('north')->setParent($germany);
+
+        $router = $this->getObjectRouter();
+
+        $this->assertEquals('/world', $router->generate($world));
+        $this->assertEquals('/world/europe', $router->generate($europe));
+        $this->assertEquals('/world/europe/germany', $router->generate($germany));
+        $this->assertEquals('/world/europe/germany/north', $router->generate($north));
     }
 }

--- a/tests/Security/Voter/ParticipationVoterTest.php
+++ b/tests/Security/Voter/ParticipationVoterTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Voter;
+
+use App\Entity\Participation;
+use App\Entity\User;
+use App\Security\Authorization\Voter\ParticipationVoter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+final class ParticipationVoterTest extends TestCase
+{
+    private function token(?object $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function attributes(): iterable
+    {
+        yield 'cancel' => ['cancel'];
+        yield 'delete' => ['delete'];
+    }
+
+    #[Test]
+    #[DataProvider('attributes')]
+    public function ownerMayCancelAndDelete(string $attribute): void
+    {
+        $owner = new User();
+        $participation = (new Participation())->setUser($owner);
+
+        $result = (new ParticipationVoter())->vote($this->token($owner), $participation, [$attribute]);
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $result);
+    }
+
+    #[Test]
+    #[DataProvider('attributes')]
+    public function adminMayCancelAndDeleteForeignParticipation(string $attribute): void
+    {
+        $admin = (new User())->setRoles(['ROLE_ADMIN']);
+        $participation = (new Participation())->setUser(new User());
+
+        $result = (new ParticipationVoter())->vote($this->token($admin), $participation, [$attribute]);
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $result);
+    }
+
+    #[Test]
+    public function strangerIsDenied(): void
+    {
+        $participation = (new Participation())->setUser(new User());
+
+        $result = (new ParticipationVoter())->vote($this->token(new User()), $participation, ['cancel']);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $result);
+    }
+
+    #[Test]
+    public function anonymousTokenIsDenied(): void
+    {
+        $participation = (new Participation())->setUser(new User());
+
+        $result = (new ParticipationVoter())->vote($this->token(null), $participation, ['cancel']);
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $result);
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $owner = new User();
+        $participation = (new Participation())->setUser($owner);
+
+        $result = (new ParticipationVoter())->vote($this->token($owner), $participation, ['edit']);
+
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, $result);
+    }
+
+    #[Test]
+    public function attributesAreCaseSensitiveDespiteLowercasedMethodLookup(): void
+    {
+        // supports() compares against the lcfirst()ed can*() names, so an upper-case
+        // attribute never reaches voteOnAttribute() (which would have lower-cased it).
+        $owner = new User();
+        $participation = (new Participation())->setUser($owner);
+
+        $result = (new ParticipationVoter())->vote($this->token($owner), $participation, ['CANCEL']);
+
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, $result);
+    }
+
+    #[Test]
+    public function abstainsOnForeignSubject(): void
+    {
+        $owner = new User();
+
+        $result = (new ParticipationVoter())->vote($this->token($owner), new \stdClass(), ['cancel']);
+
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, $result);
+    }
+}

--- a/tests/Security/Voter/PhotoVoterTest.php
+++ b/tests/Security/Voter/PhotoVoterTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Voter;
+
+use App\Entity\Photo;
+use App\Entity\User;
+use App\Security\Authorization\Voter\PhotoVoter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+final class PhotoVoterTest extends TestCase
+{
+    private function token(?object $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    #[Test]
+    public function anyLoggedInUserMayViewAndUpload(): void
+    {
+        $photo = (new Photo())->setUser(new User());
+        $voter = new PhotoVoter();
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token(new User()), $photo, ['view']));
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token(new User()), $photo, ['upload']));
+    }
+
+    #[Test]
+    public function onlyOwnerOrAdminMayEdit(): void
+    {
+        $owner = new User();
+        $photo = (new Photo())->setUser($owner);
+        $voter = new PhotoVoter();
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token($owner), $photo, ['edit']));
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token((new User())->setRoles(['ROLE_ADMIN'])), $photo, ['edit']));
+        self::assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->token(new User()), $photo, ['edit']));
+    }
+
+    #[Test]
+    public function viewIsDeniedWithoutAuthenticatedUser(): void
+    {
+        $photo = (new Photo())->setUser(new User());
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, (new PhotoVoter())->vote($this->token(null), $photo, ['view']));
+    }
+
+    #[Test]
+    public function abstainsForNonPhotoSubjects(): void
+    {
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, (new PhotoVoter())->vote($this->token(new User()), new User(), ['view']));
+    }
+}

--- a/tests/Security/Voter/TrackVoterTest.php
+++ b/tests/Security/Voter/TrackVoterTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Voter;
+
+use App\Entity\Track;
+use App\Entity\User;
+use App\Security\Authorization\Voter\TrackVoter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+final class TrackVoterTest extends TestCase
+{
+    private function token(?object $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function attributes(): iterable
+    {
+        yield 'view' => ['view'];
+        yield 'download' => ['download'];
+        yield 'approve' => ['approve'];
+        yield 'edit' => ['edit'];
+    }
+
+    #[Test]
+    #[DataProvider('attributes')]
+    public function everyAttributeIsRestrictedToOwnerOrAdmin(string $attribute): void
+    {
+        $owner = new User();
+        $track = (new Track())->setUser($owner);
+        $voter = new TrackVoter();
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token($owner), $track, [$attribute]));
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token((new User())->setRoles(['ROLE_ADMIN'])), $track, [$attribute]));
+        self::assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->token(new User()), $track, [$attribute]));
+    }
+
+    #[Test]
+    public function abstainsOnUnsupportedAttribute(): void
+    {
+        $owner = new User();
+        $track = (new Track())->setUser($owner);
+
+        self::assertSame(VoterInterface::ACCESS_ABSTAIN, (new TrackVoter())->vote($this->token($owner), $track, ['delete']));
+    }
+
+    #[Test]
+    public function trackWithoutOwnerIsOnlyAccessibleToAdmins(): void
+    {
+        $track = new Track();
+        $voter = new TrackVoter();
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->token(new User()), $track, ['view']));
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token((new User())->setRoles(['ROLE_ADMIN'])), $track, ['view']));
+    }
+}

--- a/tests/Support/EntityIdHelper.php
+++ b/tests/Support/EntityIdHelper.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Support;
+
+/**
+ * Most entities have no setId(); tests that need a stable identifier (voters,
+ * duplicate detection, grouping) assign it through reflection instead.
+ */
+final class EntityIdHelper
+{
+    public static function setId(object $entity, int $id): void
+    {
+        $reflection = new \ReflectionObject($entity);
+
+        while (!$reflection->hasProperty('id')) {
+            $reflection = $reflection->getParentClass();
+
+            if (false === $reflection) {
+                throw new \LogicException(sprintf('%s has no id property', get_class($entity)));
+            }
+        }
+
+        $property = $reflection->getProperty('id');
+        $property->setValue($entity, $id);
+    }
+}

--- a/tests/Support/StubRouter.php
+++ b/tests/Support/StubRouter.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Minimal RouterInterface over an in-memory RouteCollection, so the custom entity router
+ * can be exercised without booting the kernel.
+ */
+final class StubRouter implements RouterInterface
+{
+    private RouteCollection $routes;
+    private RequestContext $context;
+    private UrlGeneratorInterface $generator;
+
+    /**
+     * @param array<string, string> $routes route name => path
+     */
+    public function __construct(array $routes)
+    {
+        $this->routes = new RouteCollection();
+
+        foreach ($routes as $name => $path) {
+            $this->routes->add($name, new Route($path));
+        }
+
+        $this->context = new RequestContext('', 'GET', 'criticalmass.in', 'https');
+        $this->generator = new UrlGenerator($this->routes, $this->context);
+    }
+
+    public function setContext(RequestContext $context): void
+    {
+        $this->context = $context;
+        $this->generator->setContext($context);
+    }
+
+    public function getContext(): RequestContext
+    {
+        return $this->context;
+    }
+
+    public function getRouteCollection(): RouteCollection
+    {
+        return $this->routes;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
+    {
+        return $this->generator->generate($name, $parameters, $referenceType);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function match(string $pathinfo): array
+    {
+        throw new \LogicException('Matching is not supported by the stub router');
+    }
+}

--- a/tests/Twig/MarkdownTwigExtensionTest.php
+++ b/tests/Twig/MarkdownTwigExtensionTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Twig;
+
+use App\Criticalmass\TextParser\TextParserInterface;
+use App\Twig\Extension\MarkdownTwigExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Twig\TwigFilter;
+
+final class MarkdownTwigExtensionTest extends TestCase
+{
+    #[Test]
+    public function nullAndEmptyTextShortCircuitWithoutParsing(): void
+    {
+        $parser = $this->createMock(TextParserInterface::class);
+        $parser->expects(self::never())->method('parse');
+
+        $extension = new MarkdownTwigExtension($parser);
+
+        self::assertSame('', $extension->markdown(null));
+        self::assertSame('', $extension->markdown(''));
+    }
+
+    #[Test]
+    public function textIsDelegatedToTheParser(): void
+    {
+        $parser = $this->createMock(TextParserInterface::class);
+        $parser->expects(self::once())->method('parse')->with('**bold**')->willReturn('<p><strong>bold</strong></p>');
+
+        self::assertSame('<p><strong>bold</strong></p>', (new MarkdownTwigExtension($parser))->markdown('**bold**'));
+    }
+
+    #[Test]
+    public function registersHtmlSafeMarkdownFilter(): void
+    {
+        $filters = (new MarkdownTwigExtension($this->createMock(TextParserInterface::class)))->getFilters();
+
+        self::assertCount(1, $filters);
+        self::assertInstanceOf(TwigFilter::class, $filters[0]);
+        self::assertSame('markdown', $filters[0]->getName());
+        self::assertSame(['html'], $filters[0]->getSafe(new \Twig\Node\Expression\ConstantExpression('', 0)));
+    }
+}

--- a/tests/Twig/RideNavigationTwigExtensionTest.php
+++ b/tests/Twig/RideNavigationTwigExtensionTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Twig;
+
+use App\Entity\Ride;
+use App\Repository\RideRepository;
+use App\Twig\Extension\RideNavigationTwigExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RideNavigationTwigExtensionTest extends TestCase
+{
+    #[Test]
+    public function previousAndNextDelegateToTheRepository(): void
+    {
+        $ride = new Ride();
+        $previous = new Ride();
+        $next = new Ride();
+
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('getPreviousRide')->with($ride)->willReturn($previous);
+        $repository->method('getNextRide')->with($ride)->willReturn($next);
+
+        $extension = new RideNavigationTwigExtension($repository);
+
+        self::assertSame($previous, $extension->previousRide($ride));
+        self::assertSame($next, $extension->nextRide($ride));
+    }
+
+    #[Test]
+    public function missingNeighboursAreNull(): void
+    {
+        $repository = $this->createMock(RideRepository::class);
+        $repository->method('getPreviousRide')->willReturn(null);
+        $repository->method('getNextRide')->willReturn(null);
+
+        $extension = new RideNavigationTwigExtension($repository);
+
+        self::assertNull($extension->previousRide(new Ride()));
+        self::assertNull($extension->nextRide(new Ride()));
+    }
+
+    #[Test]
+    public function exposesPreviousAndNextRideFunctions(): void
+    {
+        $names = array_map(
+            static fn (\Twig\TwigFunction $function): string => $function->getName(),
+            (new RideNavigationTwigExtension($this->createMock(RideRepository::class)))->getFunctions()
+        );
+
+        self::assertSame(['previous_ride', 'next_ride'], $names);
+    }
+}

--- a/tests/Twig/RouterTwigExtensionTest.php
+++ b/tests/Twig/RouterTwigExtensionTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Twig;
+
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\City;
+use App\Twig\Extension\RouterTwigExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RouterTwigExtensionTest extends TestCase
+{
+    #[Test]
+    public function objectPathDelegatesToObjectRouterWithDefaults(): void
+    {
+        $city = new City();
+
+        $router = $this->createMock(ObjectRouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with($city, null, [], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/hamburg');
+
+        self::assertSame('/hamburg', (new RouterTwigExtension($router))->objectPath($city));
+    }
+
+    #[Test]
+    public function objectPathPassesRouteNameAndParameters(): void
+    {
+        $city = new City();
+
+        $router = $this->createMock(ObjectRouterInterface::class);
+        $router->expects(self::once())
+            ->method('generate')
+            ->with($city, 'caldera_criticalmass_city_show', ['page' => 2], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/hamburg?page=2');
+
+        self::assertSame('/hamburg?page=2', (new RouterTwigExtension($router))->objectPath($city, 'caldera_criticalmass_city_show', ['page' => 2]));
+    }
+
+    #[Test]
+    public function registersObjectPathFunction(): void
+    {
+        $functions = (new RouterTwigExtension($this->createMock(ObjectRouterInterface::class)))->getFunctions();
+
+        self::assertCount(1, $functions);
+        self::assertSame('object_path', $functions[0]->getName());
+    }
+}

--- a/tests/Twig/SiteTwigExtensionTest.php
+++ b/tests/Twig/SiteTwigExtensionTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Twig;
+
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Twig\Extension\SiteTwigExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class SiteTwigExtensionTest extends TestCase
+{
+    private SiteTwigExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new SiteTwigExtension(
+            $this->createMock(TranslatorInterface::class),
+            $this->createMock(RouterInterface::class),
+        );
+    }
+
+    #[Test]
+    public function instanceofChecksTheClassHierarchy(): void
+    {
+        self::assertTrue($this->extension->instanceof(new Ride(), Ride::class));
+        self::assertTrue($this->extension->instanceof(new Ride(), \App\EntityInterface\RouteableInterface::class));
+        self::assertFalse($this->extension->instanceof(new Ride(), City::class));
+        self::assertFalse($this->extension->instanceof('ride', Ride::class));
+    }
+
+    #[Test]
+    public function todayComparesOnlyTheCalendarDate(): void
+    {
+        self::assertTrue($this->extension->today(new \DateTime('today 00:00:00')));
+        self::assertTrue($this->extension->today(new \DateTime('today 23:59:59')));
+        self::assertFalse($this->extension->today(new \DateTime('yesterday 23:59:59')));
+        self::assertFalse($this->extension->today(new \DateTime('tomorrow 00:00:00')));
+    }
+
+    #[Test]
+    public function daysSinceCountsFullDays(): void
+    {
+        $twoDaysAgo = '@' . (time() - 2 * 86400);
+        $almostThreeDaysAgo = '@' . (time() - 3 * 86400 + 60);
+
+        self::assertSame(2.0, $this->extension->daysSince($twoDaysAgo));
+        self::assertSame(2.0, $this->extension->daysSince($almostThreeDaysAgo));
+    }
+
+    #[Test]
+    public function daysSinceIsNegativeForFutureDates(): void
+    {
+        self::assertSame(-1.0, $this->extension->daysSince('@' . (time() + 3600)));
+    }
+
+    #[Test]
+    public function registersDaysSinceTodayAndInstanceofFunctions(): void
+    {
+        $names = array_map(
+            static fn (\Twig\TwigFunction $function): string => $function->getName(),
+            $this->extension->getFunctions()
+        );
+
+        self::assertContains('daysSince', $names);
+        self::assertContains('today', $names);
+        self::assertContains('instanceof', $names);
+    }
+
+    #[Test]
+    public function hashtagToCityFilterHasAnImplementation(): void
+    {
+        $filters = $this->extension->getFilters();
+
+        self::assertSame('hashtagToCity', $filters[0]->getName());
+
+        if (!is_callable($filters[0]->getCallable())) {
+            self::markTestIncomplete(
+                'SiteTwigExtension registers the "hashtagToCity" filter with [$this, "hashtagToCity"], '
+                .'but no such method exists — using the filter in a template would fail at render time.'
+            );
+        }
+
+        self::assertTrue(is_callable($filters[0]->getCallable()));
+    }
+}

--- a/tests/Util/RequestParameterTest.php
+++ b/tests/Util/RequestParameterTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Util;
+
+use App\Criticalmass\Util\RequestParameter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestParameterTest extends TestCase
+{
+    #[Test]
+    public function routeAttributeWinsOverQueryAndBody(): void
+    {
+        $request = Request::create('/?citySlug=query', 'POST', ['citySlug' => 'body']);
+        $request->attributes->set('citySlug', 'attribute');
+
+        self::assertSame('attribute', RequestParameter::get($request, 'citySlug'));
+    }
+
+    #[Test]
+    public function queryStringWinsOverBody(): void
+    {
+        $request = Request::create('/?citySlug=query', 'POST', ['citySlug' => 'body']);
+
+        self::assertSame('query', RequestParameter::get($request, 'citySlug'));
+    }
+
+    #[Test]
+    public function bodyIsUsedWhenNothingElseMatches(): void
+    {
+        $request = Request::create('/', 'POST', ['citySlug' => 'body']);
+
+        self::assertSame('body', RequestParameter::get($request, 'citySlug'));
+    }
+
+    #[Test]
+    public function defaultIsReturnedForMissingKey(): void
+    {
+        $request = Request::create('/');
+
+        self::assertNull(RequestParameter::get($request, 'missing'));
+        self::assertSame('fallback', RequestParameter::get($request, 'missing', 'fallback'));
+    }
+
+    #[Test]
+    public function emptyStringInQueryIsStillReturnedInsteadOfDefault(): void
+    {
+        $request = Request::create('/?citySlug=');
+
+        self::assertSame('', RequestParameter::get($request, 'citySlug', 'fallback'));
+    }
+
+    #[Test]
+    public function arrayQueryParametersAreReturnedAsArrays(): void
+    {
+        $request = Request::create('/?ids[]=1&ids[]=2');
+
+        self::assertSame(['1', '2'], RequestParameter::get($request, 'ids'));
+    }
+}

--- a/tests/Validator/ExecutorDateTimeValidatorTest.php
+++ b/tests/Validator/ExecutorDateTimeValidatorTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Validator;
+
+use App\Model\RideGenerator\CycleExecutable;
+use App\Validator\Constraint\ExecutorDateTime;
+use App\Validator\ExecutorDateTimeValidator;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<ExecutorDateTimeValidator>
+ */
+final class ExecutorDateTimeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): ExecutorDateTimeValidator
+    {
+        return new ExecutorDateTimeValidator();
+    }
+
+    private function executable(?string $from, ?string $until): CycleExecutable
+    {
+        return (new CycleExecutable())
+            ->setFromDate($from ? new \DateTime($from) : null)
+            ->setUntilDate($until ? new \DateTime($until) : null);
+    }
+
+    #[Test]
+    public function fromBeforeUntilIsValid(): void
+    {
+        $this->validator->validate($this->executable('2024-01-01', '2024-12-31'), new ExecutorDateTime());
+
+        $this->assertNoViolation();
+    }
+
+    #[Test]
+    public function sameDayIsValid(): void
+    {
+        $this->validator->validate($this->executable('2024-05-31', '2024-05-31'), new ExecutorDateTime());
+
+        $this->assertNoViolation();
+    }
+
+    #[Test]
+    public function fromAfterUntilAddsViolationOnUntilDate(): void
+    {
+        $constraint = new ExecutorDateTime();
+
+        $this->validator->validate($this->executable('2024-12-31', '2024-01-01'), $constraint);
+
+        $this->buildViolation($constraint->message)
+            ->atPath('property.path.untilDate')
+            ->assertRaised();
+    }
+
+    #[Test]
+    public function missingDatesDoNotRaise(): void
+    {
+        $this->validator->validate($this->executable(null, null), new ExecutorDateTime());
+
+        $this->assertNoViolation();
+    }
+
+    #[Test]
+    public function constraintTargetsTheWholeClass(): void
+    {
+        $constraint = new ExecutorDateTime();
+
+        self::assertSame(ExecutorDateTime::CLASS_CONSTRAINT, $constraint->getTargets());
+        self::assertSame(ExecutorDateTimeValidator::class, $constraint->validatedBy());
+    }
+}

--- a/tests/ValueResolver/CityValueResolverTest.php
+++ b/tests/ValueResolver/CityValueResolverTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Tests\ValueResolver;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Repository\CitySlugRepository;
+use App\ValueResolver\CityValueResolver;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class CityValueResolverTest extends TestCase
+{
+    /** @var array<string, CitySlug> */
+    private array $slugs = [];
+
+    private function resolver(): CityValueResolver
+    {
+        $repository = $this->createMock(CitySlugRepository::class);
+        $repository->method('__call')->willReturnCallback(
+            fn (string $method, array $arguments): ?CitySlug => 'findOneBySlug' === $method ? ($this->slugs[$arguments[0]] ?? null) : null
+        );
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(CitySlug::class)->willReturn($repository);
+
+        return new CityValueResolver($registry);
+    }
+
+    private function registerCity(string $slug): City
+    {
+        $city = new City();
+        $citySlug = (new CitySlug())->setSlug($slug)->setCity($city);
+        $city->setMainSlug($citySlug);
+
+        $this->slugs[$slug] = $citySlug;
+
+        return $city;
+    }
+
+    private function argument(string $name = 'city', string $type = City::class, bool $nullable = false): ArgumentMetadata
+    {
+        return new ArgumentMetadata($name, $type, false, false, null, $nullable);
+    }
+
+    #[Test]
+    public function resolvesCityFromRouteAttribute(): void
+    {
+        $city = $this->registerCity('hamburg');
+
+        $request = Request::create('/hamburg');
+        $request->attributes->set('citySlug', 'hamburg');
+
+        self::assertSame([$city], $this->resolver()->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function resolvesCityFromQueryParameter(): void
+    {
+        $city = $this->registerCity('berlin');
+
+        $request = Request::create('/api/rides?citySlug=berlin');
+
+        self::assertSame([$city], $this->resolver()->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function ignoresArgumentsOfOtherTypeOrName(): void
+    {
+        $this->registerCity('hamburg');
+        $request = Request::create('/?citySlug=hamburg');
+
+        self::assertSame([], $this->resolver()->resolve($request, $this->argument('city', \stdClass::class)));
+        self::assertSame([], $this->resolver()->resolve($request, $this->argument('town')));
+    }
+
+    #[Test]
+    public function throwsNotFoundForUnknownSlug(): void
+    {
+        $request = Request::create('/?citySlug=atlantis');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('City not found');
+
+        $this->resolver()->resolve($request, $this->argument());
+    }
+
+    #[Test]
+    public function unknownSlugYieldsNothingForNullableArgument(): void
+    {
+        $request = Request::create('/?citySlug=atlantis');
+
+        self::assertSame([], $this->resolver()->resolve($request, $this->argument(nullable: true)));
+    }
+
+    #[Test]
+    public function slugWithoutCityIsNotFound(): void
+    {
+        $this->slugs['orphan'] = (new CitySlug())->setSlug('orphan');
+        $request = Request::create('/?citySlug=orphan');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->resolver()->resolve($request, $this->argument());
+    }
+}

--- a/tests/ValueResolver/RegionValueResolverTest.php
+++ b/tests/ValueResolver/RegionValueResolverTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Tests\ValueResolver;
+
+use App\Entity\Region;
+use App\Repository\RegionRepository;
+use App\ValueResolver\RegionValueResolver;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class RegionValueResolverTest extends TestCase
+{
+    private Region $region;
+    private RegionValueResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->region = (new Region())->setName('Europe')->setSlug('europe');
+
+        $repository = $this->createMock(RegionRepository::class);
+        $repository->method('findOneBy')->willReturnCallback(
+            fn (array $criteria): ?Region => 'europe' === ($criteria['slug'] ?? null) ? $this->region : null
+        );
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Region::class)->willReturn($repository);
+
+        $this->resolver = new RegionValueResolver($registry);
+    }
+
+    private function argument(string $name = 'region', string $type = Region::class): ArgumentMetadata
+    {
+        return new ArgumentMetadata($name, $type, false, false, null);
+    }
+
+    #[Test]
+    public function resolvesRegionFromQueryParameter(): void
+    {
+        $request = Request::create('/api/city?regionSlug=europe');
+
+        self::assertSame([$this->region], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function onlyTheQueryStringIsConsulted(): void
+    {
+        $request = Request::create('/world/europe');
+        $request->attributes->set('regionSlug', 'europe');
+
+        self::assertSame([], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function emptySlugYieldsNothing(): void
+    {
+        $request = Request::create('/?regionSlug=');
+
+        self::assertSame([], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function ignoresArgumentsOfOtherTypeOrName(): void
+    {
+        $request = Request::create('/?regionSlug=europe');
+
+        self::assertSame([], $this->resolver->resolve($request, $this->argument('area')));
+        self::assertSame([], $this->resolver->resolve($request, $this->argument('region', \stdClass::class)));
+    }
+
+    #[Test]
+    public function unknownSlugThrowsNotFoundWithSlugInMessage(): void
+    {
+        $request = Request::create('/?regionSlug=narnia');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Region with slug "narnia" not found.');
+
+        $this->resolver->resolve($request, $this->argument());
+    }
+}

--- a/tests/ValueResolver/RideValueResolverTest.php
+++ b/tests/ValueResolver/RideValueResolverTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types=1);
+
+namespace Tests\ValueResolver;
+
+use App\Entity\City;
+use App\Entity\CitySlug;
+use App\Entity\Ride;
+use App\Repository\CitySlugRepository;
+use App\Repository\RideRepository;
+use App\ValueResolver\RideValueResolver;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class RideValueResolverTest extends TestCase
+{
+    private MockObject&RideRepository $rideRepository;
+    private City $city;
+    private RideValueResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->city = new City();
+        $citySlug = (new CitySlug())->setSlug('hamburg')->setCity($this->city);
+        $this->city->setMainSlug($citySlug);
+
+        $citySlugRepository = $this->createMock(CitySlugRepository::class);
+        $citySlugRepository->method('findOneBy')->willReturnCallback(
+            fn (array $criteria): ?CitySlug => 'hamburg' === ($criteria['slug'] ?? null) ? $citySlug : null
+        );
+
+        $this->rideRepository = $this->createMock(RideRepository::class);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->willReturnMap([
+            [CitySlug::class, null, $citySlugRepository],
+            [Ride::class, null, $this->rideRepository],
+        ]);
+
+        $this->resolver = new RideValueResolver($registry);
+    }
+
+    private function argument(bool $nullable = false, string $name = 'ride', string $type = Ride::class): ArgumentMetadata
+    {
+        return new ArgumentMetadata($name, $type, false, false, null, $nullable);
+    }
+
+    #[Test]
+    public function ignoresArgumentsOfOtherTypeOrName(): void
+    {
+        $request = Request::create('/?rideId=1');
+
+        self::assertSame([], $this->resolver->resolve($request, $this->argument(name: 'other')));
+        self::assertSame([], $this->resolver->resolve($request, $this->argument(type: City::class)));
+    }
+
+    #[Test]
+    public function resolvesByRideIdFromQueryParameter(): void
+    {
+        $ride = new Ride();
+        $this->rideRepository->expects(self::once())->method('find')->with('42')->willReturn($ride);
+
+        $request = Request::create('/api/ride?rideId=42');
+
+        self::assertSame([$ride], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function rideIdTakesPrecedenceOverSlugs(): void
+    {
+        $ride = new Ride();
+        $this->rideRepository->method('find')->willReturn($ride);
+        $this->rideRepository->expects(self::never())->method('findCityRideByDate');
+
+        $request = Request::create('/?rideId=7&citySlug=hamburg&rideIdentifier=2024-05-31');
+
+        self::assertSame([$ride], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function resolvesFullDateIdentifierViaCityRideByDate(): void
+    {
+        $ride = new Ride();
+        $this->rideRepository->expects(self::once())
+            ->method('findCityRideByDate')
+            ->with($this->city, self::callback(fn (\DateTimeInterface $d): bool => '2024-05-31' === $d->format('Y-m-d')))
+            ->willReturn($ride);
+
+        $request = Request::create('/hamburg/2024-05-31');
+        $request->attributes->set('citySlug', 'hamburg');
+        $request->attributes->set('rideIdentifier', '2024-05-31');
+
+        self::assertSame([$ride], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function resolvesMonthIdentifierViaFirstRideOfMonth(): void
+    {
+        $first = new Ride();
+        $second = new Ride();
+        $this->rideRepository->expects(self::once())
+            ->method('findByCityAndMonth')
+            ->with($this->city, self::callback(fn (\DateTimeInterface $d): bool => '2024-05-01' === $d->format('Y-m-d')))
+            ->willReturn([$first, $second]);
+
+        $request = Request::create('/?citySlug=hamburg&rideIdentifier=2024-05');
+
+        self::assertSame([$first], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function trailingDashIsStrippedFromIdentifier(): void
+    {
+        $ride = new Ride();
+        $this->rideRepository->method('findCityRideByDate')->willReturn($ride);
+
+        $request = Request::create('/?citySlug=hamburg&rideIdentifier=2024-05-31-');
+
+        self::assertSame([$ride], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function nonDateIdentifierIsLookedUpAsSlug(): void
+    {
+        $ride = new Ride();
+        $this->rideRepository->expects(self::once())
+            ->method('findOneByCityAndSlug')
+            ->with($this->city, 'kidical-mass')
+            ->willReturn($ride);
+
+        $request = Request::create('/?citySlug=hamburg&rideIdentifier=kidical-mass');
+
+        self::assertSame([$ride], $this->resolver->resolve($request, $this->argument()));
+    }
+
+    #[Test]
+    public function unknownCitySlugThrowsNotFound(): void
+    {
+        $request = Request::create('/?citySlug=atlantis&rideIdentifier=2024-05-31');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->resolver->resolve($request, $this->argument());
+    }
+
+    #[Test]
+    public function missingParametersYieldNullForNullableArgument(): void
+    {
+        $request = Request::create('/');
+
+        self::assertSame([null], $this->resolver->resolve($request, $this->argument(nullable: true)));
+    }
+
+    #[Test]
+    public function missingParametersThrowForRequiredArgument(): void
+    {
+        $request = Request::create('/?citySlug=hamburg');
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Ride not found');
+
+        $this->resolver->resolve($request, $this->argument());
+    }
+}

--- a/tests/ValueResolver/ThreadValueResolverTest.php
+++ b/tests/ValueResolver/ThreadValueResolverTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Tests\ValueResolver;
+
+use App\Entity\Thread;
+use App\EntityInterface\PostableInterface;
+use App\Repository\ThreadRepository;
+use App\ValueResolver\ThreadValueResolver;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ThreadValueResolverTest extends TestCase
+{
+    private Thread $thread;
+    private ThreadValueResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->thread = (new Thread())->setSlug('my-thread');
+
+        $repository = $this->createMock(ThreadRepository::class);
+        $repository->method('__call')->willReturnCallback(
+            fn (string $method, array $arguments): ?Thread => 'findOneBySlug' === $method && 'my-thread' === $arguments[0] ? $this->thread : null
+        );
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getRepository')->with(Thread::class)->willReturn($repository);
+
+        $this->resolver = new ThreadValueResolver($registry);
+    }
+
+    #[Test]
+    public function resolvesThreadFromRouteAttribute(): void
+    {
+        $request = Request::create('/boards/x/thread/my-thread');
+        $request->attributes->set('threadSlug', 'my-thread');
+
+        $argument = new ArgumentMetadata('thread', Thread::class, false, false, null);
+
+        self::assertSame([$this->thread], $this->resolver->resolve($request, $argument));
+    }
+
+    #[Test]
+    public function resolvesPostableInterfaceArgumentsToo(): void
+    {
+        $request = Request::create('/?threadSlug=my-thread');
+
+        $argument = new ArgumentMetadata('postable', PostableInterface::class, false, false, null);
+
+        self::assertSame([$this->thread], $this->resolver->resolve($request, $argument));
+    }
+
+    #[Test]
+    public function ignoresUnrelatedArgumentTypes(): void
+    {
+        $request = Request::create('/?threadSlug=my-thread');
+
+        $argument = new ArgumentMetadata('thread', \stdClass::class, false, false, null);
+
+        self::assertSame([], $this->resolver->resolve($request, $argument));
+    }
+
+    #[Test]
+    public function unknownSlugThrowsNotFound(): void
+    {
+        $request = Request::create('/?threadSlug=nope');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $this->resolver->resolve($request, new ArgumentMetadata('thread', Thread::class, false, false, null));
+    }
+
+    #[Test]
+    public function unknownSlugYieldsNullForNullableArgument(): void
+    {
+        $request = Request::create('/?threadSlug=nope');
+
+        $argument = new ArgumentMetadata('thread', Thread::class, false, false, null, true);
+
+        self::assertSame([null], $this->resolver->resolve($request, $argument));
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #feature/symfony-8. Adds **53 new test files + 2 support helpers** with **237 new test methods** (1264 → 1553 test cases incl. data providers) in areas that had no or thin coverage. No production code was touched.

- **ValueResolver** – City/Ride/Thread/Region resolvers incl. the query-parameter lookup (`rideId`, `citySlug`/`rideIdentifier`, month vs. day vs. slug identifiers), 404 vs. nullable; `Util/RequestParameter` precedence
- **Security voters** – Participation/Photo/Track (owner, admin, stranger, anonymous, abstain)
- **EventSubscribers** – Cors, Kernel (canonical), Sitemap, Participation, RideEstimate, Track, ProfilePhoto
- **Twig** – Markdown, RideNavigation, Router, Site; **RideNamer** counting namers; **TextParser** CriticalParser (strip html, unsafe links, cache); **SeoPage**
- **MassTrackImport** – DateTime/Duration/Location/Name voter boundary tables, RideResult; **Upload** Track/Photo handlers (duplicate/matched/parked/staged/invalid)
- **Timeline** – ordering, feature gating, 3-month cut-off, MAX_ITEMS, Thread/CityCreated/RidePhoto collectors
- **Participation** – calculator, manager, city-list factory sorting; **Calendar** RideEvent/RideProvider; **RideDuplicates** finder + merger
- **Router** – ObjectRouter + Ride/Thread/Board/Region delegated routers against an in-memory `StubRouter`, parameter resolvers, plus kernel-level checks of the real route names (photo, track, threads, boards, regions)
- **Commands** (`CommandTester`) – cycles:list, ride-duplicates:list, rideestimate:recalculate, track:generate-polylines, photos:timeshift
- **Form types** (`TypeTestCase`) – Login/Post/RideEstimate/RideDisable/TrackRange/PhotoCoord/ProfileColor/Username, RideType (timezone conversion, admin-only slug, enabled checkbox), CityCycleType
- **DQL** custom functions (SQL generation via kernel), **Enums**, `ExecutorDateTimeValidator`, Region/Ride/User entity logic

All new tests use `#[Test]` / `#[DataProvider]` attributes, are hermetic (mocked Doctrine/HTTP, no network, no real-time dependence beyond `time()`-relative offsets) and `declare(strict_types=1)`.

## Findings

Real bugs found while reading the code. Each is pinned by a test marked `markTestIncomplete` (8 incomplete in total) so it becomes green once fixed — no production code was changed here.

1. `src/EventSubscriber/KernelEventSubscriber.php:43` – `str_replace('http', 'https', …)` turns an **https** request URI into `httpss://…`; every canonical link / `og:url` for an HTTPS request is broken.
2. `src/Criticalmass/TextParser/CriticalParser.php:33-45` – builds an `Environment` with `AutolinkExtension`/`EmbedExtension`, then instantiates `CommonMarkConverter($config)` which creates its own environment → the extensions are never used (bare URLs are not autolinked; oembed can never work).
3. `src/Criticalmass/Router/ParameterResolver/ClassParameterResolver.php:22` – `$classAttribute instanceof DefaultParameter` is checked on a `ReflectionAttribute`, never true → `#[DefaultParameter]` is silently ignored.
4. `src/Criticalmass/Router/ParameterResolver/PropertyParameterResolver.php:49` – `->getDateFormat()` is called on the `ReflectionAttribute` → fatal `Call to undefined method` for any DateTime-typed route parameter.
5. `src/Command/Cycles/ListCyclesCommand.php:41-45` and `src/Command/DuplicateRides/ListDuplicateRidesCommand.php:43-49` – print "No city found" for an unknown slug but do not `return`, then call `getCity()` on null (crash).
6. `src/Criticalmass/Timeline/Collector/CityCreatedCollector.php:16` – `if ($city->getSlugs())` on a `Collection` is always truthy; cities without slugs are not filtered.
7. `src/Twig/Extension/SiteTwigExtension.php:26` – filter `hashtagToCity` is registered with `[$this, 'hashtagToCity']` but no such method exists (render-time error if used).

Oddities not covered by tests (dead/unreachable code):
- `src/Entity/Board.php:50` – `__construct()` assigns an undeclared `$dateTime` → "Creation of dynamic property" deprecation on every `new Board()` (fatal in PHP 9).
- `src/Twig/Extension/SeoTwigExtension.php:41` – uses `$this->encoding`, which does not exist (class is swapped in by `TwigSeoExtensionPass`).
- `src/Criticalmass/TextParser/Embedder/Embedder.php`, `EmbedExtension/EmbedProcessor.php` – reference `League\CommonMark\Inline\Element\Link`/`HtmlInline`, which do not exist in commonmark 2.x.
- `src/Criticalmass/DataQuery/Query/HasCoordinatesQuery.php`, `LocationNameQuery.php` – reference undefined `AbstractQuery`/`DoctrineQueryInterface` (already excluded from phpstan).
- `CountingEnglishRideNamer` always appends `th` ("1th", "2th") – pinned as current behaviour.
- `AbstractVoter::supports()` is case-sensitive although `voteOnAttribute()` lower-cases the attribute – pinned as current behaviour.

## Verification

Throwaway MariaDB, `doctrine:schema:drop/create` + `fixtures:load` + `rm -rf var/cache/test` before each run:

- Run 1: `Tests: 1553, Assertions: 27052, Deprecations: 4, PHPUnit Deprecations: 20, Skipped: 11, Incomplete: 8` – OK
- Run 2: identical (`1553 / 27052 / Incomplete: 8`) – OK
- Base branch before: `Tests: 1264, Assertions: 26255, Deprecations: 3, Skipped: 11`
- `vendor/bin/phpstan analyse --memory-limit=2G` → `[OK] No errors` (baseline untouched)
- Note: `phpunit.xml` forces `SYMFONY_DEPRECATIONS_HELPER=disabled=1` (`force="true"`), so a `max` run is not possible without changing the tracked config. The one additional deprecation vs. base is the `Board::$dateTime` dynamic property (finding above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
