### PR TITLE
CI auch auf gestapelten Pull Requests laufen lassen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
+# Auch gestapelte Pull Requests pruefen: Wenn nur PRs gegen main laufen, bleibt
+# jeder Zwischenschritt einer Kette ungeprueft, und die Fehler tauchen erst auf,
+# wenn alles zusammen in main liegt.
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   phpstan:


### PR DESCRIPTION
## Summary

`ci.yml` lief nur auf Pull Requests gegen `main`:

```yaml
on:
  pull_request:
    branches: [main]
```

Bei einer gestapelten Kette bleibt damit **jeder Zwischenschritt ungeprüft**. Nur die unterste PR wird getestet; alle darüber laufen ohne einen einzigen Check, und die Fehler tauchen erst auf, wenn alles zusammen in `main` liegt.

Genau so ist `main` heute rot geworden: Der MCP-Stack (#1439–#1446) sah PR für PR grün aus, zusammengeführt fehlten dann sechs PHPStan-Einträge und drei Tests (repariert in #1481). Der Forum-Stack, an dem ich gerade arbeite, hat dasselbe Problem — #1485, #1486 und #1487 zeigen „no checks".

Der Filter entfällt, `on: pull_request` prüft jeden Pull Request unabhängig von seiner Basis.

## Test Plan

- [x] Diese PR selbst läuft gegen `main` und wird wie bisher geprüft
- [ ] Nach dem Merge zeigen die gestapelten Forum-PRs Checks an

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR