### PR TITLE
Forum: Beiträge und Thread-Titel bearbeiten

### DIFF
--- a/migrations/Version20260901210000.php
+++ b/migrations/Version20260901210000.php
@@ -20,14 +20,14 @@ final class Version20260901210000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE post ADD updatedAt DATETIME DEFAULT NULL, ADD updated_by_user_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE post ADD CONSTRAINT FK_5A8A6C8D8C1D8E29 FOREIGN KEY (updated_by_user_id) REFERENCES user (id)');
-        $this->addSql('CREATE INDEX IDX_5A8A6C8D8C1D8E29 ON post (updated_by_user_id)');
+        $this->addSql('ALTER TABLE post ADD CONSTRAINT FK_5A8A6C8D2793CC5E FOREIGN KEY (updated_by_user_id) REFERENCES user (id)');
+        $this->addSql('CREATE INDEX IDX_5A8A6C8D2793CC5E ON post (updated_by_user_id)');
     }
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE post DROP FOREIGN KEY FK_5A8A6C8D8C1D8E29');
-        $this->addSql('DROP INDEX IDX_5A8A6C8D8C1D8E29 ON post');
+        $this->addSql('ALTER TABLE post DROP FOREIGN KEY FK_5A8A6C8D2793CC5E');
+        $this->addSql('DROP INDEX IDX_5A8A6C8D2793CC5E ON post');
         $this->addSql('ALTER TABLE post DROP updatedAt, DROP updated_by_user_id');
     }
 }

--- a/migrations/Version20260901210000.php
+++ b/migrations/Version20260901210000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Track edits of forum posts: when a post was last changed and by whom.
+ */
+final class Version20260901210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add updatedAt and updated_by_user_id to post';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE post ADD updatedAt DATETIME DEFAULT NULL, ADD updated_by_user_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE post ADD CONSTRAINT FK_5A8A6C8D8C1D8E29 FOREIGN KEY (updated_by_user_id) REFERENCES user (id)');
+        $this->addSql('CREATE INDEX IDX_5A8A6C8D8C1D8E29 ON post (updated_by_user_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE post DROP FOREIGN KEY FK_5A8A6C8D8C1D8E29');
+        $this->addSql('DROP INDEX IDX_5A8A6C8D8C1D8E29 ON post');
+        $this->addSql('ALTER TABLE post DROP updatedAt, DROP updated_by_user_id');
+    }
+}

--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -12,6 +12,7 @@ use App\Entity\City;
 use App\Entity\Post;
 use App\Entity\Thread;
 use App\EntityInterface\BoardInterface;
+use App\Form\Type\ThreadType;
 use Malenki\Slug;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -82,6 +83,53 @@ class BoardController extends AbstractController
             'thread' => $thread,
             'posts' => $posts,
         ]);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/thread/edit/{threadSlug}', name: 'caldera_criticalmass_board_editthread', priority: 240)]
+    public function editThreadAction(
+        Request $request,
+        ObjectRouterInterface $objectRouter,
+        ThreadRepository $threadRepository,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->denyAccessUnlessGranted('edit', $thread);
+
+        $form = $this->createForm(ThreadType::class, $thread);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $thread->setSlug($this->uniqueThreadSlug((string) $thread->getTitle(), $thread, $threadRepository));
+
+            $this->managerRegistry->getManager()->flush();
+
+            $this->addFlash('success', 'Der Titel wurde geändert.');
+
+            return $this->redirect($objectRouter->generate($thread));
+        }
+
+        return $this->render('Board/edit_thread.html.twig', [
+            'board' => $thread->getCity() ?? $thread->getBoard(),
+            'thread' => $thread,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * Der Slug wandert mit dem Titel mit. Weil er die Adresse des Themas ist, darf er
+     * kein zweites Mal vorkommen — sonst liefert findThreadBySlug() mehr als ein Ergebnis.
+     */
+    protected function uniqueThreadSlug(string $title, Thread $thread, ThreadRepository $threadRepository): string
+    {
+        $base = (new Slug($title))->render();
+        $slug = $base;
+        $suffix = 1;
+
+        while (null !== ($existing = $threadRepository->findOneBy(['slug' => $slug])) && $existing !== $thread) {
+            $slug = sprintf('%s-%d', $base, ++$suffix);
+        }
+
+        return $slug;
     }
 
     #[IsGranted('ROLE_USER')]

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -11,6 +11,7 @@ use App\Entity\City;
 use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\Thread;
+use App\Entity\User;
 use App\EntityInterface\BoardInterface;
 use App\Form\Type\PostType;
 use Symfony\Component\Form\FormInterface;
@@ -108,6 +109,54 @@ class PostController extends AbstractController
         return $this->render('Post/write_failed.html.twig', [
             'form' => $form->createView(),
         ]);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/post/edit/{postId}', name: 'caldera_criticalmass_post_edit', priority: 120)]
+    public function editAction(
+        Request $request,
+        ObjectRouterInterface $objectRouter,
+        #[MapEntity(mapping: ['postId' => 'id'])] Post $post
+    ): Response {
+        $this->denyAccessUnlessGranted('edit', $post);
+
+        $form = $this->createForm(PostType::class, $post);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var User $editor */
+            $editor = $this->getUser();
+
+            $post
+                ->setUpdatedAt(new \DateTime())
+                ->setUpdatedBy($editor);
+
+            $this->managerRegistry->getManager()->flush();
+
+            $this->addFlash('success', 'Dein Beitrag wurde geändert.');
+
+            return $this->redirect($this->generatePostUrl($post, $objectRouter));
+        }
+
+        return $this->render('Post/edit.html.twig', [
+            'post' => $post,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * Ein Beitrag hängt immer an genau einem Gegenstand — Thema, Tour, Stadt oder Foto.
+     * Nach dem Bearbeiten landet man wieder dort, beim Beitrag selbst.
+     */
+    protected function generatePostUrl(Post $post, ObjectRouterInterface $objectRouter): string
+    {
+        $postable = $post->getThread() ?? $post->getRide() ?? $post->getCity() ?? $post->getPhoto();
+
+        if (null === $postable) {
+            return $this->generateUrl('caldera_criticalmass_board_overview');
+        }
+
+        return sprintf('%s#post-%d', $objectRouter->generate($postable), $post->getId());
     }
 
     public function listAction(

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -81,6 +81,15 @@ class Post
     #[Groups(['post-list'])]
     protected ?string $message = null;
 
+    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[Groups(['post-list'])]
+    protected ?\DateTime $updatedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'updated_by_user_id', referencedColumnName: 'id', nullable: true)]
+    #[Ignore]
+    protected ?User $updatedBy = null;
+
     #[DataQuery\DefaultBooleanValue(alias: 'isEnabled', value: true)]
     #[ORM\Column(type: 'boolean', nullable: true)]
     #[Ignore]
@@ -130,6 +139,35 @@ class Post
     public function setDateTime(\DateTime $dateTime): Post
     {
         $this->dateTime = $dateTime;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTime $updatedAt): Post
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function isEdited(): bool
+    {
+        return null !== $this->updatedAt;
+    }
+
+    public function getUpdatedBy(): ?User
+    {
+        return $this->updatedBy;
+    }
+
+    public function setUpdatedBy(?User $updatedBy): Post
+    {
+        $this->updatedBy = $updatedBy;
 
         return $this;
     }

--- a/src/Form/Type/ThreadType.php
+++ b/src/Form/Type/ThreadType.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Form\Type;
+
+use App\Entity\Thread;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ThreadType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('title', TextType::class, [
+                'label' => 'Titel des Themas',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Thread::class,
+        ]);
+    }
+}

--- a/src/Security/Authorization/Voter/PostVoter.php
+++ b/src/Security/Authorization/Voter/PostVoter.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\Authorization\Voter;
+
+use App\Entity\Post;
+use App\Entity\User;
+
+class PostVoter extends AbstractVoter
+{
+    protected function canEdit(Post $post, User $user): bool
+    {
+        if ($user->hasRole('ROLE_ADMIN')) {
+            return true;
+        }
+
+        return $user === $post->getUser();
+    }
+}

--- a/src/Security/Authorization/Voter/ThreadVoter.php
+++ b/src/Security/Authorization/Voter/ThreadVoter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace App\Security\Authorization\Voter;
+
+use App\Entity\Thread;
+use App\Entity\User;
+
+class ThreadVoter extends AbstractVoter
+{
+    /**
+     * Wer das Thema eröffnet hat, darf seinen Titel ändern — erkennbar am Autor des ersten Beitrags.
+     */
+    protected function canEdit(Thread $thread, User $user): bool
+    {
+        if ($user->hasRole('ROLE_ADMIN')) {
+            return true;
+        }
+
+        $firstPost = $thread->getFirstPost();
+
+        return null !== $firstPost && $user === $firstPost->getUser();
+    }
+}

--- a/templates/Board/edit_thread.html.twig
+++ b/templates/Board/edit_thread.html.twig
@@ -1,0 +1,47 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}Titel bearbeiten{% endblock %}
+
+{% block breadcrumb %}
+    {{ breadcrumb.item('Diskussionen', path('caldera_criticalmass_board_overview')) }}
+    {{ breadcrumb.item(board.title, object_path(board)) }}
+    {{ breadcrumb.item(thread.title, object_path(thread)) }}
+    {{ breadcrumb.active('Titel bearbeiten') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h3 mb-0">
+                <i class="far fa-edit text-muted me-2"></i>
+                Titel bearbeiten
+            </h1>
+        </div>
+
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_errors(form) }}
+
+                <div class="mb-3">
+                    <label class="form-label" for="{{ form.title.vars.id }}">Titel deines Themas:</label>
+                    {{ form_widget(form.title, { 'attr' : { 'class': 'form-control'} }) }}
+                    <div class="form-text">Mit dem Titel &auml;ndert sich auch die Adresse des Themas.</div>
+                </div>
+
+                <div class="d-flex justify-content-end">
+                    <a href="{{ object_path(thread) }}" class="btn btn-light me-2">
+                        Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-success">
+                        <i class="far fa-save me-1"></i>
+                        Speichern
+                    </button>
+                </div>
+
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -16,12 +16,21 @@
                 <i class="far fa-comment-alt text-muted me-2"></i>
                 {{ thread.title }}
             </h1>
-            {% if app.getUser() %}
-                <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modal-add-post">
-                    <i class="far fa-comment me-1"></i>
-                    <span class="d-none d-sm-inline">Antwort hinzuf&uuml;gen</span>
-                </button>
-            {% endif %}
+            <div class="d-flex gap-2">
+                {% if is_granted('edit', thread) %}
+                    <a href="{{ path('caldera_criticalmass_board_editthread', { 'threadSlug': thread.slug }) }}"
+                       class="btn btn-outline-secondary btn-sm">
+                        <i class="far fa-edit me-1"></i>
+                        <span class="d-none d-sm-inline">Titel bearbeiten</span>
+                    </a>
+                {% endif %}
+                {% if app.getUser() %}
+                    <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modal-add-post">
+                        <i class="far fa-comment me-1"></i>
+                        <span class="d-none d-sm-inline">Antwort hinzuf&uuml;gen</span>
+                    </button>
+                {% endif %}
+            </div>
         </div>
 
         {% for post in posts %}

--- a/templates/Post/edit.html.twig
+++ b/templates/Post/edit.html.twig
@@ -1,0 +1,47 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}Beitrag bearbeiten{% endblock %}
+
+{% block breadcrumb %}
+    {% if post.thread %}
+        {{ breadcrumb.item('Diskussionen', path('caldera_criticalmass_board_overview')) }}
+        {{ breadcrumb.item(post.thread.title, object_path(post.thread)) }}
+    {% endif %}
+    {{ breadcrumb.active('Beitrag bearbeiten') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h3 mb-0">
+                <i class="far fa-edit text-muted me-2"></i>
+                Beitrag bearbeiten
+            </h1>
+        </div>
+
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_errors(form) }}
+
+                <div class="mb-3">
+                    <label class="form-label" for="{{ form.message.vars.id }}">Dein Beitrag:</label>
+                    {{ form_widget(form.message, { 'attr' : { 'class': 'form-control', 'rows': 10 } }) }}
+                </div>
+
+                <div class="d-flex justify-content-end">
+                    <a href="{{ object_path(post.thread ?? post.ride ?? post.city ?? post.photo) }}" class="btn btn-light me-2">
+                        Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-success">
+                        <i class="far fa-save me-1"></i>
+                        Speichern
+                    </button>
+                </div>
+
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Post/post.html.twig
+++ b/templates/Post/post.html.twig
@@ -33,6 +33,19 @@
                 <div class="post-content">
                     {{ post.message|markdown }}
                 </div>
+                {% if post.isEdited %}
+                    <p class="text-muted small fst-italic mt-2 mb-0">
+                        bearbeitet am {{ post.updatedAt|date('d.m.Y, H:i', 'Europe/Berlin') }}
+                    </p>
+                {% endif %}
+                {% if is_granted('edit', post) %}
+                    <div class="mt-2">
+                        <a href="{{ path('caldera_criticalmass_post_edit', { 'postId': post.id }) }}"
+                           class="btn btn-outline-secondary btn-sm">
+                            <i class="far fa-edit me-1"></i>Bearbeiten
+                        </a>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/tests/Controller/ForumEditControllerTest.php
+++ b/tests/Controller/ForumEditControllerTest.php
@@ -73,11 +73,10 @@ class ForumEditControllerTest extends AbstractControllerTestCase
         $slug = $this->openThread($client, 'Fremder Beitrag Test');
         $post = $this->firstPostOf($slug);
 
-        $other = static::createClient();
-        $this->loginAs($other, 'cyclist@criticalmass.in');
-        $other->request('GET', '/post/edit/' . $post->getId());
+        $this->loginAs($client, 'cyclist@criticalmass.in');
+        $client->request('GET', '/post/edit/' . $post->getId());
 
-        self::assertEquals(403, $other->getResponse()->getStatusCode());
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
     }
 
     public function testEditPostRequiresLogin(): void
@@ -87,10 +86,10 @@ class ForumEditControllerTest extends AbstractControllerTestCase
         $slug = $this->openThread($client, 'Anonymer Zugriff Test');
         $post = $this->firstPostOf($slug);
 
-        $anonymous = static::createClient();
-        $anonymous->request('GET', '/post/edit/' . $post->getId());
+        $client->getCookieJar()->clear();
+        $client->request('GET', '/post/edit/' . $post->getId());
 
-        self::assertEquals(302, $anonymous->getResponse()->getStatusCode());
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
     }
 
     public function testThreadOpenerCanRenameTheThread(): void
@@ -147,10 +146,9 @@ class ForumEditControllerTest extends AbstractControllerTestCase
         $this->loginAs($client, self::AUTHOR);
         $slug = $this->openThread($client, 'Fremdes Thema Test');
 
-        $other = static::createClient();
-        $this->loginAs($other, 'cyclist@criticalmass.in');
-        $other->request('GET', '/thread/edit/' . $slug);
+        $this->loginAs($client, 'cyclist@criticalmass.in');
+        $client->request('GET', '/thread/edit/' . $slug);
 
-        self::assertEquals(403, $other->getResponse()->getStatusCode());
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
     }
 }

--- a/tests/Controller/ForumEditControllerTest.php
+++ b/tests/Controller/ForumEditControllerTest.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Post;
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumEditControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+
+    /**
+     * Legt über das Formular ein frisches Thema an und liefert dessen Slug zurück.
+     */
+    private function openThread(KernelBrowser $client, string $title): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = 'Der erste Beitrag zu ' . $title . '.';
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread, 'Das Thema sollte angelegt worden sein.');
+
+        return (string) $thread->getSlug();
+    }
+
+    private function firstPostOf(string $threadSlug): Post
+    {
+        $doctrine = static::getContainer()->get('doctrine');
+        $thread = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $threadSlug]);
+
+        $post = $thread?->getFirstPost();
+        self::assertInstanceOf(Post::class, $post);
+
+        return $post;
+    }
+
+    public function testAuthorCanEditTheirPost(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Beitrag bearbeiten Test');
+        $post = $this->firstPostOf($slug);
+
+        $crawler = $client->request('GET', '/post/edit/' . $post->getId());
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['post[message]'] = 'Dieser Text wurde nachträglich geändert.';
+        $client->submit($form);
+
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+
+        static::getContainer()->get('doctrine')->getManager()->clear();
+        $updated = static::getContainer()->get('doctrine')->getRepository(Post::class)->find($post->getId());
+
+        self::assertSame('Dieser Text wurde nachträglich geändert.', $updated->getMessage());
+        self::assertNotNull($updated->getUpdatedAt(), 'Eine Bearbeitung muss einen Zeitstempel hinterlassen.');
+    }
+
+    public function testStrangerCannotEditSomeoneElsesPost(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Fremder Beitrag Test');
+        $post = $this->firstPostOf($slug);
+
+        $other = static::createClient();
+        $this->loginAs($other, 'cyclist@criticalmass.in');
+        $other->request('GET', '/post/edit/' . $post->getId());
+
+        self::assertEquals(403, $other->getResponse()->getStatusCode());
+    }
+
+    public function testEditPostRequiresLogin(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Anonymer Zugriff Test');
+        $post = $this->firstPostOf($slug);
+
+        $anonymous = static::createClient();
+        $anonymous->request('GET', '/post/edit/' . $post->getId());
+
+        self::assertEquals(302, $anonymous->getResponse()->getStatusCode());
+    }
+
+    public function testThreadOpenerCanRenameTheThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Titel vorher');
+
+        $crawler = $client->request('GET', '/thread/edit/' . $slug);
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['thread[title]'] = 'Titel nachher';
+        $client->submit($form);
+
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+        $thread = $doctrine->getRepository(Thread::class)->findOneBy(['title' => 'Titel nachher']);
+
+        self::assertNotNull($thread);
+        self::assertSame('titel-nachher', $thread->getSlug(), 'Der Slug wandert mit dem Titel mit.');
+    }
+
+    public function testRenamingKeepsSlugsUnique(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $this->openThread($client, 'Doppelter Titel');
+        $secondSlug = $this->openThread($client, 'Noch ein Thema');
+
+        $crawler = $client->request('GET', '/thread/edit/' . $secondSlug);
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['thread[title]'] = 'Doppelter Titel';
+        $client->submit($form);
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+        $threads = $doctrine->getRepository(Thread::class)->findBy(['title' => 'Doppelter Titel']);
+
+        self::assertCount(2, $threads);
+        self::assertNotSame(
+            $threads[0]->getSlug(),
+            $threads[1]->getSlug(),
+            'Zwei Themen dürfen nie unter derselben Adresse liegen.'
+        );
+    }
+
+    public function testStrangerCannotRenameThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Fremdes Thema Test');
+
+        $other = static::createClient();
+        $this->loginAs($other, 'cyclist@criticalmass.in');
+        $other->request('GET', '/thread/edit/' . $slug);
+
+        self::assertEquals(403, $other->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Security/Authorization/Voter/PostVoterTest.php
+++ b/tests/Security/Authorization/Voter/PostVoterTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Authorization\Voter;
+
+use App\Entity\Post;
+use App\Entity\User;
+use App\Security\Authorization\Voter\PostVoter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class PostVoterTest extends TestCase
+{
+    private function token(?User $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function user(array $roles = []): User
+    {
+        return (new User())->setRoles($roles);
+    }
+
+    public function testAuthorMayEditTheirOwnPost(): void
+    {
+        $author = $this->user();
+        $post = (new Post())->setUser($author);
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            (new PostVoter())->vote($this->token($author), $post, ['edit'])
+        );
+    }
+
+    public function testStrangerMayNotEditSomeoneElsesPost(): void
+    {
+        $post = (new Post())->setUser($this->user());
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            (new PostVoter())->vote($this->token($this->user()), $post, ['edit'])
+        );
+    }
+
+    public function testAdminMayEditAnyPost(): void
+    {
+        $post = (new Post())->setUser($this->user());
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            (new PostVoter())->vote($this->token($this->user(['ROLE_ADMIN'])), $post, ['edit'])
+        );
+    }
+
+    public function testAnonymousVisitorMayNotEdit(): void
+    {
+        $post = (new Post())->setUser($this->user());
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            (new PostVoter())->vote($this->token(null), $post, ['edit'])
+        );
+    }
+
+    public function testVoterAbstainsOnForeignAttributes(): void
+    {
+        $post = (new Post())->setUser($this->user());
+
+        // Wichtig: access_decision_manager läuft auf "unanimous" — ein Voter, der sich
+        // für fremde Attribute zuständig erklärt, würde andere Entscheidungen kippen.
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            (new PostVoter())->vote($this->token($this->user()), $post, ['delete'])
+        );
+    }
+
+    public function testVoterAbstainsOnForeignSubjects(): void
+    {
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            (new PostVoter())->vote($this->token($this->user()), new \stdClass(), ['edit'])
+        );
+    }
+}

--- a/tests/Security/Authorization/Voter/ThreadVoterTest.php
+++ b/tests/Security/Authorization/Voter/ThreadVoterTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Security\Authorization\Voter;
+
+use App\Entity\Post;
+use App\Entity\Thread;
+use App\Entity\User;
+use App\Security\Authorization\Voter\ThreadVoter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+class ThreadVoterTest extends TestCase
+{
+    private function token(?User $user): TokenInterface
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+
+    /**
+     * @param list<string> $roles
+     */
+    private function user(array $roles = []): User
+    {
+        return (new User())->setRoles($roles);
+    }
+
+    private function threadOpenedBy(?User $author): Thread
+    {
+        $thread = new Thread();
+
+        if (null !== $author) {
+            $thread->setFirstPost((new Post())->setUser($author));
+        }
+
+        return $thread;
+    }
+
+    public function testThreadOpenerMayEditTheTitle(): void
+    {
+        $opener = $this->user();
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            (new ThreadVoter())->vote($this->token($opener), $this->threadOpenedBy($opener), ['edit'])
+        );
+    }
+
+    public function testSomeoneWhoOnlyRepliedMayNotEditTheTitle(): void
+    {
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            (new ThreadVoter())->vote($this->token($this->user()), $this->threadOpenedBy($this->user()), ['edit'])
+        );
+    }
+
+    public function testAdminMayEditAnyTitle(): void
+    {
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            (new ThreadVoter())->vote($this->token($this->user(['ROLE_ADMIN'])), $this->threadOpenedBy($this->user()), ['edit'])
+        );
+    }
+
+    public function testThreadWithoutFirstPostIsEditableByAdminsOnly(): void
+    {
+        // Ältere Threads können ohne firstPost in der Datenbank liegen.
+        $voter = new ThreadVoter();
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($this->user()), $this->threadOpenedBy(null), ['edit'])
+        );
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $this->threadOpenedBy(null), ['edit'])
+        );
+    }
+
+    public function testAnonymousVisitorMayNotEdit(): void
+    {
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            (new ThreadVoter())->vote($this->token(null), $this->threadOpenedBy($this->user()), ['edit'])
+        );
+    }
+
+    public function testVoterAbstainsOnForeignAttributes(): void
+    {
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            (new ThreadVoter())->vote($this->token($this->user()), $this->threadOpenedBy($this->user()), ['move'])
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Erster Teil des Forum-Ausbaus. Bisher war ein Beitrag nach dem Absenden endgültig — es gab weder einen Bearbeiten-Endpunkt noch Voter für `Post` oder `Thread`.

- **`PostVoter`** und **`ThreadVoter`** nach der `AbstractVoter`-Konvention (`can<Attribut>`). Beide enthalten sich bei fremden Attributen — der `access_decision_manager` läuft auf `unanimous`, ein zu breiter Voter würde fremde Entscheidungen kippen.
- **`Post::$updatedAt` und `Post::$updatedBy`** plus Migration, damit eine Änderung sichtbar bleibt statt still zu passieren. Im Beitrag steht dann „bearbeitet am …".
- **`/post/edit/{postId}`** — Autor und Admin, leitet zurück zum Beitrag (`#post-N`), egal ob er an einem Thema, einer Tour, einer Stadt oder einem Foto hängt.
- **`/thread/edit/{threadSlug}`** — wer das Thema eröffnet hat (Autor des ersten Beitrags) und jeder Admin. Neuer `ThreadType`; das Thread-Formular war bisher inline im Controller.
- Buttons in `Post/post.html.twig` und `Board/view_thread.html.twig`, jeweils hinter `is_granted`.

## Slug-Eindeutigkeit

Der Slug ist die Adresse des Themas und wandert mit dem Titel mit. `ThreadRepository::findThreadBySlug()` nutzt `getSingleResult()` und würde bei zwei gleichen Slugs eine Exception werfen — deshalb hängt `uniqueThreadSlug()` bei Kollision einen Zähler an. Beim Anlegen eines Themas gab es diese Prüfung bisher nicht; das bleibt in diesem PR unverändert, ist aber der nächste Kandidat.

## Test Plan

- [x] `vendor/bin/phpunit tests/Security/Authorization/Voter/` — 12 Tests grün (reine Unit-Tests, ohne Datenbank)
- [x] `vendor/bin/phpstan analyse` auf allen geänderten Dateien — keine Fehler
- [ ] `tests/Controller/ForumEditControllerTest.php` — 6 funktionale Tests, laufen in CI (lokal überschreibt die Suite die Dev-Daten)
- [ ] Manuell: fremden Beitrag aufrufen → 403; eigenen bearbeiten → „bearbeitet am" erscheint; Titel ändern → Weiterleitung auf die neue Adresse

Closes #1147
Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR