### PR TITLE
CI auf main reparieren (Nachwehen des MCP-Merges)

### DIFF
--- a/src/DataFixtures/CityFixtures.php
+++ b/src/DataFixtures/CityFixtures.php
@@ -96,7 +96,7 @@ class CityFixtures extends Fixture implements DependentFixtureInterface
             $bayernRegion,
             $adminUser,
             $manager,
-            0.05
+            0.005
         );
         $this->addReference(self::INACTIVE_CITY_REFERENCE, $inactiveCity);
 

--- a/tests/Controller/Api/CycleApi/CycleApiDeleteTest.php
+++ b/tests/Controller/Api/CycleApi/CycleApiDeleteTest.php
@@ -31,6 +31,9 @@ class CycleApiDeleteTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, CityCycle, Ride}
+     */
     private function createCityWithCycleAndRide(): array
     {
         $slug = 'cycle-del-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Controller/Api/EstimateApi/EstimateApiWriteTest.php
+++ b/tests/Controller/Api/EstimateApi/EstimateApiWriteTest.php
@@ -31,6 +31,9 @@ class EstimateApiWriteTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, Ride, RideEstimate}
+     */
     private function createRideWithEstimate(int $participants = 100): array
     {
         $slug = 'estimate-api-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Controller/Api/RideApi/RideApiEnabledTest.php
+++ b/tests/Controller/Api/RideApi/RideApiEnabledTest.php
@@ -29,6 +29,9 @@ class RideApiEnabledTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, Ride}
+     */
     private function createRide(): array
     {
         $slug = 'ride-enabled-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Controller/Api/SocialNetworkProfileApi/SocialNetworkDeleteTest.php
+++ b/tests/Controller/Api/SocialNetworkProfileApi/SocialNetworkDeleteTest.php
@@ -29,6 +29,9 @@ class SocialNetworkDeleteTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, SocialNetworkProfile}
+     */
     private function createProfile(): array
     {
         $slug = 'social-api-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Controller/Api/SubrideApi/SubrideApiWriteTest.php
+++ b/tests/Controller/Api/SubrideApi/SubrideApiWriteTest.php
@@ -31,6 +31,9 @@ class SubrideApiWriteTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, Ride}
+     */
     private function createRide(): array
     {
         $slug = 'subride-api-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Controller/Api/WeatherApi/WeatherApiWriteTest.php
+++ b/tests/Controller/Api/WeatherApi/WeatherApiWriteTest.php
@@ -31,6 +31,9 @@ class WeatherApiWriteTest extends AbstractApiControllerTestCase
         parent::tearDown();
     }
 
+    /**
+     * @return array{City, Ride, Weather}
+     */
     private function createRideWithWeather(): array
     {
         $slug = 'weather-api-' . substr(md5(uniqid('', true)), 0, 12);

--- a/tests/Repository/CityRepositoryTest.php
+++ b/tests/Repository/CityRepositoryTest.php
@@ -25,7 +25,7 @@ class CityRepositoryTest extends KernelTestCase
 
         $cityNames = array_map(fn(City $city) => $city->getCity(), $activeCities);
 
-        $this->assertNotContains('Ghosttown', $cityNames, 'Inactive city (score < 0.15) should be excluded');
+        $this->assertNotContains('Ghosttown', $cityNames, 'Inactive city (score below the threshold) should be excluded');
     }
 
     public function testFindActiveCitiesIncludesHighScoreCities(): void
@@ -61,7 +61,7 @@ class CityRepositoryTest extends KernelTestCase
 
     public function testActivityScoreThreshold(): void
     {
-        $this->assertEquals(0.15, CityRepository::ACTIVITY_SCORE_THRESHOLD);
+        $this->assertEquals(0.01, CityRepository::ACTIVITY_SCORE_THRESHOLD);
     }
 
     protected function tearDown(): void

--- a/tests/Repository/RideRepositoryTest.php
+++ b/tests/Repository/RideRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Repository;
 
 use App\Entity\City;
 use App\Entity\Ride;
+use App\Repository\CityRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -25,7 +26,7 @@ class RideRepositoryTest extends KernelTestCase
             $this->markTestSkipped('Inactive city fixture not found');
         }
 
-        $this->assertLessThan(0.15, $inactiveCity->getActivityScore(), 'Test requires inactive city with low score');
+        $this->assertLessThan(CityRepository::ACTIVITY_SCORE_THRESHOLD, $inactiveCity->getActivityScore(), 'Test requires inactive city with low score');
 
         $rides = $this->entityManager->getRepository(Ride::class)->findFrontpageRides();
 
@@ -49,8 +50,8 @@ class RideRepositoryTest extends KernelTestCase
         foreach ($rides as $ride) {
             $city = $ride->getCity();
             $this->assertTrue(
-                $city->getActivityScore() === null || $city->getActivityScore() >= 0.15,
-                sprintf('Ride from city %s should have activity score >= 0.15 or NULL', $city->getCity())
+                $city->getActivityScore() === null || $city->getActivityScore() >= CityRepository::ACTIVITY_SCORE_THRESHOLD,
+                sprintf('Ride from city %s should have activity score >= %s or NULL', $city->getCity(), CityRepository::ACTIVITY_SCORE_THRESHOLD)
             );
         }
     }


### PR DESCRIPTION
## Summary

`main` ist seit dem Merge des MCP-Stacks (#1439–#1446) rot: 6 PHPStan-Fehler und 3 PHPUnit-Failures. Jede der acht PRs war einzeln grün — zusammengeführt sind sie es nicht.

**PHPStan (6 Fehler, `missingType.iterableValue`)**
Die `tests/Controller/Api/*`-Dateien stammen aus dem Juli und kamen ohne passende Baseline-Einträge herein, weil `phpstan-baseline.neon` auf `main` zwischenzeitlich neu erzeugt wurde. Statt sie nachträglich zu baselinen bekommen die sechs Hilfsmethoden echte Array-Shapes (`@return array{City, Ride}` usw.).

**PHPUnit (3 Failures)**
Der Server-Hotfix „Lower activity score threshold 0.15 → 0.01" (`b4f21706a`, kam über den `mcp-live`-Branch mit) senkte `CityRepository::ACTIVITY_SCORE_THRESHOLD`, ohne die Tests nachzuziehen. Die Fixture-Stadt Ghosttown lag mit `0.05` genau zwischen alter und neuer Schwelle und galt damit nicht mehr als inaktiv, worauf zwei Tests bauen. Der Fixture-Wert liegt jetzt mit `0.005` wieder darunter, und `testActivityScoreThreshold` pinnt den tatsächlichen Wert.

Wo Tests die Schwelle sonst als Literal führten (`RideRepositoryTest`), verweisen sie jetzt auf die Konstante — dann läuft dieselbe Falle beim nächsten Schwellenwechsel nicht wieder zu.

## Test Plan

- [x] `vendor/bin/phpstan analyse` — vorher 6 Fehler, jetzt grün
- [ ] PHPUnit über CI (die Suite lokal laufen zu lassen überschreibt die Dev-Daten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR