### PR TITLE
Forum: Paginierung für Themen und Beiträge

### DIFF
--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -15,6 +15,7 @@ use App\Entity\Thread;
 use App\EntityInterface\BoardInterface;
 use App\Form\Type\ThreadType;
 use Malenki\Slug;
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -27,6 +28,9 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class BoardController extends AbstractController
 {
+    public const THREADS_PER_PAGE = 20;
+    public const POSTS_PER_PAGE = 20;
+
     #[Route('/boards/overview', name: 'caldera_criticalmass_board_overview', priority: 240)]
     public function overviewAction(
         CityRepository $cityRepository,
@@ -42,6 +46,8 @@ class BoardController extends AbstractController
     #[Route('/boards/{boardSlug}', name: 'caldera_criticalmass_board_listthreads', priority: 240)]
     #[Route('/{citySlug}/listthreads', name: 'caldera_criticalmass_board_listcitythreads', priority: 240)]
     public function listThreadsAction(
+        Request $request,
+        PaginatorInterface $paginator,
         ThreadRepository $threadRepository,
         ObjectRouterInterface $objectRouter,
         #[MapEntity(mapping: ['boardSlug' => 'slug'])] ?Board $board = null,
@@ -51,18 +57,15 @@ class BoardController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $threads = [];
-        $newThreadUrl = '';
-
         if ($board) {
-            $threads = $threadRepository->findThreadsForBoard($board);
+            $query = $threadRepository->queryThreadsForBoard($board);
             $newThreadUrl = $objectRouter->generate($board, 'caldera_criticalmass_board_addthread');
-        }
-
-        if ($city) {
-            $threads = $threadRepository->findThreadsForCity($city);
+        } else {
+            $query = $threadRepository->queryThreadsForCity($city);
             $newThreadUrl = $objectRouter->generate($city, 'caldera_criticalmass_board_addcitythread');
         }
+
+        $threads = $paginator->paginate($query, $request->query->getInt('page', 1), self::THREADS_PER_PAGE);
 
         return $this->render('Board/list_threads.html.twig', [
             'threads' => $threads,
@@ -74,10 +77,17 @@ class BoardController extends AbstractController
     #[Route('/boards/{boardSlug}/thread/{threadSlug}', name: 'caldera_criticalmass_board_viewthread', priority: 240)]
     #[Route('/{citySlug}/thread/{threadSlug}', name: 'caldera_criticalmass_board_viewcitythread', priority: 240)]
     public function viewThreadAction(
+        Request $request,
+        PaginatorInterface $paginator,
         PostRepository $postRepository,
         Thread $thread
     ): Response {
-        $posts = $postRepository->findPostsForThread($thread);
+        $posts = $paginator->paginate(
+            $postRepository->queryPostsForThread($thread),
+            $request->query->getInt('page', 1),
+            self::POSTS_PER_PAGE
+        );
+
         $board = $thread->getCity() ?? $thread->getBoard();
 
         return $this->render('Board/view_thread.html.twig', [

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -123,6 +123,7 @@ class PostController extends AbstractController
     public function editAction(
         Request $request,
         ObjectRouterInterface $objectRouter,
+        PostRepository $postRepository,
         #[MapEntity(mapping: ['postId' => 'id'])] Post $post
     ): Response {
         $this->denyAccessUnlessGranted('edit', $post);
@@ -142,7 +143,7 @@ class PostController extends AbstractController
 
             $this->addFlash('success', 'Dein Beitrag wurde geändert.');
 
-            return $this->redirect($this->generatePostUrl($post, $objectRouter));
+            return $this->redirect($this->generatePostUrl($post, $objectRouter, $postRepository));
         }
 
         return $this->render('Post/edit.html.twig', [
@@ -156,6 +157,7 @@ class PostController extends AbstractController
     public function disableAction(
         ObjectRouterInterface $objectRouter,
         ForumStatistics $forumStatistics,
+        PostRepository $postRepository,
         #[MapEntity(mapping: ['postId' => 'id'])] Post $post
     ): Response {
         $this->denyAccessUnlessGranted('delete', $post);
@@ -171,14 +173,15 @@ class PostController extends AbstractController
 
         $this->addFlash('success', 'Dein Beitrag wurde zurückgezogen.');
 
-        return $this->redirect($this->generatePostUrl($post, $objectRouter));
+        return $this->redirect($this->generatePostUrl($post, $objectRouter, $postRepository));
     }
 
     /**
      * Ein Beitrag hängt immer an genau einem Gegenstand — Thema, Tour, Stadt oder Foto.
-     * Nach dem Bearbeiten landet man wieder dort, beim Beitrag selbst.
+     * Nach dem Bearbeiten landet man wieder dort, beim Beitrag selbst. In langen Themen
+     * liegt er womöglich nicht auf der ersten Seite, deshalb reist die Seitenzahl mit.
      */
-    protected function generatePostUrl(Post $post, ObjectRouterInterface $objectRouter): string
+    protected function generatePostUrl(Post $post, ObjectRouterInterface $objectRouter, ?PostRepository $postRepository = null): string
     {
         $postable = $post->getThread() ?? $post->getRide() ?? $post->getCity() ?? $post->getPhoto();
 
@@ -186,7 +189,17 @@ class PostController extends AbstractController
             return $this->generateUrl('caldera_criticalmass_board_overview');
         }
 
-        return sprintf('%s#post-%d', $objectRouter->generate($postable), $post->getId());
+        $url = $objectRouter->generate($postable);
+
+        if ($postable instanceof Thread && null !== $postRepository) {
+            $page = (int) ceil($postRepository->findPositionInThread($post) / BoardController::POSTS_PER_PAGE);
+
+            if ($page > 1) {
+                $url .= (str_contains($url, '?') ? '&' : '?') . 'page=' . $page;
+            }
+        }
+
+        return sprintf('%s#post-%d', $url, $post->getId());
     }
 
     public function listAction(

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\Thread;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query;
 use Doctrine\Persistence\ManagerRegistry;
 
 class PostRepository extends ServiceEntityRepository
@@ -97,6 +98,14 @@ class PostRepository extends ServiceEntityRepository
 
     public function findPostsForThread(Thread $thread): array
     {
+        return $this->queryPostsForThread($thread)->getResult();
+    }
+
+    /**
+     * Die Abfrage statt des Ergebnisses — der Paginator braucht sie, um selbst zu begrenzen.
+     */
+    public function queryPostsForThread(Thread $thread): Query
+    {
         $builder = $this->createQueryBuilder('p');
 
         $builder
@@ -107,9 +116,33 @@ class PostRepository extends ServiceEntityRepository
             ->setParameter('enabled', true)
             ->addOrderBy('p.dateTime', 'ASC');
 
-        $query = $builder->getQuery();
+        return $builder->getQuery();
+    }
 
-        return $query->getResult();
+    /**
+     * Der wievielte Beitrag eines Themas ist das? Aus der Position folgt die Seite,
+     * auf der ein Dauerlink wie #post-42 tatsaechlich zu finden ist.
+     */
+    public function findPositionInThread(Post $post): int
+    {
+        $thread = $post->getThread();
+
+        if (null === $thread) {
+            return 1;
+        }
+
+        $builder = $this->createQueryBuilder('p');
+
+        $builder
+            ->select('COUNT(p.id)')
+            ->where($builder->expr()->eq('p.thread', ':thread'))
+            ->setParameter('thread', $thread)
+            ->andWhere($builder->expr()->eq('p.enabled', ':enabled'))
+            ->setParameter('enabled', true)
+            ->andWhere($builder->expr()->lte('p.dateTime', ':dateTime'))
+            ->setParameter('dateTime', $post->getDateTime());
+
+        return max(1, (int) $builder->getQuery()->getSingleScalarResult());
     }
 
     public function findForTimelineThreadPostCollector(

--- a/src/Repository/ThreadRepository.php
+++ b/src/Repository/ThreadRepository.php
@@ -7,6 +7,7 @@ use App\Entity\City;
 use App\Entity\Thread;
 use App\EntityInterface\BoardInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query;
 use Doctrine\Persistence\ManagerRegistry;
 
 class ThreadRepository extends ServiceEntityRepository
@@ -18,40 +19,42 @@ class ThreadRepository extends ServiceEntityRepository
 
     public function findThreadsForBoard(Board $board): array
     {
-        $builder = $this->createQueryBuilder('t');
+        return $this->queryThreadsForBoard($board)->getResult();
+    }
 
-        $builder
-            ->select('t')
-            ->leftJoin('t.lastPost', 'lastPost')
-            ->where($builder->expr()->eq('t.board', ':board'))
-            ->setParameter('board', $board)
-            ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
-            ->setParameter('enabled', true)
-            ->orderBy('t.sticky', 'DESC')
-            ->addOrderBy('lastPost.dateTime', 'DESC');
-
-        $query = $builder->getQuery();
-
-        return $query->getResult();
+    /**
+     * Die Abfrage statt des Ergebnisses — der Paginator braucht sie, um selbst zu begrenzen.
+     */
+    public function queryThreadsForBoard(Board $board): Query
+    {
+        return $this->buildThreadQuery('t.board', $board);
     }
 
     public function findThreadsForCity(City $city): array
+    {
+        return $this->queryThreadsForCity($city)->getResult();
+    }
+
+    public function queryThreadsForCity(City $city): Query
+    {
+        return $this->buildThreadQuery('t.city', $city);
+    }
+
+    private function buildThreadQuery(string $field, Board|City $board): Query
     {
         $builder = $this->createQueryBuilder('t');
 
         $builder
             ->select('t')
             ->leftJoin('t.lastPost', 'lastPost')
-            ->where($builder->expr()->eq('t.city', ':city'))
-            ->setParameter('city', $city)
+            ->where($builder->expr()->eq($field, ':board'))
+            ->setParameter('board', $board)
             ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
             ->setParameter('enabled', true)
             ->orderBy('t.sticky', 'DESC')
             ->addOrderBy('lastPost.dateTime', 'DESC');
 
-        $query = $builder->getQuery();
-
-        return $query->getResult();
+        return $builder->getQuery();
     }
 
     /**

--- a/templates/Board/list_threads.html.twig
+++ b/templates/Board/list_threads.html.twig
@@ -8,6 +8,16 @@
     {{ breadcrumb.active(board.title) }}
 {% endblock %}
 
+{% block additionalHeaderElements %}
+    {{ parent() }}
+    {% if threads.currentPageNumber > 1 %}
+        <link rel="prev" href="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge({ 'page': threads.currentPageNumber - 1 })) }}"/>
+    {% endif %}
+    {% if threads.currentPageNumber < threads.pageCount %}
+        <link rel="next" href="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge({ 'page': threads.currentPageNumber + 1 })) }}"/>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     <div class="container">
         <div class="d-flex justify-content-between align-items-center mb-4">
@@ -90,6 +100,12 @@
                     </div>
                 </div>
             {% endfor %}
+
+            {% if threads.pageCount > 1 %}
+                <nav class="d-flex justify-content-center mt-4" aria-label="Seiten">
+                    {{ knp_pagination_render(threads) }}
+                </nav>
+            {% endif %}
         {% else %}
             <div class="text-center py-5">
                 <i class="far fa-comments fa-3x text-muted mb-3"></i>

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -9,6 +9,16 @@
     {{ breadcrumb.active(thread.title) }}
 {% endblock %}
 
+{% block additionalHeaderElements %}
+    {{ parent() }}
+    {% if posts.currentPageNumber > 1 %}
+        <link rel="prev" href="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge({ 'page': posts.currentPageNumber - 1 })) }}"/>
+    {% endif %}
+    {% if posts.currentPageNumber < posts.pageCount %}
+        <link rel="next" href="{{ path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge({ 'page': posts.currentPageNumber + 1 })) }}"/>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     <div class="container">
         <div class="d-flex justify-content-between align-items-center mb-4">
@@ -75,6 +85,12 @@
         {% for post in posts %}
             {% include('Post/post.html.twig') with { 'post': post } %}
         {% endfor %}
+
+        {% if posts.pageCount > 1 %}
+            <nav class="d-flex justify-content-center mb-4" aria-label="Seiten">
+                {{ knp_pagination_render(posts) }}
+            </nav>
+        {% endif %}
 
         {% if posts is empty %}
             <div class="text-center py-5">

--- a/tests/Controller/ForumPaginationControllerTest.php
+++ b/tests/Controller/ForumPaginationControllerTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Controller\BoardController;
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumPaginationControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+
+    private function openThread(KernelBrowser $client, string $title): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = 'Der erste Beitrag zu ' . $title . '.';
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread);
+
+        return (string) $thread->getSlug();
+    }
+
+    public function testThreadListStaysReachableWithAPageParameter(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/boards/general', ['page' => 1]);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testThreadViewStaysReachableWithAPageParameter(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Seitenzahl im Thema');
+
+        $client->request('GET', '/boards/general/thread/' . $slug, ['page' => 1]);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testShortThreadShowsNoPagination(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Kurzes Thema ohne Seiten');
+        $crawler = $client->request('GET', '/boards/general/thread/' . $slug);
+
+        self::assertSame(
+            0,
+            $crawler->filter('nav[aria-label="Seiten"]')->count(),
+            'Ein Thema mit einem Beitrag braucht keine Seitennavigation.'
+        );
+    }
+
+    public function testLongThreadIsSplitIntoPages(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Langes Thema mit Seiten');
+
+        // Ein Beitrag mehr als auf eine Seite passt.
+        for ($i = 0; $i < BoardController::POSTS_PER_PAGE; ++$i) {
+            $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Antwort Nummer ' . $i]]);
+        }
+
+        $crawler = $client->request('GET', '/boards/general/thread/' . $slug);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertGreaterThan(0, $crawler->filter('nav[aria-label="Seiten"]')->count());
+        self::assertGreaterThan(0, $crawler->filter('link[rel="next"]')->count(), 'Suchmaschinen brauchen den Vorwärtsverweis.');
+
+        $secondPage = $client->request('GET', '/boards/general/thread/' . $slug, ['page' => 2]);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertGreaterThan(0, $secondPage->filter('link[rel="prev"]')->count());
+    }
+
+    public function testEditRedirectLandsOnThePageHoldingThePost(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Bearbeiten auf Seite zwei');
+
+        for ($i = 0; $i < BoardController::POSTS_PER_PAGE; ++$i) {
+            $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Antwort Nummer ' . $i]]);
+        }
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+        $lastPost = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $slug])->getLastPost();
+
+        $crawler = $client->request('GET', '/post/edit/' . $lastPost->getId());
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['post[message]'] = 'Nachträglich geändert.';
+        $client->submit($form);
+
+        self::assertStringContainsString(
+            'page=2',
+            (string) $client->getResponse()->headers->get('Location'),
+            'Der Dauerlink muss auf die Seite zeigen, auf der der Beitrag wirklich steht.'
+        );
+    }
+}

--- a/tests/Controller/ForumPaginationControllerTest.php
+++ b/tests/Controller/ForumPaginationControllerTest.php
@@ -28,6 +28,19 @@ class ForumPaginationControllerTest extends AbstractControllerTestCase
         return (string) $thread->getSlug();
     }
 
+    /**
+     * Antwortet ueber das echte Formular; ein roher POST scheitert an der CSRF-Pruefung.
+     */
+    private function reply(KernelBrowser $client, string $threadSlug, string $message): void
+    {
+        $crawler = $client->request('GET', '/post/write/thread/' . $threadSlug);
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['post[message]'] = $message;
+
+        $client->submit($form);
+    }
+
     public function testThreadListStaysReachableWithAPageParameter(): void
     {
         $client = static::createClient();
@@ -73,7 +86,7 @@ class ForumPaginationControllerTest extends AbstractControllerTestCase
 
         // Ein Beitrag mehr als auf eine Seite passt.
         for ($i = 0; $i < BoardController::POSTS_PER_PAGE; ++$i) {
-            $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Antwort Nummer ' . $i]]);
+            $this->reply($client, $slug, 'Antwort Nummer ' . $i);
         }
 
         $crawler = $client->request('GET', '/boards/general/thread/' . $slug);
@@ -96,7 +109,7 @@ class ForumPaginationControllerTest extends AbstractControllerTestCase
         $slug = $this->openThread($client, 'Bearbeiten auf Seite zwei');
 
         for ($i = 0; $i < BoardController::POSTS_PER_PAGE; ++$i) {
-            $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Antwort Nummer ' . $i]]);
+            $this->reply($client, $slug, 'Antwort Nummer ' . $i);
         }
 
         $doctrine = static::getContainer()->get('doctrine');


### PR DESCRIPTION
## Summary

Vierter Teil, gestapelt auf #1486. Ein Forum lud bisher alle Themen und ein Thema alle Beiträge auf einmal.

- **20 pro Seite**, über den bereits vorhandenen KnpPaginator (`BoardController::THREADS_PER_PAGE` / `POSTS_PER_PAGE`)
- Die Repository-Methoden liefern jetzt zusätzlich die *Abfrage* statt des Ergebnisses (`queryThreadsForBoard`, `queryThreadsForCity`, `queryPostsForThread`) — der Paginator muss selbst begrenzen können, sonst lädt er erst alles und wirft dann weg. Die alten `find*`-Methoden bleiben und delegieren.
- `?page=N`, Seitennavigation in beiden Templates, `rel="prev"` / `rel="next"` im Kopf der Seite

## Dauerlinks bleiben gültig

In einem langen Thema steht ein Beitrag womöglich nicht auf der ersten Seite. `PostRepository::findPositionInThread()` ermittelt seine Position, und `generatePostUrl()` hängt die passende Seitenzahl an — sonst hätte der Verweis nach dem Bearbeiten (aus #1484) auf `#post-42` gezeigt, während der Beitrag auf Seite 3 liegt.

## Test Plan

- [x] `vendor/bin/phpstan analyse` (gesamtes Projekt) — keine Fehler
- [ ] `tests/Controller/ForumPaginationControllerTest.php` — 5 funktionale Tests in CI, darunter einer, der ein Thema über die Seitengrenze hinaus füllt und prüft, dass der Bearbeiten-Verweis auf `page=2` zeigt
- [ ] Manuell: Forum mit mehr als 20 Themen durchblättern

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR