### PR TITLE
Forum: Threads schließen und anheften

### DIFF
--- a/migrations/Version20260901213000.php
+++ b/migrations/Version20260901213000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Moderation states for forum threads: closed threads take no further replies,
+ * sticky threads stay on top of the list.
+ */
+final class Version20260901213000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add locked and sticky to thread';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE thread ADD locked TINYINT(1) DEFAULT 0 NOT NULL, ADD sticky TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE thread DROP locked, DROP sticky');
+    }
+}

--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -115,6 +115,44 @@ class BoardController extends AbstractController
         ]);
     }
 
+    #[IsGranted('ROLE_USER')]
+    #[Route('/thread/lock/{threadSlug}', name: 'caldera_criticalmass_board_lockthread', methods: ['POST'], priority: 240)]
+    public function lockThreadAction(
+        ObjectRouterInterface $objectRouter,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->denyAccessUnlessGranted('lock', $thread);
+
+        $thread->setLocked(!$thread->isLocked());
+
+        $this->managerRegistry->getManager()->flush();
+
+        $this->addFlash('success', $thread->isLocked()
+            ? 'Das Thema ist geschlossen und nimmt keine Antworten mehr an.'
+            : 'Das Thema ist wieder offen für Antworten.');
+
+        return $this->redirect($objectRouter->generate($thread));
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/thread/pin/{threadSlug}', name: 'caldera_criticalmass_board_pinthread', methods: ['POST'], priority: 240)]
+    public function pinThreadAction(
+        ObjectRouterInterface $objectRouter,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->denyAccessUnlessGranted('pin', $thread);
+
+        $thread->setSticky(!$thread->isSticky());
+
+        $this->managerRegistry->getManager()->flush();
+
+        $this->addFlash('success', $thread->isSticky()
+            ? 'Das Thema steht jetzt oben in der Liste.'
+            : 'Das Thema steht wieder in der normalen Reihenfolge.');
+
+        return $this->redirect($objectRouter->generate($thread));
+    }
+
     /**
      * Der Slug wandert mit dem Titel mit. Weil er die Adresse des Themas ist, darf er
      * kein zweites Mal vorkommen — sonst liefert findThreadBySlug() mehr als ein Ergebnis.

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -76,6 +76,12 @@ class PostController extends AbstractController
 
     protected function addPostAction(Request $request, FormInterface $form, Post $post, PostableInterface $postable, ObjectRouterInterface $objectRouter): Response
     {
+        // Das Template blendet das Formular bei geschlossenen Themen aus; hier wird
+        // der direkte POST abgewiesen, der daran vorbeigeht.
+        if ($postable instanceof Thread && $postable->isLocked()) {
+            throw $this->createAccessDeniedException('Dieses Thema ist geschlossen und nimmt keine Antworten mehr an.');
+        }
+
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Entity/Thread.php
+++ b/src/Entity/Thread.php
@@ -49,6 +49,18 @@ class Thread implements RouteableInterface, PostableInterface
     #[ORM\Column(type: 'boolean', nullable: true)]
     protected ?bool $enabled = true;
 
+    /**
+     * Geschlossene Themen bleiben lesbar, nehmen aber keine Antworten mehr an.
+     */
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    protected bool $locked = false;
+
+    /**
+     * Angeheftete Themen stehen unabhängig vom letzten Beitrag oben in der Liste.
+     */
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    protected bool $sticky = false;
+
     public function __construct()
     {
     }
@@ -73,6 +85,30 @@ class Thread implements RouteableInterface, PostableInterface
     public function setEnabled(bool $enabled): Thread
     {
         $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->locked;
+    }
+
+    public function setLocked(bool $locked): Thread
+    {
+        $this->locked = $locked;
+
+        return $this;
+    }
+
+    public function isSticky(): bool
+    {
+        return $this->sticky;
+    }
+
+    public function setSticky(bool $sticky): Thread
+    {
+        $this->sticky = $sticky;
 
         return $this;
     }

--- a/src/Repository/ThreadRepository.php
+++ b/src/Repository/ThreadRepository.php
@@ -26,7 +26,8 @@ class ThreadRepository extends ServiceEntityRepository
             ->setParameter('board', $board)
             ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
             ->setParameter('enabled', true)
-            ->orderBy('lastPost.dateTime', 'DESC');
+            ->orderBy('t.sticky', 'DESC')
+            ->addOrderBy('lastPost.dateTime', 'DESC');
 
         $query = $builder->getQuery();
 
@@ -44,7 +45,8 @@ class ThreadRepository extends ServiceEntityRepository
             ->setParameter('city', $city)
             ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
             ->setParameter('enabled', true)
-            ->orderBy('lastPost.dateTime', 'DESC');
+            ->orderBy('t.sticky', 'DESC')
+            ->addOrderBy('lastPost.dateTime', 'DESC');
 
         $query = $builder->getQuery();
 

--- a/src/Security/Authorization/Voter/ThreadVoter.php
+++ b/src/Security/Authorization/Voter/ThreadVoter.php
@@ -20,4 +20,17 @@ class ThreadVoter extends AbstractVoter
 
         return null !== $firstPost && $user === $firstPost->getUser();
     }
+
+    /**
+     * Schließen und Anheften sind Moderation und bleiben der Administration vorbehalten.
+     */
+    protected function canLock(Thread $thread, User $user): bool
+    {
+        return $user->hasRole('ROLE_ADMIN');
+    }
+
+    protected function canPin(Thread $thread, User $user): bool
+    {
+        return $user->hasRole('ROLE_ADMIN');
+    }
 }

--- a/templates/Board/list_threads.html.twig
+++ b/templates/Board/list_threads.html.twig
@@ -43,6 +43,12 @@
                                     </div>
                                     <div class="flex-grow-1">
                                         <a href="{{ object_path(thread) }}" class="text-decoration-none">
+                                            {% if thread.sticky %}
+                                                <i class="fas fa-thumbtack text-muted me-1" title="angeheftet"></i>
+                                            {% endif %}
+                                            {% if thread.locked %}
+                                                <i class="fas fa-lock text-muted me-1" title="geschlossen"></i>
+                                            {% endif %}
                                             <strong>{{ thread.title }}</strong>
                                         </a>
                                         <br/>

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -13,10 +13,32 @@
     <div class="container">
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="h3 mb-0">
-                <i class="far fa-comment-alt text-muted me-2"></i>
+                {% if thread.sticky %}
+                    <i class="fas fa-thumbtack text-muted me-2" title="angeheftet"></i>
+                {% elseif thread.locked %}
+                    <i class="fas fa-lock text-muted me-2" title="geschlossen"></i>
+                {% else %}
+                    <i class="far fa-comment-alt text-muted me-2"></i>
+                {% endif %}
                 {{ thread.title }}
             </h1>
             <div class="d-flex gap-2">
+                {% if is_granted('pin', thread) %}
+                    <form method="post" action="{{ path('caldera_criticalmass_board_pinthread', { 'threadSlug': thread.slug }) }}">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm">
+                            <i class="fas fa-thumbtack me-1"></i>
+                            <span class="d-none d-sm-inline">{{ thread.sticky ? 'L&ouml;sen' : 'Anheften' }}</span>
+                        </button>
+                    </form>
+                {% endif %}
+                {% if is_granted('lock', thread) %}
+                    <form method="post" action="{{ path('caldera_criticalmass_board_lockthread', { 'threadSlug': thread.slug }) }}">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm">
+                            <i class="fas fa-{{ thread.locked ? 'lock-open' : 'lock' }} me-1"></i>
+                            <span class="d-none d-sm-inline">{{ thread.locked ? '&Ouml;ffnen' : 'Schlie&szlig;en' }}</span>
+                        </button>
+                    </form>
+                {% endif %}
                 {% if is_granted('edit', thread) %}
                     <a href="{{ path('caldera_criticalmass_board_editthread', { 'threadSlug': thread.slug }) }}"
                        class="btn btn-outline-secondary btn-sm">
@@ -24,7 +46,7 @@
                         <span class="d-none d-sm-inline">Titel bearbeiten</span>
                     </a>
                 {% endif %}
-                {% if app.getUser() %}
+                {% if app.getUser() and not thread.locked %}
                     <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modal-add-post">
                         <i class="far fa-comment me-1"></i>
                         <span class="d-none d-sm-inline">Antwort hinzuf&uuml;gen</span>
@@ -45,7 +67,15 @@
             </div>
         {% endif %}
 
-        {% if app.getUser() %}
+        {% if thread.locked %}
+            <div class="alert alert-secondary d-flex align-items-center" role="status">
+                <i class="fas fa-lock me-2"></i>
+                <div>
+                    <strong>Dieses Thema wurde geschlossen.</strong>
+                    Du kannst es weiterhin lesen, aber nicht mehr darauf antworten.
+                </div>
+            </div>
+        {% elseif app.getUser() %}
             {{ render(controller('App\\Controller\\PostController::writeThreadAction', { 'threadSlug': thread.slug, 'noButton': true })) }}
         {% endif %}
     </div>

--- a/tests/Controller/ForumModerationControllerTest.php
+++ b/tests/Controller/ForumModerationControllerTest.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumModerationControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+    private const ADMIN = 'admin@criticalmass.in';
+
+    private function openThread(KernelBrowser $client, string $title): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = 'Der erste Beitrag zu ' . $title . '.';
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread);
+
+        return (string) $thread->getSlug();
+    }
+
+    private function reloadThread(string $slug): Thread
+    {
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+
+        $thread = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $slug]);
+        self::assertInstanceOf(Thread::class, $thread);
+
+        return $thread;
+    }
+
+    public function testNewThreadsAreNeitherLockedNorSticky(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $thread = $this->reloadThread($this->openThread($client, 'Frisches Thema'));
+
+        self::assertFalse($thread->isLocked());
+        self::assertFalse($thread->isSticky());
+    }
+
+    public function testAdminCanLockAndReopenAThread(): void
+    {
+        $author = static::createClient();
+        $this->loginAs($author, self::AUTHOR);
+        $slug = $this->openThread($author, 'Zu schliessendes Thema');
+
+        $admin = static::createClient();
+        $this->loginAs($admin, self::ADMIN);
+
+        $admin->request('POST', '/thread/lock/' . $slug);
+        self::assertEquals(302, $admin->getResponse()->getStatusCode());
+        self::assertTrue($this->reloadThread($slug)->isLocked());
+
+        $admin->request('POST', '/thread/lock/' . $slug);
+        self::assertFalse($this->reloadThread($slug)->isLocked(), 'Derselbe Endpunkt öffnet wieder.');
+    }
+
+    public function testAuthorCannotLockTheirOwnThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Selbst schliessen verboten');
+
+        $client->request('POST', '/thread/lock/' . $slug);
+
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
+    }
+
+    public function testAdminCanPinAndUnpinAThread(): void
+    {
+        $author = static::createClient();
+        $this->loginAs($author, self::AUTHOR);
+        $slug = $this->openThread($author, 'Anzuheftendes Thema');
+
+        $admin = static::createClient();
+        $this->loginAs($admin, self::ADMIN);
+
+        $admin->request('POST', '/thread/pin/' . $slug);
+        self::assertTrue($this->reloadThread($slug)->isSticky());
+
+        $admin->request('POST', '/thread/pin/' . $slug);
+        self::assertFalse($this->reloadThread($slug)->isSticky());
+    }
+
+    public function testLockedThreadRejectsReplies(): void
+    {
+        $author = static::createClient();
+        $this->loginAs($author, self::AUTHOR);
+        $slug = $this->openThread($author, 'Geschlossen fuer Antworten');
+
+        $admin = static::createClient();
+        $this->loginAs($admin, self::ADMIN);
+        $admin->request('POST', '/thread/lock/' . $slug);
+
+        $author->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Trotzdem!']]);
+
+        self::assertEquals(403, $author->getResponse()->getStatusCode());
+    }
+
+    public function testLockedThreadStaysReadable(): void
+    {
+        $author = static::createClient();
+        $this->loginAs($author, self::AUTHOR);
+        $slug = $this->openThread($author, 'Lesbar trotz Schloss');
+
+        $admin = static::createClient();
+        $this->loginAs($admin, self::ADMIN);
+        $admin->request('POST', '/thread/lock/' . $slug);
+
+        $crawler = $author->request('GET', '/boards/general/thread/' . $slug);
+
+        self::assertEquals(200, $author->getResponse()->getStatusCode());
+        self::assertStringContainsString('geschlossen', $crawler->filter('body')->text());
+    }
+
+    public function testStickyThreadsAreListedFirst(): void
+    {
+        $author = static::createClient();
+        $this->loginAs($author, self::AUTHOR);
+
+        $olderSlug = $this->openThread($author, 'Aelteres Thema oben');
+        $this->openThread($author, 'Neueres Thema unten');
+
+        $admin = static::createClient();
+        $this->loginAs($admin, self::ADMIN);
+        $admin->request('POST', '/thread/pin/' . $olderSlug);
+
+        $crawler = $author->request('GET', '/boards/general');
+        $titles = $crawler->filter('.card-body strong')->each(fn ($node) => trim($node->text()));
+
+        $pinnedPosition = array_search('Aelteres Thema oben', $titles, true);
+        $normalPosition = array_search('Neueres Thema unten', $titles, true);
+
+        self::assertNotFalse($pinnedPosition);
+        self::assertNotFalse($normalPosition);
+        self::assertLessThan($normalPosition, $pinnedPosition, 'Angeheftete Themen stehen oben.');
+    }
+}

--- a/tests/Controller/ForumModerationControllerTest.php
+++ b/tests/Controller/ForumModerationControllerTest.php
@@ -52,18 +52,17 @@ class ForumModerationControllerTest extends AbstractControllerTestCase
 
     public function testAdminCanLockAndReopenAThread(): void
     {
-        $author = static::createClient();
-        $this->loginAs($author, self::AUTHOR);
-        $slug = $this->openThread($author, 'Zu schliessendes Thema');
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Zu schliessendes Thema');
 
-        $admin = static::createClient();
-        $this->loginAs($admin, self::ADMIN);
+        $this->loginAs($client, self::ADMIN);
 
-        $admin->request('POST', '/thread/lock/' . $slug);
-        self::assertEquals(302, $admin->getResponse()->getStatusCode());
+        $client->request('POST', '/thread/lock/' . $slug);
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
         self::assertTrue($this->reloadThread($slug)->isLocked());
 
-        $admin->request('POST', '/thread/lock/' . $slug);
+        $client->request('POST', '/thread/lock/' . $slug);
         self::assertFalse($this->reloadThread($slug)->isLocked(), 'Derselbe Endpunkt öffnet wieder.');
     }
 
@@ -80,64 +79,61 @@ class ForumModerationControllerTest extends AbstractControllerTestCase
 
     public function testAdminCanPinAndUnpinAThread(): void
     {
-        $author = static::createClient();
-        $this->loginAs($author, self::AUTHOR);
-        $slug = $this->openThread($author, 'Anzuheftendes Thema');
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Anzuheftendes Thema');
 
-        $admin = static::createClient();
-        $this->loginAs($admin, self::ADMIN);
+        $this->loginAs($client, self::ADMIN);
 
-        $admin->request('POST', '/thread/pin/' . $slug);
+        $client->request('POST', '/thread/pin/' . $slug);
         self::assertTrue($this->reloadThread($slug)->isSticky());
 
-        $admin->request('POST', '/thread/pin/' . $slug);
+        $client->request('POST', '/thread/pin/' . $slug);
         self::assertFalse($this->reloadThread($slug)->isSticky());
     }
 
     public function testLockedThreadRejectsReplies(): void
     {
-        $author = static::createClient();
-        $this->loginAs($author, self::AUTHOR);
-        $slug = $this->openThread($author, 'Geschlossen fuer Antworten');
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Geschlossen fuer Antworten');
 
-        $admin = static::createClient();
-        $this->loginAs($admin, self::ADMIN);
-        $admin->request('POST', '/thread/lock/' . $slug);
+        $this->loginAs($client, self::ADMIN);
+        $client->request('POST', '/thread/lock/' . $slug);
 
-        $author->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Trotzdem!']]);
+        $this->loginAs($client, self::AUTHOR);
+        $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Trotzdem!']]);
 
-        self::assertEquals(403, $author->getResponse()->getStatusCode());
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
     }
 
     public function testLockedThreadStaysReadable(): void
     {
-        $author = static::createClient();
-        $this->loginAs($author, self::AUTHOR);
-        $slug = $this->openThread($author, 'Lesbar trotz Schloss');
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Lesbar trotz Schloss');
 
-        $admin = static::createClient();
-        $this->loginAs($admin, self::ADMIN);
-        $admin->request('POST', '/thread/lock/' . $slug);
+        $this->loginAs($client, self::ADMIN);
+        $client->request('POST', '/thread/lock/' . $slug);
 
-        $crawler = $author->request('GET', '/boards/general/thread/' . $slug);
+        $crawler = $client->request('GET', '/boards/general/thread/' . $slug);
 
-        self::assertEquals(200, $author->getResponse()->getStatusCode());
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
         self::assertStringContainsString('geschlossen', $crawler->filter('body')->text());
     }
 
     public function testStickyThreadsAreListedFirst(): void
     {
-        $author = static::createClient();
-        $this->loginAs($author, self::AUTHOR);
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
 
-        $olderSlug = $this->openThread($author, 'Aelteres Thema oben');
-        $this->openThread($author, 'Neueres Thema unten');
+        $olderSlug = $this->openThread($client, 'Aelteres Thema oben');
+        $this->openThread($client, 'Neueres Thema unten');
 
-        $admin = static::createClient();
-        $this->loginAs($admin, self::ADMIN);
-        $admin->request('POST', '/thread/pin/' . $olderSlug);
+        $this->loginAs($client, self::ADMIN);
+        $client->request('POST', '/thread/pin/' . $olderSlug);
 
-        $crawler = $author->request('GET', '/boards/general');
+        $crawler = $client->request('GET', '/boards/general');
         $titles = $crawler->filter('.card-body strong')->each(fn ($node) => trim($node->text()));
 
         $pinnedPosition = array_search('Aelteres Thema oben', $titles, true);

--- a/tests/Security/Authorization/Voter/ThreadVoterTest.php
+++ b/tests/Security/Authorization/Voter/ThreadVoterTest.php
@@ -95,4 +95,37 @@ class ThreadVoterTest extends TestCase
             (new ThreadVoter())->vote($this->token($this->user()), $this->threadOpenedBy($this->user()), ['move'])
         );
     }
+
+    public function testOnlyAdminsMayLockAThread(): void
+    {
+        $opener = $this->user();
+        $thread = $this->threadOpenedBy($opener);
+        $voter = new ThreadVoter();
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($opener), $thread, ['lock']),
+            'Auch wer das Thema eröffnet hat, schließt es nicht selbst.'
+        );
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $thread, ['lock'])
+        );
+    }
+
+    public function testOnlyAdminsMayPinAThread(): void
+    {
+        $opener = $this->user();
+        $thread = $this->threadOpenedBy($opener);
+        $voter = new ThreadVoter();
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($opener), $thread, ['pin'])
+        );
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $thread, ['pin'])
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Zweiter Teil des Forum-Ausbaus, gestapelt auf #1484. Threads liefen bisher endlos weiter und standen immer in derselben Reihenfolge.

- **`Thread::$locked`** — geschlossene Themen bleiben lesbar, nehmen aber keine Antworten mehr an
- **`Thread::$sticky`** — angeheftete Themen stehen oben in der Liste, unabhängig vom letzten Beitrag (`ThreadRepository` sortiert jetzt `sticky DESC, lastPost.dateTime DESC`)
- Migration für beide Felder
- **`POST /thread/lock/{threadSlug}`** und **`POST /thread/pin/{threadSlug}`** — beide togglen, beide nur für Admins (`ThreadVoter::canLock` / `canPin`)
- Schloss- und Pin-Symbol in Thread-Liste und Thread-Ansicht, Hinweistext bei geschlossenen Themen

## Warum die Sperre doppelt sitzt

Das Antwortformular verschwindet bei geschlossenen Themen aus dem Template — das allein reicht aber nicht, weil es als Sub-Request gerendert wird und ein direkter POST daran vorbeigeht. `addPostAction()` weist deshalb serverseitig ab.

Bewusst nicht gemacht: Auch wer ein Thema eröffnet hat, kann es nicht selbst schließen. Schließen und Anheften sind Moderation, nicht Eigentum.

## Test Plan

- [x] `vendor/bin/phpunit tests/Security/Authorization/Voter/` — 14 Tests grün
- [x] `vendor/bin/phpstan analyse` auf allen geänderten Dateien — keine Fehler
- [ ] `tests/Controller/ForumModerationControllerTest.php` — 7 funktionale Tests in CI
- [ ] Manuell: Thema schließen → Antwortknopf weg, Hinweis da, direkter POST → 403; anheften → steht oben

Closes #1150
Closes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR