### PR TITLE
Forum: Themen verschieben und Beiträge zurückziehen

### DIFF
--- a/assets/controllers/confirm_submit_controller.js
+++ b/assets/controllers/confirm_submit_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Fragt vor dem Absenden nach. Als Stimulus-Controller statt als onsubmit-Attribut,
+ * weil die Content-Security-Policy dieser Seite kein 'unsafe-inline' für Skripte
+ * erlaubt — ein Inline-Handler würde beim Scharfschalten stillschweigend ausfallen.
+ */
+export default class extends Controller {
+    static values = { message: String };
+
+    confirm(event) {
+        if (!window.confirm(this.messageValue)) {
+            event.preventDefault();
+        }
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2443,12 +2443,6 @@ parameters:
 			path: src/Entity/BlockedCity.php
 
 		-
-			message: '#^Access to an undefined property App\\Entity\\Board\:\:\$dateTime\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Entity/Board.php
-
-		-
 			message: '#^Method App\\Entity\\City\:\:getColor\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Criticalmass\Forum\ForumStatistics;
 use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Entity\Board;
 use App\Repository\BoardRepository;
@@ -15,6 +16,7 @@ use App\EntityInterface\BoardInterface;
 use App\Form\Type\ThreadType;
 use Malenki\Slug;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
@@ -151,6 +153,100 @@ class BoardController extends AbstractController
             : 'Das Thema steht wieder in der normalen Reihenfolge.');
 
         return $this->redirect($objectRouter->generate($thread));
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/thread/move/{threadSlug}', name: 'caldera_criticalmass_board_movethread', priority: 240)]
+    public function moveThreadAction(
+        Request $request,
+        ObjectRouterInterface $objectRouter,
+        BoardRepository $boardRepository,
+        CityRepository $cityRepository,
+        ForumStatistics $forumStatistics,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->denyAccessUnlessGranted('move', $thread);
+
+        $targets = [];
+
+        foreach ($boardRepository->findEnabledBoards() as $candidate) {
+            $targets['Foren'][(string) $candidate->getTitle()] = 'board:' . $candidate->getId();
+        }
+
+        foreach ($cityRepository->findCitiesWithBoard() as $candidate) {
+            $targets['Städte'][(string) $candidate->getTitle()] = 'city:' . $candidate->getId();
+        }
+
+        $form = $this->createFormBuilder()
+            ->add('target', ChoiceType::class, [
+                'label' => 'Neues Forum',
+                'choices' => $targets,
+            ])
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            [$kind, $id] = explode(':', (string) $form->get('target')->getData(), 2);
+
+            $target = 'city' === $kind
+                ? $cityRepository->find((int) $id)
+                : $boardRepository->find((int) $id);
+
+            if (!$target instanceof BoardInterface) {
+                throw $this->createNotFoundException('Dieses Forum gibt es nicht.');
+            }
+
+            $source = $thread->getCity() ?? $thread->getBoard();
+
+            if ($source instanceof BoardInterface && $source !== $target) {
+                $forumStatistics->moveThread($thread, $source, $target);
+
+                if ($target instanceof City) {
+                    $thread->setCity($target)->setBoard(null);
+                } elseif ($target instanceof Board) {
+                    $thread->setBoard($target)->setCity(null);
+                }
+
+                $this->managerRegistry->getManager()->flush();
+
+                $this->addFlash('success', sprintf('Das Thema liegt jetzt in „%s“.', $target->getTitle()));
+            }
+
+            return $this->redirect($objectRouter->generate($thread));
+        }
+
+        return $this->render('Board/move_thread.html.twig', [
+            'board' => $thread->getCity() ?? $thread->getBoard(),
+            'thread' => $thread,
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/thread/disable/{threadSlug}', name: 'caldera_criticalmass_board_disablethread', methods: ['POST'], priority: 240)]
+    public function disableThreadAction(
+        ObjectRouterInterface $objectRouter,
+        ForumStatistics $forumStatistics,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->denyAccessUnlessGranted('delete', $thread);
+
+        $board = $thread->getCity() ?? $thread->getBoard();
+
+        if ($board instanceof BoardInterface) {
+            $forumStatistics->disableThread($thread, $board);
+        }
+
+        $thread->setEnabled(false);
+
+        $this->managerRegistry->getManager()->flush();
+
+        $this->addFlash('success', 'Das Thema wurde zurückgezogen.');
+
+        return $this->redirect($board instanceof BoardInterface
+            ? $objectRouter->generate($board)
+            : $this->generateUrl('caldera_criticalmass_board_overview'));
     }
 
     /**

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Criticalmass\Forum\ForumStatistics;
 use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Entity\Photo;
 use App\EntityInterface\PostableInterface;
@@ -148,6 +149,29 @@ class PostController extends AbstractController
             'post' => $post,
             'form' => $form->createView(),
         ]);
+    }
+
+    #[IsGranted('ROLE_USER')]
+    #[Route('/post/disable/{postId}', name: 'caldera_criticalmass_post_disable', methods: ['POST'], priority: 120)]
+    public function disableAction(
+        ObjectRouterInterface $objectRouter,
+        ForumStatistics $forumStatistics,
+        #[MapEntity(mapping: ['postId' => 'id'])] Post $post
+    ): Response {
+        $this->denyAccessUnlessGranted('delete', $post);
+
+        $thread = $post->getThread();
+        $board = $thread?->getCity() ?? $thread?->getBoard();
+
+        $forumStatistics->disablePost($post, $board instanceof BoardInterface ? $board : null);
+
+        $post->setEnabled(false);
+
+        $this->managerRegistry->getManager()->flush();
+
+        $this->addFlash('success', 'Dein Beitrag wurde zurückgezogen.');
+
+        return $this->redirect($this->generatePostUrl($post, $objectRouter));
     }
 
     /**

--- a/src/Criticalmass/Forum/ForumStatistics.php
+++ b/src/Criticalmass/Forum/ForumStatistics.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\Forum;
+
+use App\Entity\Post;
+use App\Entity\Thread;
+use App\EntityInterface\BoardInterface;
+use App\Repository\PostRepository;
+use App\Repository\ThreadRepository;
+
+/**
+ * Hält die Zähler und Verweise der Foren in Ordnung, wenn Themen wandern oder verschwinden.
+ *
+ * Board und City führen threadNumber, postNumber und lastThread als Momentaufnahme mit;
+ * ohne Pflege zeigen sie nach dem Verschieben oder Deaktivieren auf Themen, die dort
+ * nicht mehr liegen.
+ */
+class ForumStatistics
+{
+    public function __construct(
+        private readonly PostRepository $postRepository,
+        private readonly ThreadRepository $threadRepository
+    ) {
+    }
+
+    public function moveThread(Thread $thread, BoardInterface $source, BoardInterface $target): void
+    {
+        $postCount = $this->postRepository->countPostsForThread($thread);
+
+        $source->decThreadNumber();
+        $source->decPostNumber($postCount);
+
+        $target->incThreadNumber();
+        $target->incPostNumber($postCount);
+        $target->setLastThread($thread);
+
+        $this->forgetThread($source, $thread);
+    }
+
+    public function disableThread(Thread $thread, BoardInterface $board): void
+    {
+        $board->decThreadNumber();
+        $board->decPostNumber($this->postRepository->countPostsForThread($thread));
+
+        $this->forgetThread($board, $thread);
+    }
+
+    public function disablePost(Post $post, ?BoardInterface $board): void
+    {
+        $thread = $post->getThread();
+
+        if (null !== $thread) {
+            $thread->decPostNumber();
+
+            if ($thread->getLastPost() === $post) {
+                $thread->setLastPost($this->postRepository->findLatestPostForThread($thread));
+            }
+        }
+
+        $board?->decPostNumber();
+    }
+
+    /**
+     * Zeigt das Forum noch auf das entfernte Thema, tritt das nächstjüngere an seine Stelle.
+     */
+    private function forgetThread(BoardInterface $board, Thread $thread): void
+    {
+        if ($board->getLastThread() !== $thread) {
+            return;
+        }
+
+        $board->setLastThread($this->threadRepository->findLatestThread($board));
+    }
+}

--- a/src/Entity/Board.php
+++ b/src/Entity/Board.php
@@ -47,7 +47,6 @@ class Board implements BoardInterface, RouteableInterface
 
     public function __construct()
     {
-        $this->dateTime = new \DateTime();
     }
 
     public function getId(): ?int
@@ -91,7 +90,7 @@ class Board implements BoardInterface, RouteableInterface
         return $this->enabled;
     }
 
-    public function setLastThread(Thread $lastThread): BoardInterface
+    public function setLastThread(?Thread $lastThread = null): BoardInterface
     {
         $this->lastThread = $lastThread;
 
@@ -115,9 +114,16 @@ class Board implements BoardInterface, RouteableInterface
         return $this->postNumber ?? 0;
     }
 
-    public function incPostNumber(): BoardInterface
+    public function incPostNumber(int $amount = 1): BoardInterface
     {
-        ++$this->postNumber;
+        $this->postNumber = ($this->postNumber ?? 0) + $amount;
+
+        return $this;
+    }
+
+    public function decPostNumber(int $amount = 1): BoardInterface
+    {
+        $this->postNumber = max(0, ($this->postNumber ?? 0) - $amount);
 
         return $this;
     }
@@ -137,6 +143,13 @@ class Board implements BoardInterface, RouteableInterface
     public function incThreadNumber(): BoardInterface
     {
         ++$this->threadNumber;
+
+        return $this;
+    }
+
+    public function decThreadNumber(): BoardInterface
+    {
+        $this->threadNumber = max(0, ($this->threadNumber ?? 0) - 1);
 
         return $this;
     }

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -608,9 +608,16 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
         return $this->postNumber;
     }
 
-    public function incPostNumber(): BoardInterface
+    public function incPostNumber(int $amount = 1): BoardInterface
     {
-        ++$this->postNumber;
+        $this->postNumber = ($this->postNumber ?? 0) + $amount;
+
+        return $this;
+    }
+
+    public function decPostNumber(int $amount = 1): BoardInterface
+    {
+        $this->postNumber = max(0, ($this->postNumber ?? 0) - $amount);
 
         return $this;
     }
@@ -630,6 +637,13 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
     public function incThreadNumber(): BoardInterface
     {
         ++$this->threadNumber;
+
+        return $this;
+    }
+
+    public function decThreadNumber(): BoardInterface
+    {
+        $this->threadNumber = max(0, ($this->threadNumber ?? 0) - 1);
 
         return $this;
     }

--- a/src/Entity/Thread.php
+++ b/src/Entity/Thread.php
@@ -185,6 +185,13 @@ class Thread implements RouteableInterface, PostableInterface
         return $this;
     }
 
+    public function decPostNumber(): Thread
+    {
+        $this->postNumber = max(0, ($this->postNumber ?? 0) - 1);
+
+        return $this;
+    }
+
     public function setSlug(string $slug): Thread
     {
         $this->slug = $slug;

--- a/src/EntityInterface/BoardInterface.php
+++ b/src/EntityInterface/BoardInterface.php
@@ -16,13 +16,17 @@ interface BoardInterface
 
     public function incThreadNumber(): BoardInterface;
 
+    public function decThreadNumber(): BoardInterface;
+
     public function getPostNumber();
 
     public function setPostNumber(int $postNumber): BoardInterface;
 
-    public function incPostNumber(): BoardInterface;
+    public function incPostNumber(int $amount = 1): BoardInterface;
+
+    public function decPostNumber(int $amount = 1): BoardInterface;
 
     public function getLastThread(): ?Thread;
 
-    public function setLastThread(Thread $thread): BoardInterface;
+    public function setLastThread(?Thread $thread): BoardInterface;
 }

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -65,6 +65,36 @@ class PostRepository extends ServiceEntityRepository
         return $query->getResult();
     }
 
+    public function countPostsForThread(Thread $thread): int
+    {
+        $builder = $this->createQueryBuilder('p');
+
+        $builder
+            ->select('COUNT(p.id)')
+            ->where($builder->expr()->eq('p.thread', ':thread'))
+            ->setParameter('thread', $thread)
+            ->andWhere($builder->expr()->eq('p.enabled', ':enabled'))
+            ->setParameter('enabled', true);
+
+        return (int) $builder->getQuery()->getSingleScalarResult();
+    }
+
+    public function findLatestPostForThread(Thread $thread): ?Post
+    {
+        $builder = $this->createQueryBuilder('p');
+
+        $builder
+            ->select('p')
+            ->where($builder->expr()->eq('p.thread', ':thread'))
+            ->setParameter('thread', $thread)
+            ->andWhere($builder->expr()->eq('p.enabled', ':enabled'))
+            ->setParameter('enabled', true)
+            ->orderBy('p.dateTime', 'DESC')
+            ->setMaxResults(1);
+
+        return $builder->getQuery()->getOneOrNullResult();
+    }
+
     public function findPostsForThread(Thread $thread): array
     {
         $builder = $this->createQueryBuilder('p');

--- a/src/Repository/ThreadRepository.php
+++ b/src/Repository/ThreadRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Board;
 use App\Entity\City;
 use App\Entity\Thread;
+use App\EntityInterface\BoardInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -51,6 +52,27 @@ class ThreadRepository extends ServiceEntityRepository
         $query = $builder->getQuery();
 
         return $query->getResult();
+    }
+
+    /**
+     * Das zuletzt aktive Thema eines Forums — Grundlage für die Anzeige „letzter Beitrag“,
+     * wenn das bisherige lastThread verschoben oder deaktiviert wurde.
+     */
+    public function findLatestThread(BoardInterface $board): ?Thread
+    {
+        $builder = $this->createQueryBuilder('t');
+
+        $builder
+            ->select('t')
+            ->leftJoin('t.lastPost', 'lastPost')
+            ->where($builder->expr()->eq($board instanceof City ? 't.city' : 't.board', ':board'))
+            ->setParameter('board', $board)
+            ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
+            ->setParameter('enabled', true)
+            ->orderBy('lastPost.dateTime', 'DESC')
+            ->setMaxResults(1);
+
+        return $builder->getQuery()->getOneOrNullResult();
     }
 
     public function findThreadBySlug(string $slug): ?Thread

--- a/src/Security/Authorization/Voter/PostVoter.php
+++ b/src/Security/Authorization/Voter/PostVoter.php
@@ -15,4 +15,19 @@ class PostVoter extends AbstractVoter
 
         return $user === $post->getUser();
     }
+
+    /**
+     * Der erste Beitrag traegt das Thema — er laesst sich nicht einzeln zurueckziehen,
+     * sonst bliebe ein Thema ohne Anfang stehen. Dafuer gibt es das Loeschen des Themas.
+     */
+    protected function canDelete(Post $post, User $user): bool
+    {
+        $thread = $post->getThread();
+
+        if (null !== $thread && $thread->getFirstPost() === $post) {
+            return false;
+        }
+
+        return $this->canEdit($post, $user);
+    }
 }

--- a/src/Security/Authorization/Voter/ThreadVoter.php
+++ b/src/Security/Authorization/Voter/ThreadVoter.php
@@ -33,4 +33,20 @@ class ThreadVoter extends AbstractVoter
     {
         return $user->hasRole('ROLE_ADMIN');
     }
+
+    /**
+     * Ein Thema in ein anderes Forum zu schieben ist eine Aufräumarbeit der Administration.
+     */
+    protected function canMove(Thread $thread, User $user): bool
+    {
+        return $user->hasRole('ROLE_ADMIN');
+    }
+
+    /**
+     * Ein ganzes Thema zurückzuziehen darf, wer es eröffnet hat — und jeder Admin.
+     */
+    protected function canDelete(Thread $thread, User $user): bool
+    {
+        return $this->canEdit($thread, $user);
+    }
 }

--- a/templates/Board/move_thread.html.twig
+++ b/templates/Board/move_thread.html.twig
@@ -1,0 +1,51 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}Thema verschieben{% endblock %}
+
+{% block breadcrumb %}
+    {{ breadcrumb.item('Diskussionen', path('caldera_criticalmass_board_overview')) }}
+    {{ breadcrumb.item(board.title, object_path(board)) }}
+    {{ breadcrumb.item(thread.title, object_path(thread)) }}
+    {{ breadcrumb.active('verschieben') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1 class="h3 mb-0">
+                <i class="far fa-share-square text-muted me-2"></i>
+                Thema verschieben
+            </h1>
+        </div>
+
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <p class="text-muted">
+                    &bdquo;{{ thread.title }}&ldquo; liegt zurzeit in <strong>{{ board.title }}</strong>.
+                </p>
+
+                {{ form_start(form) }}
+                {{ form_errors(form) }}
+
+                <div class="mb-3">
+                    <label class="form-label" for="{{ form.target.vars.id }}">Neues Forum:</label>
+                    {{ form_widget(form.target, { 'attr' : { 'class': 'form-select'} }) }}
+                    <div class="form-text">Die Z&auml;hler beider Foren werden mitgezogen.</div>
+                </div>
+
+                <div class="d-flex justify-content-end">
+                    <a href="{{ object_path(thread) }}" class="btn btn-light me-2">
+                        Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-success">
+                        <i class="far fa-share-square me-1"></i>
+                        Verschieben
+                    </button>
+                </div>
+
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -39,12 +39,29 @@
                         </button>
                     </form>
                 {% endif %}
+                {% if is_granted('move', thread) %}
+                    <a href="{{ path('caldera_criticalmass_board_movethread', { 'threadSlug': thread.slug }) }}"
+                       class="btn btn-outline-secondary btn-sm">
+                        <i class="far fa-share-square me-1"></i>
+                        <span class="d-none d-sm-inline">Verschieben</span>
+                    </a>
+                {% endif %}
                 {% if is_granted('edit', thread) %}
                     <a href="{{ path('caldera_criticalmass_board_editthread', { 'threadSlug': thread.slug }) }}"
                        class="btn btn-outline-secondary btn-sm">
                         <i class="far fa-edit me-1"></i>
                         <span class="d-none d-sm-inline">Titel bearbeiten</span>
                     </a>
+                {% endif %}
+                {% if is_granted('delete', thread) %}
+                    <form method="post"
+                          action="{{ path('caldera_criticalmass_board_disablethread', { 'threadSlug': thread.slug }) }}"
+                          onsubmit="return confirm('Dieses Thema mitsamt allen Beiträgen zurückziehen?');">
+                        <button type="submit" class="btn btn-outline-danger btn-sm">
+                            <i class="far fa-trash-alt me-1"></i>
+                            <span class="d-none d-sm-inline">Thema zur&uuml;ckziehen</span>
+                        </button>
+                    </form>
                 {% endif %}
                 {% if app.getUser() and not thread.locked %}
                     <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#modal-add-post">

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -56,7 +56,9 @@
                 {% if is_granted('delete', thread) %}
                     <form method="post"
                           action="{{ path('caldera_criticalmass_board_disablethread', { 'threadSlug': thread.slug }) }}"
-                          onsubmit="return confirm('Dieses Thema mitsamt allen Beiträgen zurückziehen?');">
+                          data-controller="confirm-submit"
+                          data-confirm-submit-message-value="Dieses Thema mitsamt allen Beiträgen zurückziehen?"
+                          data-action="submit->confirm-submit#confirm">
                         <button type="submit" class="btn btn-outline-danger btn-sm">
                             <i class="far fa-trash-alt me-1"></i>
                             <span class="d-none d-sm-inline">Thema zur&uuml;ckziehen</span>

--- a/templates/Post/post.html.twig
+++ b/templates/Post/post.html.twig
@@ -38,12 +38,23 @@
                         bearbeitet am {{ post.updatedAt|date('d.m.Y, H:i', 'Europe/Berlin') }}
                     </p>
                 {% endif %}
-                {% if is_granted('edit', post) %}
-                    <div class="mt-2">
-                        <a href="{{ path('caldera_criticalmass_post_edit', { 'postId': post.id }) }}"
-                           class="btn btn-outline-secondary btn-sm">
-                            <i class="far fa-edit me-1"></i>Bearbeiten
-                        </a>
+                {% if is_granted('edit', post) or is_granted('delete', post) %}
+                    <div class="mt-2 d-flex gap-2">
+                        {% if is_granted('edit', post) %}
+                            <a href="{{ path('caldera_criticalmass_post_edit', { 'postId': post.id }) }}"
+                               class="btn btn-outline-secondary btn-sm">
+                                <i class="far fa-edit me-1"></i>Bearbeiten
+                            </a>
+                        {% endif %}
+                        {% if is_granted('delete', post) %}
+                            <form method="post"
+                                  action="{{ path('caldera_criticalmass_post_disable', { 'postId': post.id }) }}"
+                                  onsubmit="return confirm('Diesen Beitrag zurückziehen?');">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">
+                                    <i class="far fa-trash-alt me-1"></i>Zur&uuml;ckziehen
+                                </button>
+                            </form>
+                        {% endif %}
                     </div>
                 {% endif %}
             </div>

--- a/templates/Post/post.html.twig
+++ b/templates/Post/post.html.twig
@@ -49,7 +49,9 @@
                         {% if is_granted('delete', post) %}
                             <form method="post"
                                   action="{{ path('caldera_criticalmass_post_disable', { 'postId': post.id }) }}"
-                                  onsubmit="return confirm('Diesen Beitrag zurückziehen?');">
+                                  data-controller="confirm-submit"
+                                  data-confirm-submit-message-value="Diesen Beitrag zurückziehen?"
+                                  data-action="submit->confirm-submit#confirm">
                                 <button type="submit" class="btn btn-outline-danger btn-sm">
                                     <i class="far fa-trash-alt me-1"></i>Zur&uuml;ckziehen
                                 </button>

--- a/tests/Controller/ForumWithdrawControllerTest.php
+++ b/tests/Controller/ForumWithdrawControllerTest.php
@@ -29,9 +29,20 @@ class ForumWithdrawControllerTest extends AbstractControllerTestCase
         return (string) $thread->getSlug();
     }
 
+    /**
+     * Antwortet ueber das echte Formular. Ein roher POST scheitert an der
+     * CSRF-Pruefung, und das Formular meldet den Fehler still zurueck.
+     */
     private function reply(KernelBrowser $client, string $threadSlug, string $message): void
     {
-        $client->request('POST', '/post/write/thread/' . $threadSlug, ['post' => ['message' => $message]]);
+        $crawler = $client->request('GET', '/post/write/thread/' . $threadSlug);
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['post[message]'] = $message;
+
+        $client->submit($form);
+
+        self::assertEquals(302, $client->getResponse()->getStatusCode(), 'Die Antwort sollte gespeichert werden.');
     }
 
     private function thread(string $slug): Thread

--- a/tests/Controller/ForumWithdrawControllerTest.php
+++ b/tests/Controller/ForumWithdrawControllerTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Post;
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumWithdrawControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+    private const ADMIN = 'admin@criticalmass.in';
+
+    private function openThread(KernelBrowser $client, string $title): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = 'Der erste Beitrag zu ' . $title . '.';
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread);
+
+        return (string) $thread->getSlug();
+    }
+
+    private function reply(KernelBrowser $client, string $threadSlug, string $message): void
+    {
+        $client->request('POST', '/post/write/thread/' . $threadSlug, ['post' => ['message' => $message]]);
+    }
+
+    private function thread(string $slug): Thread
+    {
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+
+        $thread = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $slug]);
+        self::assertInstanceOf(Thread::class, $thread);
+
+        return $thread;
+    }
+
+    public function testAuthorCanWithdrawTheirReply(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Antwort zuruecknehmen');
+        $this->reply($client, $slug, 'Diese Antwort verschwindet gleich wieder.');
+
+        $reply = $this->thread($slug)->getLastPost();
+        self::assertInstanceOf(Post::class, $reply);
+        $replyId = $reply->getId();
+
+        $client->request('POST', '/post/disable/' . $replyId);
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+
+        self::assertFalse($doctrine->getRepository(Post::class)->find($replyId)->getEnabled());
+    }
+
+    public function testFirstPostCannotBeWithdrawnOnItsOwn(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Erster Beitrag bleibt');
+        $firstPost = $this->thread($slug)->getFirstPost();
+        self::assertInstanceOf(Post::class, $firstPost);
+
+        $client->request('POST', '/post/disable/' . $firstPost->getId());
+
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
+    }
+
+    public function testThreadOpenerCanWithdrawTheWholeThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Ganzes Thema zurueckziehen');
+
+        $client->request('POST', '/thread/disable/' . $slug);
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+
+        $thread = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $slug]);
+        self::assertFalse($thread->getEnabled() ?? true);
+    }
+
+    public function testStrangerCannotWithdrawSomeoneElsesThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Fremdes Thema bleibt');
+
+        $this->loginAs($client, 'cyclist@criticalmass.in');
+        $client->request('POST', '/thread/disable/' . $slug);
+
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
+    }
+
+    public function testAdminCanMoveAThreadToAnotherBoard(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Umzugswilliges Thema');
+
+        $this->loginAs($client, self::ADMIN);
+        $crawler = $client->request('GET', '/thread/move/' . $slug);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertGreaterThan(0, $crawler->filter('select')->count(), 'Die Zielauswahl muss angeboten werden.');
+    }
+
+    public function testAuthorCannotMoveAThread(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+        $slug = $this->openThread($client, 'Nicht verschiebbares Thema');
+
+        $client->request('GET', '/thread/move/' . $slug);
+
+        self::assertEquals(403, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Criticalmass/Forum/ForumStatisticsTest.php
+++ b/tests/Criticalmass/Forum/ForumStatisticsTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Forum;
+
+use App\Criticalmass\Forum\ForumStatistics;
+use App\Entity\Board;
+use App\Entity\Post;
+use App\Entity\Thread;
+use App\Repository\PostRepository;
+use App\Repository\ThreadRepository;
+use PHPUnit\Framework\TestCase;
+
+class ForumStatisticsTest extends TestCase
+{
+    private function board(string $title, int $threads, int $posts): Board
+    {
+        $board = new Board();
+        $board->setTitle($title)->setThreadNumber($threads)->setPostNumber($posts);
+
+        return $board;
+    }
+
+    private function statistics(int $postsInThread = 3, ?Thread $latestThread = null, ?Post $latestPost = null): ForumStatistics
+    {
+        $postRepository = $this->createMock(PostRepository::class);
+        $postRepository->method('countPostsForThread')->willReturn($postsInThread);
+        $postRepository->method('findLatestPostForThread')->willReturn($latestPost);
+
+        $threadRepository = $this->createMock(ThreadRepository::class);
+        $threadRepository->method('findLatestThread')->willReturn($latestThread);
+
+        return new ForumStatistics($postRepository, $threadRepository);
+    }
+
+    public function testMovingAThreadShiftsBothCounters(): void
+    {
+        $source = $this->board('Quelle', 5, 20);
+        $target = $this->board('Ziel', 2, 7);
+        $thread = new Thread();
+
+        $this->statistics(3)->moveThread($thread, $source, $target);
+
+        self::assertSame(4, $source->getThreadNumber());
+        self::assertSame(17, $source->getPostNumber());
+        self::assertSame(3, $target->getThreadNumber());
+        self::assertSame(10, $target->getPostNumber());
+        self::assertSame($thread, $target->getLastThread());
+    }
+
+    public function testMovingAwayTheLastThreadPromotesTheNextOne(): void
+    {
+        $thread = new Thread();
+        $successor = new Thread();
+
+        $source = $this->board('Quelle', 2, 8);
+        $source->setLastThread($thread);
+
+        $this->statistics(2, $successor)->moveThread($thread, $source, $this->board('Ziel', 0, 0));
+
+        self::assertSame($successor, $source->getLastThread());
+    }
+
+    public function testMovingAnUnrelatedThreadLeavesTheLastThreadAlone(): void
+    {
+        $other = new Thread();
+        $source = $this->board('Quelle', 3, 9);
+        $source->setLastThread($other);
+
+        $this->statistics(1, new Thread())->moveThread(new Thread(), $source, $this->board('Ziel', 0, 0));
+
+        self::assertSame($other, $source->getLastThread(), 'Nur das entfernte Thema wird ersetzt.');
+    }
+
+    public function testDisablingAThreadRemovesItFromTheCounters(): void
+    {
+        $board = $this->board('Forum', 4, 12);
+        $thread = new Thread();
+
+        $this->statistics(5)->disableThread($thread, $board);
+
+        self::assertSame(3, $board->getThreadNumber());
+        self::assertSame(7, $board->getPostNumber());
+    }
+
+    public function testCountersNeverFallBelowZero(): void
+    {
+        $board = $this->board('Leeres Forum', 0, 1);
+
+        $this->statistics(9)->disableThread(new Thread(), $board);
+
+        self::assertSame(0, $board->getThreadNumber());
+        self::assertSame(0, $board->getPostNumber(), 'Ein Zähler darf nicht negativ werden.');
+    }
+
+    public function testDisablingAPostDecrementsThreadAndBoard(): void
+    {
+        $board = $this->board('Forum', 1, 6);
+        $thread = new Thread();
+        $thread->setPostNumber(4);
+
+        $post = new Post();
+        $post->setThread($thread);
+
+        $this->statistics()->disablePost($post, $board);
+
+        self::assertSame(3, $thread->getPostNumber());
+        self::assertSame(5, $board->getPostNumber());
+    }
+
+    public function testDisablingTheLastPostPromotesThePreviousOne(): void
+    {
+        $thread = new Thread();
+        $thread->setPostNumber(2);
+
+        $post = new Post();
+        $post->setThread($thread);
+        $thread->setLastPost($post);
+
+        $predecessor = new Post();
+
+        $this->statistics(2, null, $predecessor)->disablePost($post, $this->board('Forum', 1, 3));
+
+        self::assertSame($predecessor, $thread->getLastPost());
+    }
+
+    public function testDisablingAPostOutsideAThreadOnlyTouchesTheBoard(): void
+    {
+        $board = $this->board('Forum', 1, 4);
+
+        // Kommentare an Touren, Städten und Fotos hängen an keinem Thema.
+        $this->statistics()->disablePost(new Post(), $board);
+
+        self::assertSame(3, $board->getPostNumber());
+    }
+}

--- a/tests/Security/Authorization/Voter/PostVoterTest.php
+++ b/tests/Security/Authorization/Voter/PostVoterTest.php
@@ -68,6 +68,41 @@ class PostVoterTest extends TestCase
         );
     }
 
+    public function testAuthorMayWithdrawAReply(): void
+    {
+        $author = $this->user();
+        $thread = new \App\Entity\Thread();
+        $thread->setFirstPost((new Post())->setUser($author));
+
+        $reply = (new Post())->setUser($author);
+        $reply->setThread($thread);
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            (new PostVoter())->vote($this->token($author), $reply, ['delete'])
+        );
+    }
+
+    public function testNobodyMayWithdrawTheFirstPostOfAThread(): void
+    {
+        $author = $this->user();
+        $firstPost = (new Post())->setUser($author);
+
+        $thread = new \App\Entity\Thread();
+        $thread->setFirstPost($firstPost);
+        $firstPost->setThread($thread);
+
+        $voter = new PostVoter();
+
+        // Ohne ersten Beitrag stuende ein Thema ohne Anfang da — dafuer gibt es
+        // stattdessen das Zurueckziehen des ganzen Themas.
+        self::assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->token($author), $firstPost, ['delete']));
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $firstPost, ['delete'])
+        );
+    }
+
     public function testVoterAbstainsOnForeignAttributes(): void
     {
         $post = (new Post())->setUser($this->user());
@@ -76,7 +111,7 @@ class PostVoterTest extends TestCase
         // für fremde Attribute zuständig erklärt, würde andere Entscheidungen kippen.
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
-            (new PostVoter())->vote($this->token($this->user()), $post, ['delete'])
+            (new PostVoter())->vote($this->token($this->user()), $post, ['archive'])
         );
     }
 

--- a/tests/Security/Authorization/Voter/ThreadVoterTest.php
+++ b/tests/Security/Authorization/Voter/ThreadVoterTest.php
@@ -92,7 +92,7 @@ class ThreadVoterTest extends TestCase
     {
         self::assertSame(
             VoterInterface::ACCESS_ABSTAIN,
-            (new ThreadVoter())->vote($this->token($this->user()), $this->threadOpenedBy($this->user()), ['move'])
+            (new ThreadVoter())->vote($this->token($this->user()), $this->threadOpenedBy($this->user()), ['archive'])
         );
     }
 
@@ -110,6 +110,36 @@ class ThreadVoterTest extends TestCase
         self::assertSame(
             VoterInterface::ACCESS_GRANTED,
             $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $thread, ['lock'])
+        );
+    }
+
+    public function testOnlyAdminsMayMoveAThread(): void
+    {
+        $opener = $this->user();
+        $thread = $this->threadOpenedBy($opener);
+        $voter = new ThreadVoter();
+
+        self::assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->token($opener), $thread, ['move']));
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $thread, ['move'])
+        );
+    }
+
+    public function testThreadOpenerAndAdminMayWithdrawTheThread(): void
+    {
+        $opener = $this->user();
+        $thread = $this->threadOpenedBy($opener);
+        $voter = new ThreadVoter();
+
+        self::assertSame(VoterInterface::ACCESS_GRANTED, $voter->vote($this->token($opener), $thread, ['delete']));
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($this->user(['ROLE_ADMIN'])), $thread, ['delete'])
+        );
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($this->user()), $thread, ['delete'])
         );
     }
 


### PR DESCRIPTION
## Summary

Dritter Teil, gestapelt auf #1485. Bisher ließ sich im Forum nichts zurückziehen und nichts umsortieren.

- **`ForumStatistics`** (`src/Criticalmass/Forum/`) hält Zähler und Verweise in Ordnung. `Board` und `City` führen `threadNumber`, `postNumber` und `lastThread` als Momentaufnahme mit — ohne Pflege zeigen sie nach einem Umzug auf Themen, die dort nicht mehr liegen.
- **`BoardInterface::decThreadNumber()` / `decPostNumber(int $amount = 1)`**; `incPostNumber()` nimmt jetzt ebenfalls eine Menge, damit Verschieben symmetrisch bleibt. Zähler fallen nie unter null.
- **`/thread/move/{threadSlug}`** — Admins, Auswahl aus allen Foren und Städten
- **`/thread/disable/{threadSlug}`** — Eröffner und Admins
- **`/post/disable/{postId}`** — Autor und Admins, **außer** für den ersten Beitrag eines Themas
- Neue Repository-Abfragen: `countPostsForThread`, `findLatestPostForThread`, `findLatestThread`

## Warum der erste Beitrag geschützt ist

Ohne ihn stünde ein Thema ohne Anfang da — die Thread-Liste rendert `thread.firstPost.user`. Wer den Anfang zurückziehen will, zieht das ganze Thema zurück; genau dafür gibt es den zweiten Endpunkt.

## Nebenbei behoben

`Board::__construct()` setzte ein `dateTime`-Feld, das die Entity nicht hat. In PHP 8.2 ist das eine Deprecation, in PHP 9 ein Fehler — meine neuen Tests haben es sichtbar gemacht. Der zugehörige Eintrag in `phpstan-baseline.neon` fällt damit weg.

## Test Plan

- [x] `vendor/bin/phpunit tests/Security/ tests/Criticalmass/Forum/` — 26 Tests grün, davon 8 für die Zähler-Logik
- [x] `vendor/bin/phpstan analyse` (gesamtes Projekt) — keine Fehler
- [ ] `tests/Controller/ForumWithdrawControllerTest.php` — 6 funktionale Tests in CI
- [ ] Manuell: Thema verschieben → Zähler beider Foren stimmen, „letzter Beitrag" in der Übersicht ist korrekt

Closes #1149
Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR