### PR TITLE
Forum: Markdown-Editor mit Vorschau und Zitieren

### DIFF
--- a/assets/controllers/markdown_editor_controller.js
+++ b/assets/controllers/markdown_editor_controller.js
@@ -1,0 +1,142 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Werkzeugleiste, Tastenkürzel und Vorschau für die Markdown-Felder des Forums.
+ *
+ * Die Vorschau rendert der Server mit demselben Parser wie den fertigen Beitrag —
+ * ein zweiter Renderer im Browser würde über kurz oder lang abweichen.
+ */
+export default class extends Controller {
+    static targets = ['input', 'preview', 'writePane', 'previewPane', 'writeTab', 'previewTab'];
+    static values = { previewUrl: String };
+
+    connect() {
+        this.keyHandler = this.handleKeydown.bind(this);
+        this.inputTarget.addEventListener('keydown', this.keyHandler);
+    }
+
+    disconnect() {
+        this.inputTarget.removeEventListener('keydown', this.keyHandler);
+    }
+
+    handleKeydown(event) {
+        if (!event.ctrlKey && !event.metaKey) {
+            return;
+        }
+
+        const shortcuts = { b: 'bold', i: 'italic', k: 'link' };
+        const action = shortcuts[event.key.toLowerCase()];
+
+        if (!action) {
+            return;
+        }
+
+        event.preventDefault();
+        this.applyFormat(action);
+    }
+
+    format(event) {
+        event.preventDefault();
+        this.applyFormat(event.currentTarget.dataset.format);
+    }
+
+    applyFormat(format) {
+        const input = this.inputTarget;
+        const start = input.selectionStart;
+        const end = input.selectionEnd;
+        const selected = input.value.slice(start, end);
+
+        const wraps = {
+            bold: ['**', '**', 'fetter Text'],
+            italic: ['_', '_', 'kursiver Text'],
+            code: ['`', '`', 'Code'],
+            link: ['[', '](https://)', 'Linktext'],
+        };
+        const prefixes = {
+            list: '- ',
+            quote: '> ',
+            codeblock: '```\n',
+        };
+
+        let replacement;
+        let caret;
+
+        if (wraps[format]) {
+            const [before, after, placeholder] = wraps[format];
+            const text = selected || placeholder;
+
+            replacement = before + text + after;
+            caret = start + before.length + text.length;
+        } else if (prefixes[format]) {
+            const text = selected || (format === 'codeblock' ? 'Code' : 'Zeile');
+            const prefix = prefixes[format];
+
+            replacement = format === 'codeblock'
+                ? `${prefix}${text}\n\`\`\``
+                : text.split('\n').map((line) => prefix + line).join('\n');
+            caret = start + replacement.length;
+        } else {
+            return;
+        }
+
+        input.setRangeText(replacement, start, end, 'end');
+        input.setSelectionRange(caret, caret);
+        input.focus();
+    }
+
+    /**
+     * Fügt ein Zitat am Anfang des Feldes ein — ausgelöst vom „Zitieren“-Knopf eines Beitrags.
+     */
+    quote({ detail }) {
+        if (!detail || !detail.text) {
+            return;
+        }
+
+        const quoted = detail.text.split('\n').map((line) => `> ${line}`).join('\n');
+        const attribution = detail.author ? `**${detail.author}** schrieb:\n` : '';
+        const existing = this.inputTarget.value;
+
+        this.inputTarget.value = `${attribution}${quoted}\n\n${existing}`;
+        this.inputTarget.focus();
+        this.inputTarget.setSelectionRange(this.inputTarget.value.length, this.inputTarget.value.length);
+    }
+
+    showWrite(event) {
+        event.preventDefault();
+        this.togglePanes(true);
+    }
+
+    async showPreview(event) {
+        event.preventDefault();
+        this.togglePanes(false);
+
+        this.previewTarget.innerHTML = '<p class="text-muted mb-0">Vorschau wird geladen …</p>';
+
+        try {
+            const response = await fetch(this.previewUrlValue, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({ message: this.inputTarget.value }),
+            });
+
+            if (!response.ok) {
+                throw new Error(String(response.status));
+            }
+
+            this.previewTarget.innerHTML = await response.text();
+        } catch (error) {
+            this.previewTarget.innerHTML =
+                '<p class="text-danger mb-0">Die Vorschau lässt sich gerade nicht laden. Dein Text bleibt erhalten.</p>';
+        }
+    }
+
+    togglePanes(showWrite) {
+        this.writePaneTarget.hidden = !showWrite;
+        this.previewPaneTarget.hidden = showWrite;
+
+        this.writeTabTarget.classList.toggle('active', showWrite);
+        this.previewTabTarget.classList.toggle('active', !showWrite);
+        this.writeTabTarget.setAttribute('aria-selected', String(showWrite));
+        this.previewTabTarget.setAttribute('aria-selected', String(!showWrite));
+    }
+}

--- a/assets/controllers/quote_post_controller.js
+++ b/assets/controllers/quote_post_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from '@hotwired/stimulus';
+import { Modal } from 'bootstrap';
+
+/**
+ * Der „Zitieren“-Knopf eines Beitrags: Er reicht den Text an das Antwortfeld weiter
+ * und öffnet, falls das Feld in einem Dialog liegt, diesen Dialog.
+ */
+export default class extends Controller {
+    static values = { author: String, target: String, modal: String };
+
+    quote(event) {
+        event.preventDefault();
+
+        const editor = document.querySelector(this.targetValue);
+
+        if (!editor) {
+            return;
+        }
+
+        const text = this.element.dataset.quoteText || '';
+
+        editor.dispatchEvent(new CustomEvent('markdown-editor:quote', {
+            detail: { text, author: this.authorValue },
+        }));
+
+        if (this.hasModalValue) {
+            const dialog = document.querySelector(this.modalValue);
+
+            if (dialog) {
+                Modal.getOrCreateInstance(dialog).show();
+            }
+        }
+    }
+}

--- a/assets/scss/criticalmass.scss
+++ b/assets/scss/criticalmass.scss
@@ -4,6 +4,7 @@
 @import "criticalmass/criticalmass";
 @import "criticalmass/frontpage3";
 @import "criticalmass/explore";
+@import "criticalmass/forum";
 
 .input-daterange input {
   text-align: left !important;

--- a/assets/scss/criticalmass/_forum.scss
+++ b/assets/scss/criticalmass/_forum.scss
@@ -1,0 +1,59 @@
+// Darstellung der Beitragstexte im Forum — gilt gleichermaßen für den fertigen
+// Beitrag und die Vorschau im Editor, damit beide gleich aussehen.
+.post-content {
+  overflow-wrap: break-word;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+
+  blockquote {
+    margin: 0 0 1rem;
+    padding: 0.5rem 0 0.5rem 1rem;
+    border-left: 3px solid var(--bs-border-color);
+    color: var(--bs-secondary-color);
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  pre {
+    padding: 0.75rem 1rem;
+    border-radius: var(--bs-border-radius);
+    background-color: var(--bs-tertiary-bg);
+    overflow-x: auto;
+  }
+
+  :not(pre) > code {
+    padding: 0.1em 0.35em;
+    border-radius: var(--bs-border-radius-sm);
+    background-color: var(--bs-tertiary-bg);
+  }
+
+  table {
+    width: 100%;
+    margin-bottom: 1rem;
+    display: block;
+    overflow-x: auto;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+.markdown-editor {
+  textarea {
+    resize: vertical;
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  .nav-tabs .nav-link {
+    padding-block: 0.35rem;
+  }
+}

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Criticalmass\Forum\ForumStatistics;
 use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Criticalmass\TextParser\TextParserInterface;
 use App\Entity\Photo;
 use App\EntityInterface\PostableInterface;
 use App\Criticalmass\Util\ClassUtil;
@@ -116,6 +117,23 @@ class PostController extends AbstractController
         return $this->render('Post/write_failed.html.twig', [
             'form' => $form->createView(),
         ]);
+    }
+
+    /**
+     * Die Vorschau rendert serverseitig mit demselben Parser wie der fertige Beitrag.
+     * Ein zweiter Markdown-Renderer im Browser wuerde frueher oder spaeter abweichen.
+     */
+    #[IsGranted('ROLE_USER')]
+    #[Route('/post/preview', name: 'caldera_criticalmass_post_preview', methods: ['POST'], priority: 130)]
+    public function previewAction(Request $request, TextParserInterface $textParser): Response
+    {
+        $message = trim((string) $request->request->get('message', ''));
+
+        if ('' === $message) {
+            return new Response('<p class="text-muted fst-italic mb-0">Noch nichts geschrieben.</p>');
+        }
+
+        return new Response($textParser->parse($message));
     }
 
     #[IsGranted('ROLE_USER')]

--- a/templates/Board/add_thread.html.twig
+++ b/templates/Board/add_thread.html.twig
@@ -30,7 +30,7 @@
 
                 <div class="mb-3">
                     <label class="form-label" for="{{ form.message.vars.id }}">Dein Beitrag:</label>
-                    {{ form_widget(form.message, { 'attr' : { 'class': 'form-control', 'rows': 10 } }) }}
+                    {% include 'Post/_editor.html.twig' with { 'field': form.message, 'rows': 10 } %}
                 </div>
 
                 <div class="d-flex justify-content-end">

--- a/templates/Post/_editor.html.twig
+++ b/templates/Post/_editor.html.twig
@@ -1,0 +1,62 @@
+{# Markdown-Feld mit Werkzeugleiste, Tastenkürzeln und serverseitiger Vorschau. #}
+{% set editorId = editorId|default('markdown-editor') %}
+
+<div class="markdown-editor"
+     id="{{ editorId }}"
+     data-controller="markdown-editor"
+     data-markdown-editor-preview-url-value="{{ path('caldera_criticalmass_post_preview') }}"
+     data-action="markdown-editor:quote->markdown-editor#quote">
+
+    <ul class="nav nav-tabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button type="button" class="nav-link active" role="tab" aria-selected="true"
+                    data-markdown-editor-target="writeTab"
+                    data-action="markdown-editor#showWrite">Schreiben</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button type="button" class="nav-link" role="tab" aria-selected="false"
+                    data-markdown-editor-target="previewTab"
+                    data-action="markdown-editor#showPreview">Vorschau</button>
+        </li>
+    </ul>
+
+    <div class="border border-top-0 rounded-bottom p-2">
+        <div data-markdown-editor-target="writePane">
+            <div class="btn-toolbar mb-2" role="toolbar" aria-label="Formatierung">
+                <div class="btn-group btn-group-sm" role="group">
+                    <button type="button" class="btn btn-outline-secondary" title="Fett (Strg+B)"
+                            data-format="bold" data-action="markdown-editor#format"><i class="fas fa-bold"></i></button>
+                    <button type="button" class="btn btn-outline-secondary" title="Kursiv (Strg+I)"
+                            data-format="italic" data-action="markdown-editor#format"><i class="fas fa-italic"></i></button>
+                    <button type="button" class="btn btn-outline-secondary" title="Link (Strg+K)"
+                            data-format="link" data-action="markdown-editor#format"><i class="fas fa-link"></i></button>
+                </div>
+                <div class="btn-group btn-group-sm ms-2" role="group">
+                    <button type="button" class="btn btn-outline-secondary" title="Liste"
+                            data-format="list" data-action="markdown-editor#format"><i class="fas fa-list-ul"></i></button>
+                    <button type="button" class="btn btn-outline-secondary" title="Zitat"
+                            data-format="quote" data-action="markdown-editor#format"><i class="fas fa-quote-right"></i></button>
+                    <button type="button" class="btn btn-outline-secondary" title="Code"
+                            data-format="code" data-action="markdown-editor#format"><i class="fas fa-code"></i></button>
+                    <button type="button" class="btn btn-outline-secondary" title="Code-Block"
+                            data-format="codeblock" data-action="markdown-editor#format"><i class="fas fa-file-code"></i></button>
+                </div>
+            </div>
+
+            {{ form_widget(field, { 'attr': {
+                'class': 'form-control border-0',
+                'rows': rows|default(8),
+                'placeholder': placeholder|default('Schreibe hier deinen Beitrag. Markdown ist erlaubt.'),
+                'data-markdown-editor-target': 'input'
+            } }) }}
+        </div>
+
+        <div class="post-content p-2" data-markdown-editor-target="previewPane" hidden>
+            <div data-markdown-editor-target="preview"></div>
+        </div>
+    </div>
+
+    <p class="form-text">
+        Markdown: <code>**fett**</code>, <code>_kursiv_</code>, <code>&gt; Zitat</code>, <code>- Liste</code>
+    </p>
+</div>

--- a/templates/Post/edit.html.twig
+++ b/templates/Post/edit.html.twig
@@ -27,7 +27,7 @@
 
                 <div class="mb-3">
                     <label class="form-label" for="{{ form.message.vars.id }}">Dein Beitrag:</label>
-                    {{ form_widget(form.message, { 'attr' : { 'class': 'form-control', 'rows': 10 } }) }}
+                    {% include 'Post/_editor.html.twig' with { 'field': form.message, 'rows': 10 } %}
                 </div>
 
                 <div class="d-flex justify-content-end">

--- a/templates/Post/post.html.twig
+++ b/templates/Post/post.html.twig
@@ -38,8 +38,19 @@
                         bearbeitet am {{ post.updatedAt|date('d.m.Y, H:i', 'Europe/Berlin') }}
                     </p>
                 {% endif %}
-                {% if is_granted('edit', post) or is_granted('delete', post) %}
+                {% if app.user %}
                     <div class="mt-2 d-flex gap-2">
+                        {% if post.thread %}
+                            <button type="button" class="btn btn-outline-secondary btn-sm"
+                                    data-controller="quote-post"
+                                    data-quote-post-author-value="{{ post.user.username }}"
+                                    data-quote-post-target-value="#markdown-editor-reply"
+                                    data-quote-post-modal-value="#modal-add-post"
+                                    data-quote-text="{{ post.message }}"
+                                    data-action="quote-post#quote">
+                                <i class="fas fa-quote-right me-1"></i>Zitieren
+                            </button>
+                        {% endif %}
                         {% if is_granted('edit', post) %}
                             <a href="{{ path('caldera_criticalmass_post_edit', { 'postId': post.id }) }}"
                                class="btn btn-outline-secondary btn-sm">

--- a/templates/Post/write.html.twig
+++ b/templates/Post/write.html.twig
@@ -12,7 +12,12 @@
                 <div class="modal-body">
                     <div class="mb-3">
                         <label class="form-label text-muted">Dein Kommentar</label>
-                        {{ form_widget(form.message, {'attr': {'class': 'form-control', 'rows': 6, 'placeholder': 'Schreibe hier deinen Kommentar...'}}) }}
+                        {% include 'Post/_editor.html.twig' with {
+                            'field': form.message,
+                            'rows': 6,
+                            'editorId': 'markdown-editor-reply',
+                            'placeholder': 'Schreibe hier deinen Kommentar. Markdown ist erlaubt.'
+                        } %}
                     </div>
                     {{ form_widget(form._token) }}
                 </div>

--- a/tests/Controller/ForumEditorControllerTest.php
+++ b/tests/Controller/ForumEditorControllerTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumEditorControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+
+    private function openThread(KernelBrowser $client, string $title): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = 'Der erste Beitrag zu ' . $title . '.';
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread);
+
+        return (string) $thread->getSlug();
+    }
+
+    public function testPreviewRendersMarkdown(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $client->request('POST', '/post/preview', ['message' => 'Das ist **fett** und _kursiv_.']);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $html = (string) $client->getResponse()->getContent();
+
+        self::assertStringContainsString('<strong>fett</strong>', $html);
+        self::assertStringContainsString('<em>kursiv</em>', $html);
+    }
+
+    public function testPreviewRendersQuotesAsBlockquote(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $client->request('POST', '/post/preview', ['message' => "> zitierter Text\n\nmeine Antwort"]);
+
+        self::assertStringContainsString('<blockquote>', (string) $client->getResponse()->getContent());
+    }
+
+    public function testPreviewStripsRawHtml(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $client->request('POST', '/post/preview', ['message' => '<script>alert(1)</script> harmlos']);
+
+        $html = (string) $client->getResponse()->getContent();
+
+        self::assertStringNotContainsString('<script>', $html, 'Der Parser muss rohes HTML entfernen.');
+    }
+
+    public function testEmptyPreviewSaysSo(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $client->request('POST', '/post/preview', ['message' => '   ']);
+
+        self::assertStringContainsString('Noch nichts geschrieben', (string) $client->getResponse()->getContent());
+    }
+
+    public function testPreviewRequiresLogin(): void
+    {
+        $client = static::createClient();
+
+        $client->request('POST', '/post/preview', ['message' => 'Hallo']);
+
+        self::assertEquals(302, $client->getResponse()->getStatusCode());
+    }
+
+    public function testThreadViewOffersQuoteButtons(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Zitieren im Thema');
+        $crawler = $client->request('GET', '/boards/general/thread/' . $slug);
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('[data-controller="quote-post"]')->count(),
+            'Angemeldete Nutzer sollen jeden Beitrag zitieren können.'
+        );
+    }
+
+    public function testWriteFormCarriesTheEditor(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        self::assertGreaterThan(0, $crawler->filter('[data-controller="markdown-editor"]')->count());
+        self::assertGreaterThan(0, $crawler->filter('[data-format="bold"]')->count(), 'Die Werkzeugleiste gehört dazu.');
+    }
+}


### PR DESCRIPTION
## Summary

Fünfter Teil, gestapelt auf #1487. Das Eingabefeld war ein nacktes Textarea.

- **Werkzeugleiste**: fett, kursiv, Link, Liste, Zitat, Code, Code-Block — jeweils auf die Auswahl angewandt, mit sinnvollem Platzhalter, wenn nichts markiert ist
- **Tastenkürzel** Strg/Cmd + B, I, K
- **Vorschau** über Reiter „Schreiben" / „Vorschau"
- **Zitieren-Knopf** an jedem Beitrag: trägt Text und Autor als Blockquote ins Antwortfeld und öffnet den Dialog
- Einheitliches Markdown-Styling (`_forum.scss`) für Zitate, Code-Blöcke, Tabellen und Bilder

## Zwei bewusste Entscheidungen

**Die Vorschau rendert der Server**, nicht der Browser: `POST /post/preview` schickt den Text durch denselben `TextParser` wie den fertigen Beitrag. Das Issue verlangt ausdrücklich „konsistentes Rendering im Post und in der Vorschau" — mit einem zweiten Renderer im Browser wäre das eine Frage der Zeit gewesen. Außerdem hätte eine JS-Markdown-Bibliothek eine neue Frontend-Abhängigkeit gebraucht, und laut `CLAUDE.md` ist `package-lock.json` eingefroren: jede Neuauflösung zerlegt den Baum.

**Nicht enthalten** aus #1157: Bild-Upload per Drag-and-Drop und der Emoji-Picker. Ersteres braucht einen eigenen Upload-Endpunkt und berührt die offene Härtungs-Arbeit aus #1395 — das gehört in einen eigenen PR, nicht nebenbei. Letzteres bräuchte eine neue Abhängigkeit. Sag Bescheid, wenn du beides trotzdem willst.

## Test Plan

- [x] `vendor/bin/phpstan analyse` (gesamtes Projekt) — keine Fehler
- [ ] `tests/Controller/ForumEditorControllerTest.php` — 7 funktionale Tests in CI, darunter einer, der prüft, dass der Parser rohes HTML entfernt
- [ ] Manuell: Werkzeugleiste auf markiertem Text, Vorschau, Zitieren aus einem langen Thema

Closes #1153
Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR