### PR TITLE
Eingeloggt bleiben: Remember-Me-Cookie für den Magic-Link-Login

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -22,6 +22,14 @@ security:
             login_link:
                 check_route: login_check
                 signature_properties: [ 'email' ]
+            remember_me:
+                secret: '%kernel.secret%'
+                # Konten haben kein Passwort (Login per Magic Link oder OAuth), daher
+                # signiert das Cookie wie der login_link über die E-Mail-Adresse.
+                signature_properties: [ 'email' ]
+                lifetime: 31536000 # ein Jahr
+                secure: auto
+                samesite: lax
             provider: users
             pattern: .*
             context: user

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Recipient\Recipient;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 
 class LoginController extends AbstractController
@@ -87,6 +88,10 @@ class LoginController extends AbstractController
 
             $loginLinkDetails = $loginLinkHandler->createLoginLink($user);
 
+            if ($data['remember_me'] ?? false) {
+                $loginLinkDetails = $this->rememberLogin($loginLinkDetails);
+            }
+
             // create a notification based on the login link details
             $notification = new CriticalMassLoginLinkNotification(
                 $loginLinkDetails,
@@ -104,6 +109,19 @@ class LoginController extends AbstractController
         }
 
         return $this->redirectToRoute('login');
+    }
+
+    /**
+     * Der Magic Link wird per GET aufgerufen, es gibt also kein Formularfeld mehr, aus
+     * dem die Firewall den Wunsch ablesen könnte. Der Parameter reist deshalb in der
+     * Query des Links mit; consumeLoginLink() wertet nur user, expires und hash aus.
+     */
+    private function rememberLogin(LoginLinkDetails $loginLinkDetails): LoginLinkDetails
+    {
+        $url = $loginLinkDetails->getUrl();
+        $url .= (str_contains($url, '?') ? '&' : '?').'_remember_me=1';
+
+        return new LoginLinkDetails($url, $loginLinkDetails->getExpiresAt());
     }
 
     public function createNewUser(string $email): User

--- a/src/Form/Type/LoginType.php
+++ b/src/Form/Type/LoginType.php
@@ -3,6 +3,7 @@
 namespace App\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,6 +16,12 @@ class LoginType extends AbstractType
             ->add('email', EmailType::class, [
                 'label' => 'E-Mail-Adresse',
                 'help' => 'Wenn du noch kein Benutzerkonto hast, wird automatisch ein neues mit deiner E-Mail-Adresse erstellt.'
+            ])
+            ->add('remember_me', CheckboxType::class, [
+                'label' => 'Eingeloggt bleiben',
+                'required' => false,
+                'data' => true,
+                'help' => 'Du bleibst dann auf diesem Gerät ein Jahr lang angemeldet.',
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Link zusenden',

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -59,6 +59,7 @@
 
                         {{ form_start(login_form) }}
                         {{ form_row(login_form.email) }}
+                        {{ form_row(login_form.remember_me) }}
                         <div class="frc-captcha mb-3 mx-auto" data-sitekey="{{ app.request.server.get('FRIENDLYCAPTCHA_SITE_KEY') }}"></div>
                         {{ form_end(login_form) }}
                     </div>

--- a/tests/Form/LoginTypeTest.php
+++ b/tests/Form/LoginTypeTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Form;
+
+use App\Form\Type\LoginType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class LoginTypeTest extends TypeTestCase
+{
+    public function testRememberMeIsCheckedByDefault(): void
+    {
+        $form = $this->factory->create(LoginType::class);
+
+        $this->assertTrue($form->get('remember_me')->getData());
+    }
+
+    public function testRememberMeStaysUncheckedWhenNotSubmitted(): void
+    {
+        $form = $this->factory->create(LoginType::class);
+
+        $form->submit(['email' => 'cyclist@example.org']);
+
+        $this->assertFalse($form->getData()['remember_me']);
+    }
+
+    public function testRememberMeIsSubmitted(): void
+    {
+        $form = $this->factory->create(LoginType::class);
+
+        $form->submit(['email' => 'cyclist@example.org', 'remember_me' => '1']);
+
+        $this->assertTrue($form->getData()['remember_me']);
+    }
+}


### PR DESCRIPTION
## Summary

- `remember_me` in der `main`-Firewall konfiguriert (ein Jahr Laufzeit, `secure: auto`, `samesite: lax`) — bisher war es gar nicht eingerichtet, die Anmeldung endete also mit der PHP-Session bzw. dem Schließen des Browsers
- Die Cookie-Signatur läuft über `signature_properties: ['email']` wie beim `login_link`, weil Konten kein Passwort haben (Default wäre `password`)
- Checkbox „Eingeloggt bleiben" im Login-Formular, standardmäßig gesetzt — das Feld gab es bis 2014 schon einmal und ging beim Wechsel vom Passwort- auf den Magic-Link-Login verloren
- `LoginController` hängt `_remember_me=1` an den Magic Link, wenn die Checkbox gesetzt ist
- Drei Unit-Tests für `LoginType`

## Wie das zusammenspielt

`LoginLinkAuthenticator` legt bereits einen `RememberMeBadge` in den Passport, aber `CheckRememberMeConditionsListener` aktiviert ihn nur, wenn die Anfrage den Parameter `_remember_me` trägt. Beim Magic Link gibt es kein Formularfeld mehr, aus dem die Firewall das ablesen könnte — deshalb reist der Parameter in der Query des Links mit. `LoginLinkHandler::consumeLoginLink()` wertet ausschließlich `user`, `expires` und `hash` aus und ignoriert zusätzliche Parameter, die Signatur bleibt also unberührt.

Abmelden räumt auf: `RememberMeListener` hört auf `LogoutEvent` und löscht das Cookie.

## Nicht abgedeckt

Der OAuth-Login (Facebook/Strava) bringt zwar ebenfalls einen `RememberMeBadge` mit, aber die Checkbox lässt sich nicht durch die Weiterleitung zum Anbieter tragen. Wer sich so anmeldet, bleibt weiterhin nur für die Sitzung angemeldet. Das ließe sich mit einem kleinen `LoginSuccessEvent`-Listener nachrüsten, wäre dann aber eine Richtlinienentscheidung (immer merken, ohne Wahl).

## Test Plan

- [x] `vendor/bin/phpunit tests/Form/LoginTypeTest.php` — 3 Tests grün
- [x] `vendor/bin/phpstan analyse` auf den geänderten Dateien — keine Fehler
- [x] `bin/console lint:container` — grün, `security.authenticator.remember_me.main` ist verdrahtet
- [x] `bin/console debug:config security firewalls` zeigt die aufgelöste `remember_me`-Sektion
- [ ] Manuell: Login-Mail anfordern, Link klicken, Browser schließen, Seite erneut aufrufen — Anmeldung besteht; danach abmelden und prüfen, dass das `REMEMBERME`-Cookie verschwindet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR