### PR TITLE
Forum: Volltextsuche

### DIFF
--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -30,6 +30,8 @@ class BoardController extends AbstractController
 {
     public const THREADS_PER_PAGE = 20;
     public const POSTS_PER_PAGE = 20;
+    public const RESULTS_PER_PAGE = 20;
+    public const MINIMUM_SEARCH_LENGTH = 3;
 
     #[Route('/boards/overview', name: 'caldera_criticalmass_board_overview', priority: 240)]
     public function overviewAction(
@@ -40,6 +42,31 @@ class BoardController extends AbstractController
         return $this->render('Board/overview.html.twig', [
             'boards' => $boardRepository->findEnabledBoards(),
             'cities' => $cityRepository->findCitiesWithBoard(),
+        ]);
+    }
+
+    #[Route('/boards/search', name: 'caldera_criticalmass_board_search', priority: 260)]
+    public function searchAction(
+        Request $request,
+        PaginatorInterface $paginator,
+        PostRepository $postRepository
+    ): Response {
+        $term = trim((string) $request->query->get('q', ''));
+        $results = null;
+
+        // Ein einzelner Buchstabe traefe halbe Foren — erst ab drei Zeichen suchen.
+        if (mb_strlen($term) >= self::MINIMUM_SEARCH_LENGTH) {
+            $results = $paginator->paginate(
+                $postRepository->querySearchInForum($term),
+                $request->query->getInt('page', 1),
+                self::RESULTS_PER_PAGE
+            );
+        }
+
+        return $this->render('Board/search_results.html.twig', [
+            'term' => $term,
+            'results' => $results,
+            'minimumLength' => self::MINIMUM_SEARCH_LENGTH,
         ]);
     }
 

--- a/src/Criticalmass/Forum/SearchSnippet.php
+++ b/src/Criticalmass/Forum/SearchSnippet.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\Forum;
+
+/**
+ * Schneidet aus einem Beitrag den Ausschnitt rund um den Suchbegriff heraus und
+ * hebt die Treffer hervor.
+ *
+ * Der Text wird zuerst maskiert und erst danach mit Markierungen versehen — andersherum
+ * käme der Beitragstext als HTML in die Seite.
+ */
+class SearchSnippet
+{
+    private const RADIUS = 120;
+
+    public function build(?string $text, string $term): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', (string) $text) ?? '');
+        $term = trim($term);
+
+        if ('' === $text) {
+            return '';
+        }
+
+        if ('' === $term) {
+            return htmlspecialchars($this->shorten($text, 0), ENT_QUOTES, 'UTF-8');
+        }
+
+        $position = mb_stripos($text, $term);
+        $excerpt = $this->shorten($text, false === $position ? 0 : (int) $position);
+
+        return $this->highlight(htmlspecialchars($excerpt, ENT_QUOTES, 'UTF-8'), $term);
+    }
+
+    private function shorten(string $text, int $position): string
+    {
+        if (mb_strlen($text) <= 2 * self::RADIUS) {
+            return $text;
+        }
+
+        $start = max(0, $position - self::RADIUS);
+        $excerpt = mb_substr($text, $start, 2 * self::RADIUS);
+
+        return ($start > 0 ? '… ' : '') . $excerpt . ' …';
+    }
+
+    /**
+     * Markiert die Fundstellen im bereits maskierten Text. Der Suchbegriff wird ebenso
+     * maskiert, damit er auf die maskierte Fassung passt.
+     */
+    private function highlight(string $escapedText, string $term): string
+    {
+        $escapedTerm = htmlspecialchars($term, ENT_QUOTES, 'UTF-8');
+        $pattern = '/' . preg_quote($escapedTerm, '/') . '/iu';
+
+        return preg_replace($pattern, '<mark>$0</mark>', $escapedText) ?? $escapedText;
+    }
+}

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -80,6 +80,33 @@ class PostRepository extends ServiceEntityRepository
         return (int) $builder->getQuery()->getSingleScalarResult();
     }
 
+    /**
+     * Sucht in Forenbeitraegen: im Text des Beitrags und im Titel seines Themas.
+     *
+     * LIKE statt Volltextindex — dasselbe Verfahren wie die vorhandene Seitensuche.
+     * Fuer die Groessenordnung dieses Forums reicht das; ein FULLTEXT-Index waere der
+     * naechste Schritt, wenn die Beitragszahl das noetig macht.
+     */
+    public function querySearchInForum(string $term): Query
+    {
+        $builder = $this->createQueryBuilder('p');
+
+        $builder
+            ->select('p')
+            ->innerJoin('p.thread', 't')
+            ->where($builder->expr()->eq('p.enabled', ':enabled'))
+            ->setParameter('enabled', true)
+            ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
+            ->andWhere($builder->expr()->orX(
+                $builder->expr()->like('p.message', ':term'),
+                $builder->expr()->like('t.title', ':term')
+            ))
+            ->setParameter('term', '%' . $term . '%')
+            ->orderBy('p.dateTime', 'DESC');
+
+        return $builder->getQuery();
+    }
+
     public function findLatestPostForThread(Thread $thread): ?Post
     {
         $builder = $this->createQueryBuilder('p');

--- a/src/Twig/Extension/ForumSearchTwigExtension.php
+++ b/src/Twig/Extension/ForumSearchTwigExtension.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Twig\Extension;
+
+use App\Criticalmass\Forum\SearchSnippet;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class ForumSearchTwigExtension extends AbstractExtension
+{
+    public function __construct(private readonly SearchSnippet $searchSnippet)
+    {
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            // is_safe, weil SearchSnippet den Text selbst maskiert und nur die
+            // Markierungen als HTML einfügt.
+            new TwigFilter('search_snippet', [$this, 'snippet'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function snippet(?string $text, string $term): string
+    {
+        return $this->searchSnippet->build($text, $term);
+    }
+}

--- a/templates/Board/overview.html.twig
+++ b/templates/Board/overview.html.twig
@@ -16,6 +16,17 @@
             </h1>
         </div>
 
+        <form method="get" action="{{ path('caldera_criticalmass_board_search') }}" class="mb-4">
+            <div class="input-group">
+                <input type="search" name="q" class="form-control"
+                       placeholder="Themen und Beitr&auml;ge durchsuchen" aria-label="Suchbegriff">
+                <button type="submit" class="btn btn-outline-secondary">
+                    <i class="far fa-search"></i>
+                    <span class="visually-hidden">Suchen</span>
+                </button>
+            </div>
+        </form>
+
         <h4 class="mb-3">
             <i class="far fa-globe text-muted me-2"></i>
             Allgemeines

--- a/templates/Board/search_results.html.twig
+++ b/templates/Board/search_results.html.twig
@@ -1,0 +1,67 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}{{ term ? 'Suche nach ' ~ term : 'Forum durchsuchen' }}{% endblock %}
+
+{% block breadcrumb %}
+    {{ breadcrumb.item('Diskussionen', path('caldera_criticalmass_board_overview')) }}
+    {{ breadcrumb.active('Suche') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1 class="h3 mb-4">
+            <i class="far fa-search text-muted me-2"></i>
+            Forum durchsuchen
+        </h1>
+
+        <form method="get" action="{{ path('caldera_criticalmass_board_search') }}" class="mb-4">
+            <div class="input-group">
+                <input type="search" name="q" class="form-control" value="{{ term }}"
+                       placeholder="Wonach suchst du?" aria-label="Suchbegriff" autofocus>
+                <button type="submit" class="btn btn-primary">
+                    <i class="far fa-search me-1"></i>Suchen
+                </button>
+            </div>
+        </form>
+
+        {% if term is empty %}
+            <p class="text-muted">Gib einen Begriff ein, um Themen und Beitr&auml;ge zu durchsuchen.</p>
+        {% elseif results is null %}
+            <div class="alert alert-secondary" role="status">
+                Bitte gib mindestens {{ minimumLength }} Zeichen ein.
+            </div>
+        {% elseif results|length == 0 %}
+            <div class="text-center py-5">
+                <i class="far fa-search fa-3x text-muted mb-3"></i>
+                <h5 class="text-muted">Nichts gefunden</h5>
+                <p class="text-muted mb-0">Zu &bdquo;{{ term }}&ldquo; gibt es keine Beitr&auml;ge.</p>
+            </div>
+        {% else %}
+            <p class="text-muted">
+                {{ results.getTotalItemCount }} Treffer f&uuml;r &bdquo;{{ term }}&ldquo;
+            </p>
+
+            {% for post in results %}
+                <div class="card border-0 shadow-sm mb-3">
+                    <div class="card-body">
+                        <a href="{{ object_path(post.thread) }}#post-{{ post.id }}" class="text-decoration-none">
+                            <strong>{{ post.thread.title }}</strong>
+                        </a>
+                        <p class="mb-2 mt-2">{{ post.message|search_snippet(term) }}</p>
+                        <small class="text-muted">
+                            von {{ post.user ? post.user.username : 'unbekannt' }}
+                            <i class="far fa-clock ms-2 me-1"></i>{{ post.dateTime|date('d.m.Y, H:i', 'Europe/Berlin') }}
+                        </small>
+                    </div>
+                </div>
+            {% endfor %}
+
+            {% if results.pageCount > 1 %}
+                <nav class="d-flex justify-content-center mt-4" aria-label="Seiten">
+                    {{ knp_pagination_render(results) }}
+                </nav>
+            {% endif %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/tests/Controller/ForumSearchControllerTest.php
+++ b/tests/Controller/ForumSearchControllerTest.php
@@ -87,7 +87,13 @@ class ForumSearchControllerTest extends AbstractControllerTestCase
         $this->loginAs($client, self::AUTHOR);
 
         $slug = $this->openThread($client, 'Thema mit Rueckzug', 'Der erste Beitrag.');
-        $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Stichwort Rueckzugswort hier.']]);
+
+        // Ueber das echte Formular, sonst scheitert der Beitrag an der CSRF-Pruefung
+        // und der Test bestuende, ohne je etwas zurueckgezogen zu haben.
+        $crawler = $client->request('GET', '/post/write/thread/' . $slug);
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['post[message]'] = 'Stichwort Rueckzugswort hier.';
+        $client->submit($form);
 
         $doctrine = static::getContainer()->get('doctrine');
         $doctrine->getManager()->clear();

--- a/tests/Controller/ForumSearchControllerTest.php
+++ b/tests/Controller/ForumSearchControllerTest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Thread;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+class ForumSearchControllerTest extends AbstractControllerTestCase
+{
+    private const AUTHOR = 'testuser@criticalmass.in';
+
+    private function openThread(KernelBrowser $client, string $title, string $message): string
+    {
+        $crawler = $client->request('GET', '/boards/general/addthread');
+
+        $form = $crawler->selectButton('Speichern')->form();
+        $form['form[title]'] = $title;
+        $form['form[message]'] = $message;
+
+        $client->submit($form);
+
+        $thread = static::getContainer()->get('doctrine')->getRepository(Thread::class)
+            ->findOneBy(['title' => $title]);
+
+        self::assertNotNull($thread);
+
+        return (string) $thread->getSlug();
+    }
+
+    public function testSearchPageIsPublic(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/boards/search');
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+    }
+
+    public function testShortTermsAreRejectedWithAHint(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/boards/search', ['q' => 'ab']);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString('mindestens', $crawler->filter('body')->text());
+    }
+
+    public function testFindsAPostByItsText(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $this->openThread($client, 'Suchbares Thema', 'Hier steht das Wort Klingelbeutel im Text.');
+
+        $crawler = $client->request('GET', '/boards/search', ['q' => 'Klingelbeutel']);
+
+        self::assertEquals(200, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString('Suchbares Thema', $crawler->filter('body')->text());
+        self::assertGreaterThan(0, $crawler->filter('mark')->count(), 'Der Treffer wird hervorgehoben.');
+    }
+
+    public function testFindsAThreadByItsTitle(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $this->openThread($client, 'Regenbogenforelle als Titel', 'Der Text sagt nichts dazu.');
+
+        $crawler = $client->request('GET', '/boards/search', ['q' => 'Regenbogenforelle']);
+
+        self::assertStringContainsString('Regenbogenforelle', $crawler->filter('body')->text());
+    }
+
+    public function testSaysSoWhenNothingMatches(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/boards/search', ['q' => 'Quastenflosserfahrrad']);
+
+        self::assertStringContainsString('Nichts gefunden', $crawler->filter('body')->text());
+    }
+
+    public function testWithdrawnPostsDoNotShowUp(): void
+    {
+        $client = static::createClient();
+        $this->loginAs($client, self::AUTHOR);
+
+        $slug = $this->openThread($client, 'Thema mit Rueckzug', 'Der erste Beitrag.');
+        $client->request('POST', '/post/write/thread/' . $slug, ['post' => ['message' => 'Stichwort Rueckzugswort hier.']]);
+
+        $doctrine = static::getContainer()->get('doctrine');
+        $doctrine->getManager()->clear();
+        $reply = $doctrine->getRepository(Thread::class)->findOneBy(['slug' => $slug])->getLastPost();
+
+        $client->request('POST', '/post/disable/' . $reply->getId());
+
+        $crawler = $client->request('GET', '/boards/search', ['q' => 'Rueckzugswort']);
+
+        self::assertStringContainsString('Nichts gefunden', $crawler->filter('body')->text());
+    }
+
+    public function testOverviewLinksToTheSearch(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/boards/overview');
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('form[action="/boards/search"]')->count(),
+            'Die Übersicht bietet die Suche an.'
+        );
+    }
+}

--- a/tests/Criticalmass/Forum/SearchSnippetTest.php
+++ b/tests/Criticalmass/Forum/SearchSnippetTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Forum;
+
+use App\Criticalmass\Forum\SearchSnippet;
+use PHPUnit\Framework\TestCase;
+
+class SearchSnippetTest extends TestCase
+{
+    private SearchSnippet $snippet;
+
+    protected function setUp(): void
+    {
+        $this->snippet = new SearchSnippet();
+    }
+
+    public function testMarksTheSearchTerm(): void
+    {
+        $result = $this->snippet->build('Wir treffen uns am Rathaus.', 'Rathaus');
+
+        self::assertStringContainsString('<mark>Rathaus</mark>', $result);
+    }
+
+    public function testMarkingIgnoresCase(): void
+    {
+        $result = $this->snippet->build('Das RATHAUS ist der Treffpunkt.', 'rathaus');
+
+        self::assertStringContainsString('<mark>RATHAUS</mark>', $result, 'Die Schreibweise des Fundes bleibt erhalten.');
+    }
+
+    public function testEscapesTheTextBeforeMarking(): void
+    {
+        $result = $this->snippet->build('<script>alert(1)</script> Rathaus', 'Rathaus');
+
+        self::assertStringNotContainsString('<script>', $result);
+        self::assertStringContainsString('&lt;script&gt;', $result);
+        self::assertStringContainsString('<mark>Rathaus</mark>', $result);
+    }
+
+    public function testATermWithMarkupCannotInjectHtml(): void
+    {
+        $result = $this->snippet->build('Ein ganz normaler Beitrag.', '<b>');
+
+        self::assertStringNotContainsString('<b>', $result);
+    }
+
+    public function testCutsLongTextAroundTheHit(): void
+    {
+        $text = str_repeat('Fülltext ', 200) . 'Nadel' . str_repeat(' Fülltext', 200);
+
+        $result = $this->snippet->build($text, 'Nadel');
+
+        self::assertStringContainsString('<mark>Nadel</mark>', $result);
+        self::assertLessThan(mb_strlen($text), mb_strlen($result));
+        self::assertStringStartsWith('…', $result, 'Ein abgeschnittener Anfang wird kenntlich gemacht.');
+    }
+
+    public function testShortTextStaysWhole(): void
+    {
+        $result = $this->snippet->build('Kurzer Beitrag mit Nadel.', 'Nadel');
+
+        self::assertStringStartsWith('Kurzer', $result);
+    }
+
+    public function testCollapsesWhitespace(): void
+    {
+        $result = $this->snippet->build("Zeile eins\n\n   Zeile zwei", 'Zeile');
+
+        self::assertStringNotContainsString("\n", $result);
+    }
+
+    public function testEmptyTextGivesEmptySnippet(): void
+    {
+        self::assertSame('', $this->snippet->build(null, 'egal'));
+        self::assertSame('', $this->snippet->build('   ', 'egal'));
+    }
+
+    public function testTextWithoutTheTermIsStillReturned(): void
+    {
+        $result = $this->snippet->build('Hier steht etwas anderes.', 'Nadel');
+
+        self::assertStringContainsString('etwas anderes', $result);
+        self::assertStringNotContainsString('<mark>', $result);
+    }
+}


### PR DESCRIPTION
## Summary

Sechster Teil, gestapelt auf #1489. Das Forum ließ sich bisher nur durchblättern.

- **`/boards/search?q=…`** findet Beiträge über ihren Text **und** über den Titel ihres Themas, verlinkt direkt auf den gefundenen Beitrag (`#post-N`)
- Suchformular in der Board-Übersicht und auf der Ergebnisseite
- **`SearchSnippet`** schneidet den Ausschnitt rund um den Treffer heraus (±120 Zeichen) und hebt ihn hervor
- Paginierte Ergebnisse, Mindestlänge 3 Zeichen mit Hinweis statt leerer Seite
- Zurückgezogene Beiträge und Themen tauchen nicht auf

## Warum die Reihenfolge beim Hervorheben zählt

`SearchSnippet` maskiert **zuerst** und markiert **danach**. Andersherum käme der Beitragstext als HTML in die Seite — bei nutzergeschriebenem Text ist das eine Lücke. Auch der Suchbegriff wird maskiert, bevor er zum Muster wird, damit er auf die maskierte Fassung passt und selbst kein Markup einschleusen kann. Neun Unit-Tests decken genau das ab, inklusive `<script>` im Beitrag und `<b>` als Suchbegriff.

## Bewusste Einschränkung

`LIKE '%term%'` statt Volltextindex — dasselbe Verfahren wie die vorhandene Seitensuche (`CityRepository::searchByQuery`). Für die Größenordnung dieses Forums reicht das. Ein `FULLTEXT`-Index auf `post.message` und `thread.title` wäre der nächste Schritt, braucht aber eine eigene DQL-Funktion für `MATCH … AGAINST` — das gehört in einen eigenen PR, wenn die Beitragszahl es nötig macht.

Filter nach Board, Zeitraum und Autor sind im Issue als „optional" markiert und hier nicht enthalten.

## Test Plan

- [x] `vendor/bin/phpunit tests/Criticalmass/Forum/` — 17 Tests grün, davon 9 für die Ausschnitt- und Maskierungslogik
- [x] `vendor/bin/phpstan analyse` (gesamtes Projekt) — keine Fehler
- [ ] `tests/Controller/ForumSearchControllerTest.php` — 7 funktionale Tests in CI

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR