### PR TITLE
Drop unused Composer dependencies

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -55,13 +55,6 @@ FRIENDLYCAPTCHA_API_KEY=placeholder
 FRIENDLYCAPTCHA_SITE_KEY=placeholder
 
 LOGGLY_TOKEN=placeholder
-
-###> symfony/lock ###
-# Choose one of the stores below
-# postgresql+advisory://db_user:db_password@localhost/db_name
-LOCK_DSN=flock
-###< symfony/lock ###
-
 # Reverse-Proxy-IPs/-Ranges, denen X-Forwarded-* vertraut werden darf.
 # Leer = keinem Proxy vertrauen. Beispiel hinter Proxy: "127.0.0.1,10.0.0.0/8"
 TRUSTED_PROXIES=

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "calderacc/criticalmass",
     "type": "project",
-    "version": "0.1",
     "description": "Much critical mass stuff",
     "authors": [
         {
@@ -27,28 +26,22 @@
         "vich/uploader-bundle": "^2.4",
         "liip/imagine-bundle": "^2.17",
         "knplabs/knp-paginator-bundle": "^6.0",
-        "emcconville/google-map-polyline-encoding-tool": ">=1.2.1",
+        "emcconville/google-map-polyline-encoding-tool": "^1.2",
         "symfony/monolog-bundle": "^4.0",
         "hwi/oauth-bundle": "^2.5",
-        "malenki/slug": "1.0.0",
-        "sonata-project/intl-bundle": "^3.3",
+        "malenki/slug": "^1.0",
         "miljar/php-exif": "^0.6.5",
         "sonata-project/seo-bundle": "^3.9",
         "salavert/time-ago-in-words": "^1.8",
         "emcconville/point-reduction-algorithms": "^1.2",
-        "php-http/message": "^1.6",
         "symfony/security-bundle": "^8.1",
         "symfony/apache-pack": "^1.0",
         "symfony/flex": "^2.0",
-        "khill/php-duration": "^1.0",
         "sabre/vobject": "^4.0",
         "oneup/flysystem-bundle": "^4.12.2",
         "flagception/flagception-bundle": "^6.0",
         "ext-fileinfo": "*",
-        "ext-xmlwriter": "*",
         "symfony/webpack-encore-bundle": "^2.4",
-        "ext-json": "*",
-        "ext-zip": "*",
         "league/commonmark": "^2.6",
         "nesbot/carbon": "^3.0",
         "iamstuartwilson/strava": "^1.4",
@@ -59,7 +52,6 @@
         "symfony/doctrine-bridge": "^8.1",
         "symfony/framework-bundle": "^8.1",
         "symfony/dotenv": "^8.1",
-        "jaybizzle/crawler-detect": "^1.2",
         "nelmio/api-doc-bundle": "^5.11",
         "symfony/asset": "^8.1",
         "yohang/calendr": "^4.0",
@@ -70,8 +62,6 @@
         "symfony/cache": "^8.1",
         "symfony/notifier": "^8.1",
         "symfony/twig-bundle": "^8.1",
-        "twig/cssinliner-extra": "^3.10",
-        "twig/inky-extra": "^3.10",
         "symfony/serializer": "^8.1",
         "symfony/runtime": "^8.1",
         "symfony/stimulus-bundle": "^2.25",
@@ -83,7 +73,6 @@
         "twig/intl-extra": "^3.23",
         "maltehuebner/dataquery-bundle": "^0.11",
         "symfony/rate-limiter": "^8.1",
-        "symfony/lock": "^8.1",
         "adriangibbons/php-fit-file-analysis": "^3.2",
         "league/oauth2-server-bundle": "^1.2"
     },
@@ -95,16 +84,13 @@
         "symfony/stopwatch": "^8.1",
         "symfony/web-profiler-bundle": "^8.1",
         "rector/rector": "^2.0",
-        "doctrine/doctrine-fixtures-bundle": "^4.0"
+        "doctrine/doctrine-fixtures-bundle": "^4.0",
+        "symfony/css-selector": "^8.1"
     },
     "conflict": {
         "symfony/symfony": "*"
     },
     "scripts": {
-        "post-install-cmd": [
-        ],
-        "post-update-cmd": [
-        ],
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "cache:warmup": "symfony-cmd",
@@ -124,9 +110,6 @@
         "test": [
             "@test:db:reset",
             "@test:run"
-        ],
-        "tests": [
-            "@test"
         ]
     },
     "config": {
@@ -155,6 +138,5 @@
             "type": "vcs",
             "url": "https://github.com/maltehuebner/time-ago-in-words.git"
         }
-    ],
-    "minimum-stability": "stable"
+    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4d014abf0e8593ec00378d5400dc108",
+    "content-hash": "b51ad78a7f660bf79d3772b17df0acc1",
     "packages": [
         {
             "name": "adriangibbons/php-fit-file-analysis",
@@ -175,72 +175,6 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
-        },
-        {
-            "name": "clue/stream-filter",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/clue/stream-filter.git",
-                "reference": "049509fef80032cb3f051595029ab75b49a3c2f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/clue/stream-filter/zipball/049509fef80032cb3f051595029ab75b49a3c2f7",
-                "reference": "049509fef80032cb3f051595029ab75b49a3c2f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "Clue\\StreamFilter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering"
-                }
-            ],
-            "description": "A simple and modern approach to stream filtering in PHP",
-            "homepage": "https://github.com/clue/stream-filter",
-            "keywords": [
-                "bucket brigade",
-                "callback",
-                "filter",
-                "php_user_filter",
-                "stream",
-                "stream_filter_append",
-                "stream_filter_register"
-            ],
-            "support": {
-                "issues": "https://github.com/clue/stream-filter/issues",
-                "source": "https://github.com/clue/stream-filter/tree/v1.7.0"
-            },
-            "funding": [
-                {
-                    "url": "https://clue.engineering/support",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-12-20T15:40:13+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -2344,58 +2278,6 @@
             "time": "2026-06-04T10:05:48+00:00"
         },
         {
-            "name": "jaybizzle/crawler-detect",
-            "version": "v1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JayBizzle/Crawler-Detect.git",
-                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/770e00e5bcd35054871a6f790f380123cc3b8b0c",
-                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.52|^9.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Jaybizzle\\CrawlerDetect\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mark Beech",
-                    "email": "m@rkbee.ch",
-                    "role": "Developer"
-                }
-            ],
-            "description": "CrawlerDetect is a PHP class for detecting bots/crawlers/spiders via the user agent",
-            "homepage": "https://github.com/JayBizzle/Crawler-Detect/",
-            "keywords": [
-                "crawler",
-                "crawler detect",
-                "crawler detector",
-                "crawlerdetect",
-                "php crawler detect"
-            ],
-            "support": {
-                "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
-                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.1"
-            },
-            "time": "2026-07-10T14:15:38+00:00"
-        },
-        {
             "name": "jms/metadata",
             "version": "2.9.0",
             "source": {
@@ -2458,68 +2340,6 @@
                 "source": "https://github.com/schmittjoh/metadata/tree/2.9.0"
             },
             "time": "2025-11-30T20:12:26+00:00"
-        },
-        {
-            "name": "khill/php-duration",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/kevinkhill/php-duration.git",
-                "reference": "dcb222fd0c9eb459676c9eef6fb9f9d2baf749b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/kevinkhill/php-duration/zipball/dcb222fd0c9eb459676c9eef6fb9f9d2baf749b1",
-                "reference": "dcb222fd0c9eb459676c9eef6fb9f9d2baf749b1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "require-dev": {
-                "doctrine/instantiator": "1.0.4",
-                "phpstan/phpstan": "^0.12.81",
-                "phpunit/phpunit": "~4.8|~5.0",
-                "satooshi/php-coveralls": "~1.0",
-                "symfony/config": "~2.0",
-                "symfony/console": "~2.0",
-                "symfony/filesystem": "~2.0",
-                "symfony/stopwatch": "~2.0",
-                "symfony/yaml": "~2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Khill\\Duration\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Hill",
-                    "email": "kevinkhill@gmail.com",
-                    "role": "Creator"
-                },
-                {
-                    "name": "Duration Community",
-                    "homepage": "https://github.com/kevinkhill/php-duration/contributors"
-                }
-            ],
-            "description": "Converts between colon formatted time, human-readable time and seconds",
-            "keywords": [
-                "convert",
-                "duration",
-                "seconds",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/kevinkhill/php-duration/issues",
-                "source": "https://github.com/kevinkhill/php-duration/tree/1.1.0"
-            },
-            "time": "2021-03-17T11:34:55+00:00"
         },
         {
             "name": "knplabs/knp-components",
@@ -3808,59 +3628,6 @@
             "time": "2026-08-05T12:56:26+00:00"
         },
         {
-            "name": "lorenzo/pinky",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lorenzo/pinky.git",
-                "reference": "e1b1bdb2c132b8a7ba32bca64d2443f646ddbd17"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lorenzo/pinky/zipball/e1b1bdb2c132b8a7ba32bca64d2443f646ddbd17",
-                "reference": "e1b1bdb2c132b8a7ba32bca64d2443f646ddbd17",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xsl": "*",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.21 || ^9.5.10"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/pinky.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jose Lorenzo Rodriguez",
-                    "email": "jose.zap@gmail.com"
-                }
-            ],
-            "description": "A Foundation for Emails (Inky) template transpiler",
-            "keywords": [
-                "email",
-                "foundation",
-                "inky",
-                "template",
-                "zurb"
-            ],
-            "support": {
-                "issues": "https://github.com/lorenzo/pinky/issues",
-                "source": "https://github.com/lorenzo/pinky/tree/1.1.0"
-            },
-            "time": "2023-07-31T13:36:50+00:00"
-        },
-        {
             "name": "malenki/slug",
             "version": "1.0.0",
             "source": {
@@ -4884,75 +4651,6 @@
                 "source": "https://github.com/paragonie/random_compat"
             },
             "time": "2020-10-15T08:29:30+00:00"
-        },
-        {
-            "name": "php-http/message",
-            "version": "1.16.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message.git",
-                "reference": "06dd5e8562f84e641bf929bfe699ee0f5ce8080a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/06dd5e8562f84e641bf929bfe699ee0f5ce8080a",
-                "reference": "06dd5e8562f84e641bf929bfe699ee0f5ce8080a",
-                "shasum": ""
-            },
-            "require": {
-                "clue/stream-filter": "^1.5",
-                "php": "^7.2 || ^8.0",
-                "psr/http-message": "^1.1 || ^2.0"
-            },
-            "provide": {
-                "php-http/message-factory-implementation": "1.0"
-            },
-            "require-dev": {
-                "ergebnis/composer-normalize": "^2.6",
-                "ext-zlib": "*",
-                "guzzlehttp/psr7": "^1.0 || ^2.0",
-                "laminas/laminas-diactoros": "^2.0 || ^3.0",
-                "php-http/message-factory": "^1.0.2",
-                "phpspec/phpspec": "^5.1 || ^6.3 || ^7.1",
-                "slim/slim": "^3.0"
-            },
-            "suggest": {
-                "ext-zlib": "Used with compressor/decompressor streams",
-                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
-                "laminas/laminas-diactoros": "Used with Diactoros Factories",
-                "slim/slim": "Used with Slim Framework PSR-7 implementation"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/filters.php"
-                ],
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "HTTP Message related tools",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message/issues",
-                "source": "https://github.com/php-http/message/tree/1.16.2"
-            },
-            "time": "2024-10-02T11:34:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -6584,99 +6282,6 @@
             "time": "2025-11-23T16:45:01+00:00"
         },
         {
-            "name": "sonata-project/intl-bundle",
-            "version": "3.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sonata-project/SonataIntlBundle.git",
-                "reference": "008f1a1e2fe95c6b80e4dd27e641370353862d4b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sonata-project/SonataIntlBundle/zipball/008f1a1e2fe95c6b80e4dd27e641370353862d4b",
-                "reference": "008f1a1e2fe95c6b80e4dd27e641370353862d4b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2",
-                "symfony/config": "^6.4 || ^7.3 || ^8.0",
-                "symfony/dependency-injection": "^6.4 || ^7.3 || ^8.0",
-                "symfony/http-foundation": "^6.4 || ^7.3 || ^8.0",
-                "symfony/http-kernel": "^6.4 || ^7.3 || ^8.0",
-                "symfony/intl": "^6.4 || ^7.3 || ^8.0",
-                "symfony/translation-contracts": "^2.5 || ^3.0",
-                "twig/twig": "^3.0"
-            },
-            "conflict": {
-                "sonata-project/user-bundle": "<3.6"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.4",
-                "matthiasnoback/symfony-config-test": "^6.1",
-                "matthiasnoback/symfony-dependency-injection-test": "dev-ci-updates as 6.1.0.1",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0 || ^2.0",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2.0",
-                "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
-                "phpstan/phpstan-symfony": "^1.0 || ^2.0",
-                "phpunit/phpunit": "^11.5.38 || ^12.3.10",
-                "rector/rector": "^1.1 || ^2.0",
-                "symfony/security-core": "^6.4 || ^7.3 || ^8.0"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-4": {
-                    "Sonata\\IntlBundle\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Thomas Rabaix",
-                    "email": "thomas.rabaix@sonata-project.org"
-                },
-                {
-                    "name": "Sonata Community",
-                    "homepage": "https://github.com/sonata-project/SonataIntlBundle/contributors"
-                }
-            ],
-            "description": "Symfony SonataIntlBundle",
-            "homepage": "https://docs.sonata-project.org/projects/SonataIntlBundle",
-            "keywords": [
-                "date",
-                "intl",
-                "number",
-                "sonata",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/sonata-project/SonataIntlBundle/issues",
-                "source": "https://github.com/sonata-project/SonataIntlBundle/tree/3.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/OskarStark",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/VincentLanglet",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/greg0ire",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/jordisala1991",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-25T17:46:21+00:00"
-        },
-        {
             "name": "sonata-project/seo-bundle",
             "version": "3.9.0",
             "source": {
@@ -7301,75 +6906,6 @@
                 }
             ],
             "time": "2026-08-21T14:29:57+00:00"
-        },
-        {
-            "name": "symfony/css-selector",
-            "version": "v8.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "a291fb5adb65f52a4bb315db2d803698315dc64d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/a291fb5adb65f52a4bb315db2d803698315dc64d",
-                "reference": "a291fb5adb65f52a4bb315db2d803698315dc64d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\CssSelector\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Jean-François Simon",
-                    "email": "jeanfrancois.simon@sensiolabs.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Converts CSS selectors to XPath expressions",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.1.5"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-08-21T17:47:34+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -8927,88 +8463,6 @@
                 }
             ],
             "time": "2026-08-21T17:47:34+00:00"
-        },
-        {
-            "name": "symfony/lock",
-            "version": "v8.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/lock.git",
-                "reference": "8265aa10ed6d443bf9126052d4ccc737aaf48d1c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lock/zipball/8265aa10ed6d443bf9126052d4ccc737aaf48d1c",
-                "reference": "8265aa10ed6d443bf9126052d4ccc737aaf48d1c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "psr/log": "^1|^2|^3"
-            },
-            "conflict": {
-                "doctrine/dbal": "<4.3"
-            },
-            "require-dev": {
-                "doctrine/dbal": "^4.3",
-                "predis/predis": "^1.1|^2.0",
-                "symfony/serializer": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Lock\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jérémy Derussé",
-                    "email": "jeremy@derusse.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Creates and manages locks, a mechanism to provide exclusive access to a shared resource",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cas",
-                "flock",
-                "locking",
-                "mutex",
-                "redlock",
-                "semaphore"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/lock/tree/v8.1.5"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-08-14T13:18:47+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -12757,130 +12211,6 @@
             "time": "2026-08-21T12:16:08+00:00"
         },
         {
-            "name": "tijsverkoyen/css-to-inline-styles",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tijsverkoyen/CssToInlineStyles.git",
-                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tijsverkoyen/CssToInlineStyles/zipball/f0292ccf0ec75843d65027214426b6b163b48b41",
-                "reference": "f0292ccf0ec75843d65027214426b6b163b48b41",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php": "^7.4 || ^8.0",
-                "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^8.5.21 || ^9.5.10"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TijsVerkoyen\\CssToInlineStyles\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Tijs Verkoyen",
-                    "email": "css_to_inline_styles@verkoyen.eu",
-                    "role": "Developer"
-                }
-            ],
-            "description": "CssToInlineStyles is a class that enables you to convert HTML-pages/files into HTML-pages/files with inline styles. This is very useful when you're sending emails.",
-            "homepage": "https://github.com/tijsverkoyen/CssToInlineStyles",
-            "support": {
-                "issues": "https://github.com/tijsverkoyen/CssToInlineStyles/issues",
-                "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.4.0"
-            },
-            "time": "2025-12-02T11:56:42+00:00"
-        },
-        {
-            "name": "twig/cssinliner-extra",
-            "version": "v3.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/cssinliner-extra.git",
-                "reference": "1b0dc906bbad7226c967bd325e99cccb1a850c4b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/cssinliner-extra/zipball/1b0dc906bbad7226c967bd325e99cccb1a850c4b",
-                "reference": "1b0dc906bbad7226c967bd325e99cccb1a850c4b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1.0",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "tijsverkoyen/css-to-inline-styles": "^2.0",
-                "twig/twig": "^3.13|^4.0"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Twig\\Extra\\CssInliner\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                }
-            ],
-            "description": "A Twig extension to allow inlining CSS",
-            "homepage": "https://twig.symfony.com",
-            "keywords": [
-                "css",
-                "inlining",
-                "twig"
-            ],
-            "support": {
-                "source": "https://github.com/twigphp/cssinliner-extra/tree/v3.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-15T13:14:14+00:00"
-        },
-        {
             "name": "twig/extra-bundle",
             "version": "v3.24.0",
             "source": {
@@ -12953,76 +12283,6 @@
                 }
             ],
             "time": "2026-02-07T08:07:38+00:00"
-        },
-        {
-            "name": "twig/inky-extra",
-            "version": "v3.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/twigphp/inky-extra.git",
-                "reference": "0a8b24f0d0247bf6dc5e2af0c0ab09c0c4e5343e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/inky-extra/zipball/0a8b24f0d0247bf6dc5e2af0c0ab09c0c4e5343e",
-                "reference": "0a8b24f0d0247bf6dc5e2af0c0ab09c0c4e5343e",
-                "shasum": ""
-            },
-            "require": {
-                "lorenzo/pinky": "^1.0.5",
-                "php": ">=8.1.0",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "twig/twig": "^3.13|^4.0"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Twig\\Extra\\Inky\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                }
-            ],
-            "description": "A Twig extension for the inky email templating engine",
-            "homepage": "https://twig.symfony.com",
-            "keywords": [
-                "email",
-                "emails",
-                "inky",
-                "twig"
-            ],
-            "support": {
-                "source": "https://github.com/twigphp/inky-extra/tree/v3.26.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-15T13:14:14+00:00"
         },
         {
             "name": "twig/intl-extra",
@@ -15530,6 +14790,75 @@
             "time": "2026-08-21T17:47:34+00:00"
         },
         {
+            "name": "symfony/css-selector",
+            "version": "v8.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "a291fb5adb65f52a4bb315db2d803698315dc64d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/a291fb5adb65f52a4bb315db2d803698315dc64d",
+                "reference": "a291fb5adb65f52a4bb315db2d803698315dc64d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-21T17:47:34+00:00"
+        },
+        {
             "name": "symfony/dom-crawler",
             "version": "v8.1.5",
             "source": {
@@ -15928,10 +15257,7 @@
         "php": ">=8.4",
         "ext-intl": "*",
         "ext-simplexml": "*",
-        "ext-fileinfo": "*",
-        "ext-xmlwriter": "*",
-        "ext-json": "*",
-        "ext-zip": "*"
+        "ext-fileinfo": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -9,7 +9,6 @@ return [
     Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     Nelmio\ApiDocBundle\NelmioApiDocBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Sonata\IntlBundle\SonataIntlBundle::class => ['all' => true],
     Sonata\SeoBundle\SonataSeoBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],

--- a/config/packages/lock.yaml
+++ b/config/packages/lock.yaml
@@ -1,2 +1,0 @@
-framework:
-    lock: '%env(LOCK_DSN)%'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,13 +29,6 @@
     <env name="SHELL_VERBOSITY" value="-1"/>
     <env name="FRIENDLYCAPTCHA_API_KEY" value="placeholder"/>
     <env name="FRIENDLYCAPTCHA_SITE_KEY" value="placeholder"/>
-
-        <!-- ###+ symfony/lock ### -->
-        <!-- Choose one of the stores below -->
-        <!-- postgresql+advisory://db_user:db_password@localhost/db_name -->
-        <env name="LOCK_DSN" value="flock"/>
-        <!-- ###- symfony/lock ### -->
-
         <!-- ###+ league/oauth2-server-bundle ### -->
         <env name="OAUTH_PRIVATE_KEY" value="%kernel.project_dir%/config/jwt/private.pem"/>
         <env name="OAUTH_PUBLIC_KEY" value="%kernel.project_dir%/config/jwt/public.pem"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,13 +13,6 @@
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-
-        <!-- ###+ symfony/lock ### -->
-        <!-- Choose one of the stores below -->
-        <!-- postgresql+advisory://db_user:db_password@localhost/db_name -->
-        <env name="LOCK_DSN" value="flock"/>
-        <!-- ###- symfony/lock ### -->
-
         <!-- ###+ league/oauth2-server-bundle ### -->
         <env name="OAUTH_PRIVATE_KEY" value="%kernel.project_dir%/config/jwt/private.pem"/>
         <env name="OAUTH_PUBLIC_KEY" value="%kernel.project_dir%/config/jwt/public.pem"/>

--- a/symfony.lock
+++ b/symfony.lock
@@ -222,9 +222,6 @@
             "config/packages/sonata_form.yaml"
         ]
     },
-    "sonata-project/intl-bundle": {
-        "version": "2.14.1"
-    },
     "sonata-project/seo-bundle": {
         "version": "2.13.0"
     },
@@ -295,18 +292,6 @@
             "public/index.php",
             "src/Controller/.gitignore",
             "src/Kernel.php"
-        ]
-    },
-    "symfony/lock": {
-        "version": "7.2",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "main",
-            "version": "5.2",
-            "ref": "8e937ff2b4735d110af1770f242c1107fdab4c8e"
-        },
-        "files": [
-            "config/packages/lock.yaml"
         ]
     },
     "symfony/mailer": {


### PR DESCRIPTION
## Summary
Stacked on #1473. Every removal was checked by grepping `src`, `config`, `templates`, `tests` and `migrations` and by `composer why` (nothing else depends on them).

Removed from `require`:
- `khill/php-duration` — `DurationTwigExtension` (`human_duration()`) computes hours/minutes itself since `5a68960c7` (2026-02-24)
- `jaybizzle/crawler-detect` — never referenced
- `php-http/message` — only backed the HTTPlug factory aliases that the nyholm/psr7 recipe update already dropped
- `twig/cssinliner-extra`, `twig/inky-extra` — no template uses `inline_css` / `inky_to_html` (incl. `templates/email`)
- `symfony/lock` — no `LockFactory` anywhere; only the recipe config existed. `config/packages/lock.yaml`, `LOCK_DSN` in `.env.dist` and the phpunit env entries go with it
- `sonata-project/intl-bundle` (+ `bundles.php` entry) — its filters are `sonata_format_*` and unused; the 14 `format_datetime` calls in templates resolve to `twig/intl-extra`
- `ext-zip`, `ext-xmlwriter`, `ext-json` — no direct use; the phpunit packages that need xmlwriter declare it themselves, json is built in since PHP 8

Added: `symfony/css-selector` as an explicit **dev** dependency — 14 test files use `Crawler::filter()` and it only came in transitively through inky-extra.

Tidy-ups in `composer.json`: `version` field, empty `post-install-cmd`/`post-update-cmd`, the `tests` alias and `minimum-stability: stable` dropped; `emcconville/google-map-polyline-encoding-tool` bounded to `^1.2`, `malenki/slug` loosened to `^1.0` (only 1.0.0 exists).

Kept on purpose: `salavert/time-ago-in-words` (the "vor 8 Minuten" in the timeline), `knp-paginator`/`knp-menu`, `sonata-project/seo-bundle`, `iamstuartwilson/strava` (still 3 users until #1388), `symfony/property-info` (`property_info.yaml`), `symfony/stopwatch` (dev), `ext-fileinfo`.

`composer validate --strict` now only notes the missing `license` field.

## Verification
- Full suite against a throwaway MariaDB: `Tests: 1556, Assertions: 27075, 0 failures` (identical to #1473)
- `vendor/bin/phpstan analyse` → `[OK] No errors`; `lint:container` dev + prod OK; `lint:twig` 162 files OK; `debug:container --deprecations` unchanged (6, vendor/operational)
- `composer validate --strict` OK apart from the license note

🤖 Generated with [Claude Code](https://claude.com/claude-code)