### PR TITLE
Passkeys: last login stamp for every sign-in path

### DIFF
--- a/src/EventSubscriber/LastLoginSubscriber.php
+++ b/src/EventSubscriber/LastLoginSubscriber.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+/**
+ * Records when a user last signed in — regardless of how.
+ *
+ * InteractiveLoginEvent is dispatched for every interactive authenticator, so
+ * this covers the magic link, the OAuth logins (Facebook, Strava) and any
+ * future one such as passkeys. It is deliberately NOT the LoginSuccessEvent:
+ * that one also fires for the stateless bearer-token firewalls (/mcp, API),
+ * which would mean a database write on every single API request.
+ */
+class LastLoginSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly ManagerRegistry $registry)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+        ];
+    }
+
+    public function onInteractiveLogin(InteractiveLoginEvent $event): void
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if (!$user instanceof User) {
+            return;
+        }
+
+        $user->setLastLogin(new \DateTime());
+
+        $this->registry->getManager()->flush();
+    }
+}

--- a/src/Security/UserProvider/UserProvider.php
+++ b/src/Security/UserProvider/UserProvider.php
@@ -132,10 +132,7 @@ class UserProvider implements UserProviderInterface, OAuthAwareUserProviderInter
             $user->setUsername($nickname);
         }
 
-        $user
-            ->setEnabled(true)
-            ->setLastLogin(new \DateTime())
-        ;
+        $user->setEnabled(true);
 
         if ($response->getEmail()) {
             $user->setEmail($response->getEmail());

--- a/tests/Controller/LastLoginTest.php
+++ b/tests/Controller/LastLoginTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\User;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * Covers the whole magic-link login, so the InteractiveLoginEvent is dispatched
+ * by the real authenticator rather than simulated.
+ */
+final class LastLoginTest extends AbstractControllerTestCase
+{
+    #[Test]
+    public function loggingInViaMagicLinkStampsLastLogin(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'testuser@criticalmass.in']);
+        $user->setLastLogin(new \DateTime('2020-01-01 12:00:00'));
+        $em->flush();
+
+        $before = new \DateTime();
+        $client->request('GET', $this->loginLinkFor($user));
+
+        self::assertTrue($client->getResponse()->isSuccessful() || $client->getResponse()->isRedirection());
+
+        $em->clear();
+        $reloaded = $em->getRepository(User::class)->findOneBy(['email' => 'testuser@criticalmass.in']);
+
+        self::assertNotNull($reloaded->getLastLogin());
+        self::assertGreaterThanOrEqual(
+            $before->getTimestamp(),
+            $reloaded->getLastLogin()->getTimestamp(),
+            'the magic link login must refresh last_login'
+        );
+    }
+
+    #[Test]
+    public function anonymousRequestsLeaveLastLoginAlone(): void
+    {
+        $client = static::createClient();
+        $em = static::getContainer()->get('doctrine')->getManager();
+
+        $user = $em->getRepository(User::class)->findOneBy(['email' => 'cyclist@criticalmass.in']);
+        $user->setLastLogin($stamp = new \DateTime('2021-06-01 08:00:00'));
+        $em->flush();
+        $em->clear();
+
+        $client->request('GET', '/');
+
+        $reloaded = $em->getRepository(User::class)->findOneBy(['email' => 'cyclist@criticalmass.in']);
+
+        self::assertSame($stamp->format('Y-m-d H:i:s'), $reloaded->getLastLogin()->format('Y-m-d H:i:s'));
+    }
+
+    private function loginLinkFor(User $user): string
+    {
+        /** @var LoginLinkHandlerInterface $handler */
+        $handler = static::getContainer()->get('security.authenticator.login_link_handler.main');
+
+        return $handler->createLoginLink($user)->getUrl();
+    }
+}

--- a/tests/EventSubscriber/LastLoginSubscriberTest.php
+++ b/tests/EventSubscriber/LastLoginSubscriberTest.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\Entity\User;
+use App\EventSubscriber\LastLoginSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+final class LastLoginSubscriberTest extends TestCase
+{
+    #[Test]
+    public function listensToTheInteractiveLoginEvent(): void
+    {
+        self::assertSame(
+            [SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin'],
+            LastLoginSubscriber::getSubscribedEvents()
+        );
+    }
+
+    #[Test]
+    public function stampsTheCurrentTimeOnTheUserAndFlushes(): void
+    {
+        $user = new User();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->once())->method('flush');
+
+        $before = new \DateTime();
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+        $after = new \DateTime();
+
+        self::assertNotNull($user->getLastLogin());
+        self::assertGreaterThanOrEqual($before->getTimestamp(), $user->getLastLogin()->getTimestamp());
+        self::assertLessThanOrEqual($after->getTimestamp(), $user->getLastLogin()->getTimestamp());
+    }
+
+    #[Test]
+    public function overwritesAPreviousLoginTimestamp(): void
+    {
+        $user = (new User())->setLastLogin(new \DateTime('2020-01-01 12:00:00'));
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->once())->method('flush');
+
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+
+        self::assertGreaterThan(new \DateTime('2020-01-02'), $user->getLastLogin());
+    }
+
+    #[Test]
+    public function ignoresTokensCarryingAForeignUserClass(): void
+    {
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->never())->method('flush');
+
+        $user = new InMemoryUser('someone', null);
+
+        $this->subscriber($manager)->onInteractiveLogin($this->event($user));
+
+        self::assertSame('someone', $user->getUserIdentifier(), 'the foreign user is left untouched');
+    }
+
+    private function subscriber(EntityManagerInterface $manager): LastLoginSubscriber
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        return new LastLoginSubscriber($registry);
+    }
+
+    private function event(object $user): InteractiveLoginEvent
+    {
+        return new InteractiveLoginEvent(new Request(), $this->token($user));
+    }
+
+    private function token(object $user): TokenInterface
+    {
+        return new UsernamePasswordToken($user, 'main', ['ROLE_USER']);
+    }
+}

--- a/tests/Security/Webauthn/PasskeyLastLoginTest.php
+++ b/tests/Security/Webauthn/PasskeyLastLoginTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Webauthn;
+
+use App\Entity\User;
+use App\EventSubscriber\LastLoginSubscriber;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Webauthn\Bundle\Security\Http\Authenticator\WebauthnAuthenticator;
+
+/**
+ * Passkey logins must refresh User::$lastLogin like the magic link and the
+ * OAuth logins do. That works because Symfony only dispatches the
+ * InteractiveLoginEvent — the event LastLoginSubscriber listens to — for
+ * authenticators that declare themselves interactive.
+ */
+final class PasskeyLastLoginTest extends KernelTestCase
+{
+    #[Test]
+    public function theWebauthnAuthenticatorIsInteractive(): void
+    {
+        $reflection = new \ReflectionClass(WebauthnAuthenticator::class);
+
+        self::assertTrue(
+            $reflection->implementsInterface(InteractiveAuthenticatorInterface::class),
+            'without this interface Symfony would not dispatch InteractiveLoginEvent for passkeys'
+        );
+
+        /** @var WebauthnAuthenticator $authenticator */
+        $authenticator = $reflection->newInstanceWithoutConstructor();
+
+        self::assertTrue($authenticator->isInteractive());
+    }
+
+    #[Test]
+    public function theMainFirewallUsesThatAuthenticator(): void
+    {
+        self::bootKernel();
+
+        self::assertTrue(
+            self::getContainer()->has('security.authenticator.webauthn.main'),
+            'the passkey authenticator is expected on the main firewall'
+        );
+    }
+
+    #[Test]
+    public function aPasskeyLoginStampsTheUser(): void
+    {
+        $user = new User();
+        $manager = $this->createMock(EntityManagerInterface::class);
+        $manager->expects($this->once())->method('flush');
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($manager);
+
+        $before = new \DateTime();
+        (new LastLoginSubscriber($registry))->onInteractiveLogin(
+            new InteractiveLoginEvent(new Request(), new UsernamePasswordToken($user, 'main', ['ROLE_USER']))
+        );
+
+        self::assertNotNull($user->getLastLogin());
+        self::assertGreaterThanOrEqual($before->getTimestamp(), $user->getLastLogin()->getTimestamp());
+    }
+}


### PR DESCRIPTION
## Summary
Stacked on #1467, and the passkey counterpart to #1477 in the cleanup stack.

`User::$lastLogin` was written in exactly one place — `UserProvider::createUser()` — i.e. only when an account was first created through OAuth. Signing in again never touched it, which is why the column looked as if nobody had used the Facebook login since 2024 while the access logs show completed callbacks every few days.

- `App\EventSubscriber\LastLoginSubscriber` stamps `lastLogin` on `InteractiveLoginEvent`.
- **Passkeys are covered:** `Webauthn\Bundle\Security\Http\Authenticator\WebauthnAuthenticator` implements `InteractiveAuthenticatorInterface` and returns `true` from `isInteractive()`, so Symfony dispatches the event for a passkey login exactly as it does for the magic link and OAuth. `PasskeyLastLoginTest` pins both that contract and the fact that the `main` firewall registers `security.authenticator.webauthn.main`.
- Deliberately **not** `LoginSuccessEvent`: that also fires for the stateless bearer-token firewalls (`/mcp`, API) and would mean a database write per API request.
- The one-off assignment in `UserProvider::createUser()` is removed; the subscriber fires right after account creation too.

**Note on the passkey registration ceremony:** it runs through the same authenticator, so registering a passkey while logged in also refreshes the stamp. That seems right (the user just proved presence), but say the word and I'll restrict it to the assertion ceremony.

`LastLoginSubscriber.php`, the `UserProvider` change and the two generic tests are **byte-identical** to #1477, so whichever of the two stacks lands second merges cleanly.

## Verification
- Full suite on this branch: `Tests: 1294, Assertions: 26344, 0 failures`
- `phpstan analyse` → `[OK] No errors`; `lint:container` → OK
- New tests: `PasskeyLastLoginTest` (3), `LastLoginSubscriberTest` (4), `LastLoginTest` (2, drives the real magic-link flow). Mutation-checked in the other stack: unregistering the subscriber makes the magic-link test fail.

No migration needed; the column exists. Historic values keep meaning "account created" — that cannot be backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)