### PR TITLE
Record the last login for every way of signing in

### DIFF
--- a/src/EventSubscriber/LastLoginSubscriber.php
+++ b/src/EventSubscriber/LastLoginSubscriber.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Records when a user last signed in — regardless of how.
+ *
+ * InteractiveLoginEvent is dispatched for every interactive authenticator, so
+ * this covers the magic link, the OAuth logins (Facebook, Strava) and any
+ * future one such as passkeys. It is deliberately NOT the LoginSuccessEvent:
+ * that one also fires for the stateless bearer-token firewalls (/mcp, API),
+ * which would mean a database write on every single API request.
+ */
+class LastLoginSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly ManagerRegistry $registry)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+        ];
+    }
+
+    public function onInteractiveLogin(InteractiveLoginEvent $event): void
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $user->setLastLogin(new \DateTime());
+
+        $this->registry->getManager()->flush();
+    }
+}

--- a/src/Security/UserProvider/UserProvider.php
+++ b/src/Security/UserProvider/UserProvider.php
@@ -132,10 +132,7 @@ class UserProvider implements UserProviderInterface, OAuthAwareUserProviderInter
             $user->setUsername($nickname);
         }
 
-        $user
-            ->setEnabled(true)
-            ->setLastLogin(new \DateTime())
-        ;
+        $user->setEnabled(true);
 
         if ($response->getEmail()) {
             $user->setEmail($response->getEmail());

--- a/tests/Controller/LastLoginTest.php
+++ b/tests/Controller/LastLoginTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\User;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * Covers the whole magic-link login, so the InteractiveLoginEvent is dispatched
+ * by the real authenticator rather than simulated.
+ */
+final class LastLoginTest extends AbstractControllerTestCase
+{
+    #[Test]
+    public function loggingInViaMagicLinkStampsLastLogin(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'testuser@criticalmass.in']);
+        $user->setLastLogin(new \DateTime('2020-01-01 12:00:00'));
+        $em->flush();
+
+        $before = new \DateTime();
+        $client->request('GET', $this->loginLinkFor($user));
+
+        self::assertTrue($client->getResponse()->isSuccessful() || $client->getResponse()->isRedirection());
+
+        $em->clear();
+        $reloaded = $em->getRepository(User::class)->findOneBy(['email' => 'testuser@criticalmass.in']);
+
+        self::assertNotNull($reloaded->getLastLogin());
+        self::assertGreaterThanOrEqual(
+            $before->getTimestamp(),
+            $reloaded->getLastLogin()->getTimestamp(),
+            'the magic link login must refresh last_login'
+        );
+    }
+
+    #[Test]
+    public function anonymousRequestsLeaveLastLoginAlone(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'cyclist@criticalmass.in']);
+        $user->setLastLogin($stamp = new \DateTime('2021-06-01 08:00:00'));
+        $em->flush();
+        $em->clear();
+
+        $client->request('GET', '/');
+
+        $reloaded = $em->getRepository(User::class)->findOneBy(['email' => 'cyclist@criticalmass.in']);
+
+        self::assertSame($stamp->format('Y-m-d H:i:s'), $reloaded->getLastLogin()->format('Y-m-d H:i:s'));
+    }
+
+    private function loginLinkFor(User $user): string
+    {
+        /** @var LoginLinkHandlerInterface $handler */
+        $handler = static::getContainer()->get('security.authenticator.login_link_handler.main');
+
+        return $handler->createLoginLink($user)->getUrl();
+    }
+}

--- a/tests/EventSubscriber/LastLoginSubscriberTest.php
+++ b/tests/EventSubscriber/LastLoginSubscriberTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Entity\User;
+use App\EventSubscriber\LastLoginSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+final class LastLoginSubscriberTest extends TestCase
+{
+    #[Test]
+    public function listensToTheInteractiveLoginEvent(): void
+    {
+        self::assertSame(
+            [SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin'],
+            LastLoginSubscriber::getSubscribedEvents()
+        );
+    }
+
+    #[Test]
+    public function stampsTheCurrentTimeOnTheUserAndFlushes(): void
+    {
+        $user = new User();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->once())->method('flush');
+
+        $before = new \DateTime();
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+        $after = new \DateTime();
+
+        self::assertNotNull($user->getLastLogin());
+        self::assertGreaterThanOrEqual($before->getTimestamp(), $user->getLastLogin()->getTimestamp());
+        self::assertLessThanOrEqual($after->getTimestamp(), $user->getLastLogin()->getTimestamp());
+    }
+
+    #[Test]
+    public function overwritesAPreviousLoginTimestamp(): void
+    {
+        $user = (new User())->setLastLogin(new \DateTime('2020-01-01 12:00:00'));
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->once())->method('flush');
+
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+
+        self::assertGreaterThan(new \DateTime('2020-01-02'), $user->getLastLogin());
+    }
+
+    #[Test]
+    public function ignoresTokensCarryingAForeignUserClass(): void
+    {
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->never())->method('flush');
+
+        $user = new InMemoryUser('someone', null);
+
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+
+        self::assertSame('someone', $user->getUserIdentifier(), 'the foreign user is left untouched');
+    }
+
+    private function subscriber(EntityManagerInterface $manager): LastLoginSubscriber
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        return new LastLoginSubscriber($registry);
+    }
+
+    private function event(object $user): InteractiveLoginEvent
+    {
+        return new InteractiveLoginEvent(new Request(), $this->token($user));
+    }
+
+    private function token(object $user): TokenInterface
+    {
+        return new UsernamePasswordToken($user, 'main', ['ROLE_USER']);
+    }
+}


### PR DESCRIPTION
## Summary
Stacked on #1476.

`User::$lastLogin` was written in exactly one place: `UserProvider::createUser()`, i.e. when an account is first created through OAuth. Signing in again — magic link or OAuth — never touched it. That is why the column suggested "no Facebook login since July 2024" while the access logs show completed `/login/check-facebook` callbacks every few days: 2024 was simply when the newest Facebook account was created.

- New `App\EventSubscriber\LastLoginSubscriber` stamps `lastLogin` on Symfony's `InteractiveLoginEvent`. Every interactive authenticator dispatches it, so the magic link, Facebook and Strava are covered, and a passkey authenticator would be too without further changes (worth re-checking on the passkey branch, which isn't merged yet).
- Deliberately **not** `LoginSuccessEvent`: that also fires for the stateless bearer-token firewalls (`/mcp`, API), which would mean a database write on every API request.
- The one-off assignment in `UserProvider::createUser()` is removed — the subscriber fires right after account creation too, so there is now a single source of truth.

No migration needed; the column already exists.

## Verification
- New `tests/EventSubscriber/LastLoginSubscriberTest.php` (4 cases: subscribed event, timestamp within the request window, overwriting an old value, foreign user classes ignored).
- New `tests/Controller/LastLoginTest.php` drives the **real magic-link flow** (login link created through `security.authenticator.login_link_handler.main`, then requested with the browser kit) and asserts the stamp is refreshed; a second case asserts an anonymous request changes nothing. Mutation-checked: with the subscriber unregistered the first test fails (`1577880000 is not >= …`), with it green.
- Full suite: `Tests: 1515, Assertions: 26976, 0 failures`; `phpstan` → `[OK] No errors`; `lint:container` OK; `debug:event-dispatcher security.interactive_login` lists the subscriber.

## Note on existing data
Historic values stay as they are — for most accounts `last_login` currently means "account created". From this change on it means what it says; there is no way to backfill the real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)