### PR TITLE
Forum: Abonnements und Benachrichtigungen

### DIFF
--- a/assets/controllers/auto_submit_controller.js
+++ b/assets/controllers/auto_submit_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Schickt das Formular ab, sobald sich ein Feld ändert — für Schalter, bei denen ein
+ * eigener Speichern-Knopf nur im Weg steht.
+ *
+ * Ohne Javascript bleibt der Knopf im noscript-Block der einzige Weg; deshalb wird er
+ * hier ausgeblendet statt im Markup zu fehlen.
+ */
+export default class extends Controller {
+    submit() {
+        this.element.requestSubmit();
+    }
+}

--- a/migrations/Version20260902090000.php
+++ b/migrations/Version20260902090000.php
@@ -20,11 +20,11 @@ final class Version20260902090000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE forum_subscription (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, thread_id INT DEFAULT NULL, board_id INT DEFAULT NULL, city_id INT DEFAULT NULL, global_scope TINYINT(1) DEFAULT 0 NOT NULL, createdAt DATETIME NOT NULL, INDEX forum_subscription_user_index (user_id), INDEX IDX_FS_THREAD (thread_id), INDEX IDX_FS_BOARD (board_id), INDEX IDX_FS_CITY (city_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
-        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_USER FOREIGN KEY (user_id) REFERENCES user (id)');
-        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_THREAD FOREIGN KEY (thread_id) REFERENCES thread (id)');
-        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_BOARD FOREIGN KEY (board_id) REFERENCES board (id)');
-        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_CITY FOREIGN KEY (city_id) REFERENCES city (id)');
+        $this->addSql('CREATE TABLE forum_subscription (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, thread_id INT DEFAULT NULL, board_id INT DEFAULT NULL, city_id INT DEFAULT NULL, global_scope TINYINT(1) DEFAULT 0 NOT NULL, createdAt DATETIME NOT NULL, INDEX forum_subscription_user_index (user_id), INDEX IDX_9B189294E2904019 (thread_id), INDEX IDX_9B189294E7EC5785 (board_id), INDEX IDX_9B1892948BAC62AF (city_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_9B189294A76ED395 FOREIGN KEY (user_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_9B189294E2904019 FOREIGN KEY (thread_id) REFERENCES thread (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_9B189294E7EC5785 FOREIGN KEY (board_id) REFERENCES board (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_9B1892948BAC62AF FOREIGN KEY (city_id) REFERENCES city (id)');
         $this->addSql('ALTER TABLE user ADD forum_notifications TINYINT(1) DEFAULT 1 NOT NULL');
     }
 

--- a/migrations/Version20260902090000.php
+++ b/migrations/Version20260902090000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Forum subscriptions on four levels (thread, board, city, everything) plus the
+ * per-user master switch for notification mails.
+ */
+final class Version20260902090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create forum_subscription table and add user.forum_notifications';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE forum_subscription (id INT AUTO_INCREMENT NOT NULL, user_id INT NOT NULL, thread_id INT DEFAULT NULL, board_id INT DEFAULT NULL, city_id INT DEFAULT NULL, global_scope TINYINT(1) DEFAULT 0 NOT NULL, createdAt DATETIME NOT NULL, INDEX forum_subscription_user_index (user_id), INDEX IDX_FS_THREAD (thread_id), INDEX IDX_FS_BOARD (board_id), INDEX IDX_FS_CITY (city_id), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_USER FOREIGN KEY (user_id) REFERENCES user (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_THREAD FOREIGN KEY (thread_id) REFERENCES thread (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_BOARD FOREIGN KEY (board_id) REFERENCES board (id)');
+        $this->addSql('ALTER TABLE forum_subscription ADD CONSTRAINT FK_FS_CITY FOREIGN KEY (city_id) REFERENCES city (id)');
+        $this->addSql('ALTER TABLE user ADD forum_notifications TINYINT(1) DEFAULT 1 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE forum_subscription');
+        $this->addSql('ALTER TABLE user DROP forum_notifications');
+    }
+}

--- a/src/Controller/BoardController.php
+++ b/src/Controller/BoardController.php
@@ -10,6 +10,7 @@ use App\Repository\CityRepository;
 use App\Repository\PostRepository;
 use App\Repository\ThreadRepository;
 use App\Entity\City;
+use App\Entity\ForumSubscription;
 use App\Entity\Post;
 use App\Entity\Thread;
 use App\EntityInterface\BoardInterface;
@@ -87,9 +88,11 @@ class BoardController extends AbstractController
         if ($board) {
             $query = $threadRepository->queryThreadsForBoard($board);
             $newThreadUrl = $objectRouter->generate($board, 'caldera_criticalmass_board_addthread');
+            $subscribeUrl = $this->generateUrl('caldera_criticalmass_forum_subscribe_board', ['boardSlug' => $board->getSlug()]);
         } else {
             $query = $threadRepository->queryThreadsForCity($city);
             $newThreadUrl = $objectRouter->generate($city, 'caldera_criticalmass_board_addcitythread');
+            $subscribeUrl = $this->generateUrl('caldera_criticalmass_forum_subscribe_city', ['citySlug' => $city->getMainSlugString()]);
         }
 
         $threads = $paginator->paginate($query, $request->query->getInt('page', 1), self::THREADS_PER_PAGE);
@@ -98,6 +101,7 @@ class BoardController extends AbstractController
             'threads' => $threads,
             'board' => ($board ? $board : $city),
             'newThreadUrl' => $newThreadUrl,
+            'subscribeUrl' => $subscribeUrl,
         ]);
     }
 
@@ -374,6 +378,14 @@ class BoardController extends AbstractController
             $em->persist($thread);
             $em->persist($board);
 
+            $em->flush();
+
+            // Wer ein Thema eroeffnet, verfolgt es in aller Regel weiter.
+            $subscription = (new ForumSubscription())
+                ->setUser($post->getUser())
+                ->setThread($thread);
+
+            $em->persist($subscription);
             $em->flush();
 
             return $this->redirect($objectRouter->generate($thread));

--- a/src/Controller/ForumSubscriptionController.php
+++ b/src/Controller/ForumSubscriptionController.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\Board;
+use App\Entity\City;
+use App\Entity\ForumSubscription;
+use App\Entity\Thread;
+use App\Entity\User;
+use App\Repository\ForumSubscriptionRepository;
+use Symfony\Bridge\Doctrine\Attribute\MapEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_USER')]
+class ForumSubscriptionController extends AbstractController
+{
+    #[Route('/forum/subscribe/thread/{threadSlug}', name: 'caldera_criticalmass_forum_subscribe_thread', methods: ['POST'], priority: 240)]
+    public function threadAction(
+        ObjectRouterInterface $objectRouter,
+        ForumSubscriptionRepository $repository,
+        #[MapEntity(mapping: ['threadSlug' => 'slug'])] Thread $thread
+    ): Response {
+        $this->toggle($repository, $thread, null, null, false, 'dieses Thema');
+
+        return $this->redirect($objectRouter->generate($thread));
+    }
+
+    #[Route('/forum/subscribe/board/{boardSlug}', name: 'caldera_criticalmass_forum_subscribe_board', methods: ['POST'], priority: 240)]
+    public function boardAction(
+        ObjectRouterInterface $objectRouter,
+        ForumSubscriptionRepository $repository,
+        #[MapEntity(mapping: ['boardSlug' => 'slug'])] Board $board
+    ): Response {
+        $this->toggle($repository, null, $board, null, false, sprintf('das Forum „%s“', $board->getTitle()));
+
+        return $this->redirect($objectRouter->generate($board));
+    }
+
+    #[Route('/forum/subscribe/city/{citySlug}', name: 'caldera_criticalmass_forum_subscribe_city', methods: ['POST'], priority: 240)]
+    public function cityAction(
+        ObjectRouterInterface $objectRouter,
+        ForumSubscriptionRepository $repository,
+        City $city
+    ): Response {
+        $this->toggle($repository, null, null, $city, false, sprintf('das Forum von %s', $city->getTitle()));
+
+        return $this->redirect($objectRouter->generate($city, 'caldera_criticalmass_board_listcitythreads'));
+    }
+
+    #[Route('/forum/subscribe/global', name: 'caldera_criticalmass_forum_subscribe_global', methods: ['POST'], priority: 240)]
+    public function globalAction(ForumSubscriptionRepository $repository): Response
+    {
+        $this->toggle($repository, null, null, null, true, 'das gesamte Forum');
+
+        return $this->redirectToRoute('caldera_criticalmass_board_overview');
+    }
+
+    /**
+     * Übersicht der eigenen Abonnements samt Hauptschalter für die Mails.
+     */
+    #[Route('/forum/subscriptions', name: 'caldera_criticalmass_forum_subscriptions', priority: 240)]
+    public function listAction(Request $request, ForumSubscriptionRepository $repository): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($request->isMethod(Request::METHOD_POST)) {
+            $user->setForumNotifications($request->request->getBoolean('notifications'));
+
+            $this->managerRegistry->getManager()->flush();
+
+            $this->addFlash('success', $user->wantsForumNotifications()
+                ? 'Du bekommst wieder Benachrichtigungen aus dem Forum.'
+                : 'Du bekommst keine Benachrichtigungen mehr aus dem Forum.');
+
+            return $this->redirectToRoute('caldera_criticalmass_forum_subscriptions');
+        }
+
+        return $this->render('Forum/subscriptions.html.twig', [
+            'subscriptions' => $repository->findForUser($user),
+            'notificationsEnabled' => $user->wantsForumNotifications(),
+        ]);
+    }
+
+    #[Route('/forum/subscriptions/{id}/remove', name: 'caldera_criticalmass_forum_unsubscribe', methods: ['POST'], priority: 240)]
+    public function removeAction(ForumSubscription $subscription): Response
+    {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        if ($subscription->getUser() !== $user) {
+            throw $this->createAccessDeniedException('Das ist nicht dein Abonnement.');
+        }
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->remove($subscription);
+        $manager->flush();
+
+        $this->addFlash('success', 'Das Abonnement wurde beendet.');
+
+        return $this->redirectToRoute('caldera_criticalmass_forum_subscriptions');
+    }
+
+    /**
+     * Ein Klick schaltet an, der nächste wieder aus.
+     */
+    private function toggle(
+        ForumSubscriptionRepository $repository,
+        ?Thread $thread,
+        ?Board $board,
+        ?City $city,
+        bool $globalScope,
+        string $label
+    ): void {
+        /** @var User $user */
+        $user = $this->getUser();
+
+        $manager = $this->managerRegistry->getManager();
+        $existing = $repository->findExisting($user, $thread, $board, $city, $globalScope);
+
+        if (null !== $existing) {
+            $manager->remove($existing);
+            $manager->flush();
+
+            $this->addFlash('success', sprintf('Du bekommst keine Benachrichtigungen mehr über %s.', $label));
+
+            return;
+        }
+
+        $subscription = (new ForumSubscription())
+            ->setUser($user)
+            ->setThread($thread)
+            ->setBoard($board)
+            ->setCity($city)
+            ->setGlobalScope($globalScope);
+
+        $manager->persist($subscription);
+        $manager->flush();
+
+        $this->addFlash('success', sprintf('Du wirst über %s benachrichtigt.', $label));
+    }
+}

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -2,14 +2,18 @@
 
 namespace App\Controller;
 
+use App\Criticalmass\Forum\ForumNotifier;
 use App\Criticalmass\Forum\ForumStatistics;
 use App\Criticalmass\Router\ObjectRouterInterface;
 use App\Criticalmass\TextParser\TextParserInterface;
 use App\Entity\Photo;
 use App\EntityInterface\PostableInterface;
 use App\Criticalmass\Util\ClassUtil;
+use App\Repository\ForumSubscriptionRepository;
 use App\Repository\PostRepository;
+use Doctrine\Persistence\ManagerRegistry;
 use App\Entity\City;
+use App\Entity\ForumSubscription;
 use App\Entity\Post;
 use App\Entity\Ride;
 use App\Entity\Thread;
@@ -25,6 +29,38 @@ use Symfony\Bridge\Doctrine\Attribute\MapEntity;
 
 class PostController extends AbstractController
 {
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly ForumNotifier $forumNotifier,
+        private readonly ForumSubscriptionRepository $subscriptionRepository
+    ) {
+        parent::__construct($managerRegistry);
+    }
+
+    /**
+     * Legt ein Thema-Abo an, falls noch keines besteht.
+     */
+    protected function subscribeToThread(Thread $thread): void
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof User) {
+            return;
+        }
+
+        if (null !== $this->subscriptionRepository->findExisting($user, $thread, null, null, false)) {
+            return;
+        }
+
+        $subscription = (new ForumSubscription())
+            ->setUser($user)
+            ->setThread($thread);
+
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($subscription);
+        $manager->flush();
+    }
+
     #[IsGranted('ROLE_USER')]
     #[Route('/post/write/city/{id}', name: 'caldera_criticalmass_timeline_post_write_city', priority: 120)]
     public function writeCityAction(Request $request, City $city, ObjectRouterInterface $objectRouter): Response
@@ -110,6 +146,12 @@ class PostController extends AbstractController
             }
 
             $em->flush();
+
+            if ($postable instanceof Thread) {
+                // Wer antwortet, verfolgt das Thema in aller Regel weiter.
+                $this->subscribeToThread($postable);
+                $this->forumNotifier->notifyAboutPost($post);
+            }
 
             return $this->redirect($objectRouter->generate($postable));
         }

--- a/src/Criticalmass/Forum/ForumNotifier.php
+++ b/src/Criticalmass/Forum/ForumNotifier.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace App\Criticalmass\Forum;
+
+use App\Controller\BoardController;
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\Post;
+use App\Entity\User;
+use App\Notifier\ForumPostNotification;
+use App\Repository\ForumSubscriptionRepository;
+use App\Repository\PostRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Benachrichtigt die Abonnenten eines Themas über einen neuen Beitrag.
+ *
+ * Drei Regeln bestimmen, wer eine Mail bekommt:
+ * - Wer über mehrere Ebenen zugleich abonniert hat, bekommt trotzdem nur eine.
+ * - Wer den Beitrag selbst geschrieben hat, bekommt keine.
+ * - Wer den Hauptschalter im Konto ausgeschaltet hat, bekommt keine.
+ */
+class ForumNotifier
+{
+    public function __construct(
+        private readonly ForumSubscriptionRepository $subscriptionRepository,
+        private readonly PostRepository $postRepository,
+        private readonly NotifierInterface $notifier,
+        private readonly ObjectRouterInterface $objectRouter,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly LoggerInterface $logger,
+        #[Autowire('%notification.mail.sender_address%')] private readonly string $senderAddress
+    ) {
+    }
+
+    public function notifyAboutPost(Post $post): void
+    {
+        $thread = $post->getThread();
+
+        if (null === $thread) {
+            return;
+        }
+
+        $notification = new ForumPostNotification(
+            $post,
+            (string) $thread->getTitle(),
+            $this->postUrl($post),
+            $this->urlGenerator->generate('caldera_criticalmass_forum_subscriptions', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            $this->senderAddress
+        );
+
+        foreach ($this->recipients($post) as $user) {
+            try {
+                $this->notifier->send($notification, new Recipient((string) $user->getEmail()));
+            } catch (\Throwable $exception) {
+                // Eine unzustellbare Mail darf das Schreiben eines Beitrags nicht verhindern.
+                $this->logger->error('Forums-Benachrichtigung konnte nicht zugestellt werden', [
+                    'user' => $user->getId(),
+                    'post' => $post->getId(),
+                    'exception' => $exception,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @return list<User>
+     */
+    public function recipients(Post $post): array
+    {
+        $thread = $post->getThread();
+
+        if (null === $thread) {
+            return [];
+        }
+
+        $author = $post->getUser();
+        $recipients = [];
+
+        foreach ($this->subscriptionRepository->findSubscribersForThread($thread) as $user) {
+            if ($user === $author) {
+                continue;
+            }
+
+            if (!$user->wantsForumNotifications()) {
+                continue;
+            }
+
+            if (null === $user->getEmail()) {
+                continue;
+            }
+
+            $recipients[$user->getId()] = $user;
+        }
+
+        return array_values($recipients);
+    }
+
+    private function postUrl(Post $post): string
+    {
+        $thread = $post->getThread();
+        $url = $this->objectRouter->generate($thread, null, [], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $page = (int) ceil($this->postRepository->findPositionInThread($post) / BoardController::POSTS_PER_PAGE);
+
+        if ($page > 1) {
+            $url .= (str_contains($url, '?') ? '&' : '?') . 'page=' . $page;
+        }
+
+        return sprintf('%s#post-%d', $url, $post->getId());
+    }
+}

--- a/src/Entity/ForumSubscription.php
+++ b/src/Entity/ForumSubscription.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Ein Abonnement auf einer der vier Ebenen des Forums: ein einzelnes Thema, ein Forum,
+ * das Forum einer Stadt oder alles.
+ *
+ * Die vier Felder schliessen einander aus — genau eines ist gesetzt beziehungsweise
+ * globalScope ist wahr. Eine Datenbank-Bedingung kann das nicht erzwingen, weil MySQL
+ * NULL-Werte in einem eindeutigen Index nicht als gleich behandelt; die Eindeutigkeit
+ * sichert deshalb ForumSubscriptionRepository::findExisting().
+ */
+#[ORM\Table(name: 'forum_subscription')]
+#[ORM\Index(fields: ['user'], name: 'forum_subscription_user_index')]
+#[ORM\Entity(repositoryClass: 'App\Repository\ForumSubscriptionRepository')]
+class ForumSubscription
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    protected ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]
+    protected ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Thread::class)]
+    #[ORM\JoinColumn(name: 'thread_id', referencedColumnName: 'id', nullable: true)]
+    protected ?Thread $thread = null;
+
+    #[ORM\ManyToOne(targetEntity: Board::class)]
+    #[ORM\JoinColumn(name: 'board_id', referencedColumnName: 'id', nullable: true)]
+    protected ?Board $board = null;
+
+    #[ORM\ManyToOne(targetEntity: City::class)]
+    #[ORM\JoinColumn(name: 'city_id', referencedColumnName: 'id', nullable: true)]
+    protected ?City $city = null;
+
+    #[ORM\Column(name: 'global_scope', type: 'boolean', options: ['default' => false])]
+    protected bool $globalScope = false;
+
+    #[ORM\Column(type: 'datetime')]
+    protected \DateTime $createdAt;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): ForumSubscription
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getThread(): ?Thread
+    {
+        return $this->thread;
+    }
+
+    public function setThread(?Thread $thread): ForumSubscription
+    {
+        $this->thread = $thread;
+
+        return $this;
+    }
+
+    public function getBoard(): ?Board
+    {
+        return $this->board;
+    }
+
+    public function setBoard(?Board $board): ForumSubscription
+    {
+        $this->board = $board;
+
+        return $this;
+    }
+
+    public function getCity(): ?City
+    {
+        return $this->city;
+    }
+
+    public function setCity(?City $city): ForumSubscription
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function isGlobalScope(): bool
+    {
+        return $this->globalScope;
+    }
+
+    public function setGlobalScope(bool $globalScope): ForumSubscription
+    {
+        $this->globalScope = $globalScope;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTime $createdAt): ForumSubscription
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Woran hängt dieses Abonnement? Für die Anzeige in der Kontoverwaltung.
+     */
+    public function getLabel(): string
+    {
+        if ($this->globalScope) {
+            return 'Das gesamte Forum';
+        }
+
+        return $this->thread?->getTitle()
+            ?? $this->board?->getTitle()
+            ?? $this->city?->getTitle()
+            ?? 'Unbekannt';
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -121,6 +121,14 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
     #[Ignore]
     protected bool $ownProfilePhoto = false;
 
+    /**
+     * Der Hauptschalter für Forums-Benachrichtigungen. Steht er aus, bleiben die
+     * Abonnements bestehen, es geht nur keine Mail mehr raus.
+     */
+    #[ORM\Column(name: 'forum_notifications', type: 'boolean', options: ['default' => 1])]
+    #[Ignore]
+    protected bool $forumNotifications = true;
+
     #[ORM\OneToMany(targetEntity: 'App\Entity\SocialNetworkProfile', mappedBy: 'createdBy')]
     #[Ignore]
     private Collection $socialNetworkProfiles;
@@ -628,6 +636,18 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
     public function setLastLogin(?\DateTime $lastLogin = null): self
     {
         $this->lastLogin = $lastLogin;
+
+        return $this;
+    }
+
+    public function wantsForumNotifications(): bool
+    {
+        return $this->forumNotifications;
+    }
+
+    public function setForumNotifications(bool $forumNotifications): User
+    {
+        $this->forumNotifications = $forumNotifications;
 
         return $this;
     }

--- a/src/Notifier/ForumPostNotification.php
+++ b/src/Notifier/ForumPostNotification.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App\Notifier;
+
+use App\Entity\Post;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Notifier\Message\EmailMessage;
+use Symfony\Component\Notifier\Notification\EmailNotificationInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
+
+class ForumPostNotification extends Notification implements EmailNotificationInterface
+{
+    public function __construct(
+        private readonly Post $post,
+        private readonly string $threadTitle,
+        private readonly string $postUrl,
+        private readonly string $settingsUrl,
+        private readonly string $senderAddress = 'noreply@criticalmass.in'
+    ) {
+        parent::__construct(sprintf('Neuer Beitrag: %s', $threadTitle), ['email']);
+    }
+
+    public function asEmailMessage(EmailRecipientInterface $recipient, ?string $transport = null): ?EmailMessage
+    {
+        $email = (new TemplatedEmail())
+            ->from(new Address($this->senderAddress, 'criticalmass.in'))
+            ->to($recipient->getEmail())
+            ->subject($this->getSubject())
+            ->htmlTemplate('email/forum_post.html.twig')
+            ->context([
+                'threadTitle' => $this->threadTitle,
+                'authorName' => $this->post->getUser()?->getUsername() ?? 'Jemand',
+                'excerpt' => $this->excerpt(),
+                'postUrl' => $this->postUrl,
+                'settingsUrl' => $this->settingsUrl,
+            ]);
+
+        return new EmailMessage($email);
+    }
+
+    private function excerpt(): string
+    {
+        $text = trim(preg_replace('/\s+/', ' ', (string) $this->post->getMessage()) ?? '');
+
+        return mb_strlen($text) > 300 ? mb_substr($text, 0, 300) . ' …' : $text;
+    }
+}

--- a/src/Repository/ForumSubscriptionRepository.php
+++ b/src/Repository/ForumSubscriptionRepository.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Board;
+use App\Entity\City;
+use App\Entity\ForumSubscription;
+use App\Entity\Thread;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ForumSubscription>
+ */
+class ForumSubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ForumSubscription::class);
+    }
+
+    /**
+     * Hat dieser Nutzer genau diese Ebene schon abonniert? Ein eindeutiger Index kann
+     * das nicht leisten, weil MySQL NULL-Werte darin nicht als gleich behandelt.
+     */
+    public function findExisting(User $user, ?Thread $thread, ?Board $board, ?City $city, bool $globalScope): ?ForumSubscription
+    {
+        $builder = $this->createQueryBuilder('s');
+
+        $builder
+            ->where($builder->expr()->eq('s.user', ':user'))
+            ->setParameter('user', $user)
+            ->andWhere($builder->expr()->eq('s.globalScope', ':globalScope'))
+            ->setParameter('globalScope', $globalScope);
+
+        foreach (['thread' => $thread, 'board' => $board, 'city' => $city] as $field => $value) {
+            if (null === $value) {
+                $builder->andWhere($builder->expr()->isNull('s.' . $field));
+            } else {
+                $builder
+                    ->andWhere($builder->expr()->eq('s.' . $field, ':' . $field))
+                    ->setParameter($field, $value);
+            }
+        }
+
+        return $builder->getQuery()->setMaxResults(1)->getOneOrNullResult();
+    }
+
+    /**
+     * Alle Abonnements eines Nutzers, für die Übersicht in der Kontoverwaltung.
+     *
+     * @return list<ForumSubscription>
+     */
+    public function findForUser(User $user): array
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.user = :user')
+            ->setParameter('user', $user)
+            ->orderBy('s.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * Wer soll über einen neuen Beitrag in diesem Thema erfahren?
+     *
+     * Greift ein Nutzer über mehrere Ebenen zugleich — etwa Thema und ganzes Forum —,
+     * steht er trotzdem nur einmal in der Liste.
+     *
+     * @return list<User>
+     */
+    public function findSubscribersForThread(Thread $thread): array
+    {
+        $builder = $this->createQueryBuilder('s');
+
+        $conditions = [
+            $builder->expr()->eq('s.globalScope', ':globalScope'),
+            $builder->expr()->eq('s.thread', ':thread'),
+        ];
+
+        $builder
+            ->select('DISTINCT u')
+            ->innerJoin('s.user', 'u')
+            ->setParameter('globalScope', true)
+            ->setParameter('thread', $thread);
+
+        if (null !== $thread->getBoard()) {
+            $conditions[] = $builder->expr()->eq('s.board', ':board');
+            $builder->setParameter('board', $thread->getBoard());
+        }
+
+        if (null !== $thread->getCity()) {
+            $conditions[] = $builder->expr()->eq('s.city', ':city');
+            $builder->setParameter('city', $thread->getCity());
+        }
+
+        $builder->where($builder->expr()->orX(...$conditions));
+
+        return $builder->getQuery()->getResult();
+    }
+}

--- a/src/Repository/ForumSubscriptionRepository.php
+++ b/src/Repository/ForumSubscriptionRepository.php
@@ -8,6 +8,7 @@ use App\Entity\ForumSubscription;
 use App\Entity\Thread;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -72,7 +73,15 @@ class ForumSubscriptionRepository extends ServiceEntityRepository
      */
     public function findSubscribersForThread(Thread $thread): array
     {
-        $builder = $this->createQueryBuilder('s');
+        // Abgefragt wird von User aus, nicht vom Abonnement: Doctrine laesst kein
+        // "SELECT DISTINCT u" zu, wenn u nur ein Join-Alias ist -- die Auswahl muss
+        // mindestens einen Wurzel-Alias enthalten.
+        $builder = $this->getEntityManager()->createQueryBuilder();
+
+        $builder
+            ->select('DISTINCT u')
+            ->from(User::class, 'u')
+            ->innerJoin(ForumSubscription::class, 's', Join::WITH, 's.user = u');
 
         $conditions = [
             $builder->expr()->eq('s.globalScope', ':globalScope'),
@@ -80,8 +89,6 @@ class ForumSubscriptionRepository extends ServiceEntityRepository
         ];
 
         $builder
-            ->select('DISTINCT u')
-            ->innerJoin('s.user', 'u')
             ->setParameter('globalScope', true)
             ->setParameter('thread', $thread);
 

--- a/templates/Board/list_threads.html.twig
+++ b/templates/Board/list_threads.html.twig
@@ -26,6 +26,12 @@
                 {{ board.title }}
             </h1>
             {% if app.getUser() %}
+                <form method="post" action="{{ subscribeUrl }}" class="d-inline me-2">
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">
+                        <i class="far fa-bell me-1"></i>
+                        <span class="d-none d-sm-inline">Forum abonnieren</span>
+                    </button>
+                </form>
                 <a href="{{ newThreadUrl }}" class="btn btn-success btn-sm">
                     <i class="far fa-plus me-1"></i>
                     <span class="d-none d-sm-inline">Neues Thema</span>

--- a/templates/Board/overview.html.twig
+++ b/templates/Board/overview.html.twig
@@ -16,6 +16,19 @@
             </h1>
         </div>
 
+        {% if app.user %}
+            <div class="d-flex gap-2 mb-4">
+                <form method="post" action="{{ path('caldera_criticalmass_forum_subscribe_global') }}">
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">
+                        <i class="far fa-bell me-1"></i>Gesamtes Forum abonnieren
+                    </button>
+                </form>
+                <a href="{{ path('caldera_criticalmass_forum_subscriptions') }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="far fa-cog me-1"></i>Meine Abonnements
+                </a>
+            </div>
+        {% endif %}
+
         <form method="get" action="{{ path('caldera_criticalmass_board_search') }}" class="mb-4">
             <div class="input-group">
                 <input type="search" name="q" class="form-control"

--- a/templates/Board/view_thread.html.twig
+++ b/templates/Board/view_thread.html.twig
@@ -49,6 +49,14 @@
                         </button>
                     </form>
                 {% endif %}
+                {% if app.user %}
+                    <form method="post" action="{{ path('caldera_criticalmass_forum_subscribe_thread', { 'threadSlug': thread.slug }) }}">
+                        <button type="submit" class="btn btn-outline-secondary btn-sm">
+                            <i class="far fa-bell me-1"></i>
+                            <span class="d-none d-sm-inline">Abonnieren</span>
+                        </button>
+                    </form>
+                {% endif %}
                 {% if is_granted('move', thread) %}
                     <a href="{{ path('caldera_criticalmass_board_movethread', { 'threadSlug': thread.slug }) }}"
                        class="btn btn-outline-secondary btn-sm">

--- a/templates/Forum/subscriptions.html.twig
+++ b/templates/Forum/subscriptions.html.twig
@@ -1,0 +1,71 @@
+{% extends 'Template/StandardTemplate.html.twig' %}
+{% import 'Template/Macros/breadcrumb.html.twig' as breadcrumb %}
+
+{% block title %}Meine Forum-Abonnements{% endblock %}
+
+{% block breadcrumb %}
+    {{ breadcrumb.item('Diskussionen', path('caldera_criticalmass_board_overview')) }}
+    {{ breadcrumb.active('Abonnements') }}
+{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <h1 class="h3 mb-4">
+            <i class="far fa-bell text-muted me-2"></i>
+            Meine Abonnements
+        </h1>
+
+        <div class="card border-0 shadow-sm mb-4">
+            <div class="card-body">
+                <form method="post" action="{{ path('caldera_criticalmass_forum_subscriptions') }}">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch"
+                               id="forum-notifications" name="notifications" value="1"
+                               {{ notificationsEnabled ? 'checked' : '' }}
+                               onchange="this.form.submit()">
+                        <label class="form-check-label" for="forum-notifications">
+                            Benachrichtigungen per E-Mail
+                        </label>
+                    </div>
+                    <div class="form-text">
+                        Steht der Schalter aus, bleiben deine Abonnements bestehen &mdash; es geht nur keine Mail mehr raus.
+                    </div>
+                    <noscript>
+                        <button type="submit" class="btn btn-sm btn-primary mt-2">Speichern</button>
+                    </noscript>
+                </form>
+            </div>
+        </div>
+
+        {% if subscriptions is empty %}
+            <div class="text-center py-5">
+                <i class="far fa-bell-slash fa-3x text-muted mb-3"></i>
+                <h5 class="text-muted">Noch nichts abonniert</h5>
+                <p class="text-muted mb-0">
+                    Abonniere ein Thema oder ein ganzes Forum, um bei neuen Beitr&auml;gen Bescheid zu bekommen.
+                </p>
+            </div>
+        {% else %}
+            <div class="list-group shadow-sm">
+                {% for subscription in subscriptions %}
+                    <div class="list-group-item d-flex justify-content-between align-items-center">
+                        <div>
+                            <strong>{{ subscription.label }}</strong>
+                            <br/>
+                            <small class="text-muted">
+                                {% if subscription.globalScope %}Gesamtes Forum
+                                {% elseif subscription.thread %}Thema
+                                {% elseif subscription.board %}Forum
+                                {% else %}Stadtforum{% endif %}
+                                &middot; seit {{ subscription.createdAt|date('d.m.Y', 'Europe/Berlin') }}
+                            </small>
+                        </div>
+                        <form method="post" action="{{ path('caldera_criticalmass_forum_unsubscribe', { 'id': subscription.id }) }}">
+                            <button type="submit" class="btn btn-outline-secondary btn-sm">Beenden</button>
+                        </form>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/Forum/subscriptions.html.twig
+++ b/templates/Forum/subscriptions.html.twig
@@ -17,12 +17,13 @@
 
         <div class="card border-0 shadow-sm mb-4">
             <div class="card-body">
-                <form method="post" action="{{ path('caldera_criticalmass_forum_subscriptions') }}">
+                <form method="post" action="{{ path('caldera_criticalmass_forum_subscriptions') }}"
+                      data-controller="auto-submit">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" role="switch"
                                id="forum-notifications" name="notifications" value="1"
                                {{ notificationsEnabled ? 'checked' : '' }}
-                               onchange="this.form.submit()">
+                               data-action="change->auto-submit#submit">
                         <label class="form-check-label" for="forum-notifications">
                             Benachrichtigungen per E-Mail
                         </label>

--- a/templates/email/forum_post.html.twig
+++ b/templates/email/forum_post.html.twig
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Neuer Beitrag im Forum</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f6f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f4f6f9; padding: 24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 560px; background-color: #ffffff; border-radius: 8px;">
+                <tr>
+                    <td style="padding: 32px 32px 8px;">
+                        <p style="font-size: 20px; color: #1a1a2e; font-weight: 700; margin: 0 0 16px;">
+                            Neuer Beitrag in &bdquo;{{ threadTitle }}&ldquo;
+                        </p>
+                        <p style="font-size: 16px; color: #4a4a68; line-height: 1.6; margin: 0 0 16px;">
+                            <strong>{{ authorName }}</strong> hat geschrieben:
+                        </p>
+                        <blockquote style="margin: 0 0 24px; padding: 8px 0 8px 16px; border-left: 3px solid #e2e6ea; color: #4a4a68; font-size: 15px; line-height: 1.6;">
+                            {{ excerpt }}
+                        </blockquote>
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" style="padding: 0 32px 32px;">
+                        <table role="presentation" cellpadding="0" cellspacing="0">
+                            <tr>
+                                <td style="background-color: #2a9d8f; border-radius: 6px;">
+                                    <a href="{{ postUrl }}" style="display: inline-block; padding: 14px 36px; font-size: 16px; font-weight: 600; color: #ffffff; text-decoration: none;">Beitrag lesen</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 0 32px 32px; border-top: 1px solid #eef1f4;">
+                        <p style="font-size: 13px; color: #9a9ab0; line-height: 1.5; margin: 16px 0 0;">
+                            Du bekommst diese Mail, weil du dieses Thema oder sein Forum abonniert hast.
+                            <a href="{{ settingsUrl }}" style="color: #2a9d8f; text-decoration: none;">Hier verwaltest du deine Abonnements.</a>
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/tests/Criticalmass/Forum/ForumNotifierTest.php
+++ b/tests/Criticalmass/Forum/ForumNotifierTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Forum;
+
+use App\Criticalmass\Forum\ForumNotifier;
+use App\Criticalmass\Router\ObjectRouterInterface;
+use App\Entity\Post;
+use App\Entity\Thread;
+use App\Entity\User;
+use App\Repository\ForumSubscriptionRepository;
+use App\Repository\PostRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ForumNotifierTest extends TestCase
+{
+    private int $nextUserId = 1;
+
+    private function user(string $email, bool $wantsMails = true): User
+    {
+        $user = new User();
+        $user->setEmail($email)->setForumNotifications($wantsMails);
+
+        // Ohne Id greift die Entdopplung nicht — Doctrine vergibt sie sonst.
+        $reflection = new \ReflectionProperty(User::class, 'id');
+        $reflection->setValue($user, $this->nextUserId++);
+
+        return $user;
+    }
+
+    /**
+     * @param list<User> $subscribers
+     */
+    private function notifier(array $subscribers): ForumNotifier
+    {
+        $subscriptionRepository = $this->createMock(ForumSubscriptionRepository::class);
+        $subscriptionRepository->method('findSubscribersForThread')->willReturn($subscribers);
+
+        return new ForumNotifier(
+            $subscriptionRepository,
+            $this->createMock(PostRepository::class),
+            $this->createMock(NotifierInterface::class),
+            $this->createMock(ObjectRouterInterface::class),
+            $this->createMock(UrlGeneratorInterface::class),
+            new NullLogger(),
+            'noreply@criticalmass.in'
+        );
+    }
+
+    private function postIn(Thread $thread, ?User $author): Post
+    {
+        $post = new Post();
+        $post->setThread($thread);
+
+        if (null !== $author) {
+            $post->setUser($author);
+        }
+
+        return $post;
+    }
+
+    public function testSubscribersAreNotified(): void
+    {
+        $thread = new Thread();
+        $reader = $this->user('leser@example.org');
+
+        $recipients = $this->notifier([$reader])->recipients($this->postIn($thread, $this->user('autor@example.org')));
+
+        self::assertSame([$reader], $recipients);
+    }
+
+    public function testTheAuthorDoesNotGetAMailAboutTheirOwnPost(): void
+    {
+        $author = $this->user('autor@example.org');
+        $thread = new Thread();
+
+        $recipients = $this->notifier([$author])->recipients($this->postIn($thread, $author));
+
+        self::assertSame([], $recipients);
+    }
+
+    public function testEveryoneIsNotifiedOnlyOnce(): void
+    {
+        $reader = $this->user('leser@example.org');
+
+        // Dasselbe Konto ueber Thema und Forum zugleich abonniert.
+        $recipients = $this->notifier([$reader, $reader])
+            ->recipients($this->postIn(new Thread(), $this->user('autor@example.org')));
+
+        self::assertCount(1, $recipients);
+    }
+
+    public function testSwitchedOffNotificationsAreRespected(): void
+    {
+        $reader = $this->user('stillleser@example.org', false);
+
+        $recipients = $this->notifier([$reader])
+            ->recipients($this->postIn(new Thread(), $this->user('autor@example.org')));
+
+        self::assertSame([], $recipients, 'Der Hauptschalter im Konto schlaegt das Abonnement.');
+    }
+
+    public function testAccountsWithoutMailAddressAreSkipped(): void
+    {
+        $reader = new User();
+        $reader->setForumNotifications(true);
+
+        $recipients = $this->notifier([$reader])
+            ->recipients($this->postIn(new Thread(), $this->user('autor@example.org')));
+
+        self::assertSame([], $recipients);
+    }
+
+    public function testCommentsOutsideAThreadNotifyNobody(): void
+    {
+        $post = new Post();
+
+        // Kommentare an Touren, Staedten und Fotos gehoeren zu keinem Thema.
+        self::assertSame([], $this->notifier([$this->user('leser@example.org')])->recipients($post));
+    }
+}

--- a/tests/Repository/ForumSubscriptionRepositoryTest.php
+++ b/tests/Repository/ForumSubscriptionRepositoryTest.php
@@ -27,7 +27,10 @@ class ForumSubscriptionRepositoryTest extends KernelTestCase
         self::bootKernel();
 
         $this->entityManager = static::getContainer()->get('doctrine')->getManager();
-        $this->repository = $this->entityManager->getRepository(ForumSubscription::class);
+
+        $repository = static::getContainer()->get(ForumSubscriptionRepository::class);
+        self::assertInstanceOf(ForumSubscriptionRepository::class, $repository);
+        $this->repository = $repository;
 
         // Die Tests teilen sich eine Datenbank ohne Rollback; ohne diesen Schnitt
         // findet ein Test die Abos des vorherigen.

--- a/tests/Repository/ForumSubscriptionRepositoryTest.php
+++ b/tests/Repository/ForumSubscriptionRepositoryTest.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\Board;
+use App\Entity\ForumSubscription;
+use App\Entity\Thread;
+use App\Entity\User;
+use App\Repository\ForumSubscriptionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Führt die Abfragen wirklich aus, statt das Repository zu mocken.
+ *
+ * Der Grund steht in der Geschichte dieses Repositories: Ein „SELECT DISTINCT u“ mit
+ * u als blossem Join-Alias ist ungültiges DQL, und ein gemocktes Repository hat das
+ * anstandslos durchgehen lassen — bis jede Antwort im Forum mit einem 500er endete.
+ */
+class ForumSubscriptionRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private ForumSubscriptionRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->repository = $this->entityManager->getRepository(ForumSubscription::class);
+
+        // Die Tests teilen sich eine Datenbank ohne Rollback; ohne diesen Schnitt
+        // findet ein Test die Abos des vorherigen.
+        $this->entityManager->createQuery('DELETE FROM ' . ForumSubscription::class . ' s')->execute();
+    }
+
+    private function user(string $email): User
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+
+    private function thread(): Thread
+    {
+        $board = $this->entityManager->getRepository(Board::class)->findOneBy(['slug' => 'general']);
+        self::assertInstanceOf(Board::class, $board);
+
+        $thread = new Thread();
+        $thread->setBoard($board)->setTitle('Abo-Testthema')->setSlug('abo-testthema-' . uniqid());
+
+        $this->entityManager->persist($thread);
+        $this->entityManager->flush();
+
+        return $thread;
+    }
+
+    private function subscribe(User $user, ?Thread $thread, ?Board $board, bool $globalScope): void
+    {
+        $subscription = (new ForumSubscription())
+            ->setUser($user)
+            ->setThread($thread)
+            ->setBoard($board)
+            ->setGlobalScope($globalScope);
+
+        $this->entityManager->persist($subscription);
+        $this->entityManager->flush();
+    }
+
+    public function testThreadSubscriberIsFound(): void
+    {
+        $thread = $this->thread();
+        $user = $this->user('testuser@criticalmass.in');
+
+        $this->subscribe($user, $thread, null, false);
+
+        self::assertContains($user, $this->repository->findSubscribersForThread($thread));
+    }
+
+    public function testBoardSubscriberIsFoundForAThreadInThatBoard(): void
+    {
+        $thread = $this->thread();
+        $user = $this->user('cyclist@criticalmass.in');
+
+        $this->subscribe($user, null, $thread->getBoard(), false);
+
+        self::assertContains($user, $this->repository->findSubscribersForThread($thread));
+    }
+
+    public function testGlobalSubscriberIsFoundEverywhere(): void
+    {
+        $thread = $this->thread();
+        $user = $this->user('admin@criticalmass.in');
+
+        $this->subscribe($user, null, null, true);
+
+        self::assertContains($user, $this->repository->findSubscribersForThread($thread));
+    }
+
+    public function testSomeoneSubscribedTwiceAppearsOnce(): void
+    {
+        $thread = $this->thread();
+        $user = $this->user('testuser@criticalmass.in');
+
+        $this->subscribe($user, $thread, null, false);
+        $this->subscribe($user, null, $thread->getBoard(), false);
+
+        $subscribers = $this->repository->findSubscribersForThread($thread);
+        $matches = array_filter($subscribers, static fn (User $candidate): bool => $candidate === $user);
+
+        self::assertCount(1, $matches, 'Mehrere Abonnements derselben Person ergeben einen Empfänger.');
+    }
+
+    public function testUnrelatedSubscriptionsStayOut(): void
+    {
+        $thread = $this->thread();
+        $other = $this->thread();
+        $user = $this->user('photodownloader@criticalmass.in');
+
+        $this->subscribe($user, $other, null, false);
+
+        self::assertNotContains($user, $this->repository->findSubscribersForThread($thread));
+    }
+
+    public function testFindExistingDistinguishesTheLevels(): void
+    {
+        $thread = $this->thread();
+        $user = $this->user('cyclist@criticalmass.in');
+
+        $this->subscribe($user, $thread, null, false);
+
+        self::assertNotNull($this->repository->findExisting($user, $thread, null, null, false));
+        self::assertNull(
+            $this->repository->findExisting($user, null, $thread->getBoard(), null, false),
+            'Ein Thema-Abo ist kein Forum-Abo.'
+        );
+        self::assertNull($this->repository->findExisting($user, null, null, null, true));
+    }
+}


### PR DESCRIPTION
## Summary

Siebter Teil, gestapelt auf #1490. Der größte Brocken der Reihe.

- **`ForumSubscription`** auf vier Ebenen: einzelnes Thema, ein Forum, das Forum einer Stadt, das gesamte Forum. Plus Migration.
- **`ForumNotifier`** sammelt die Empfänger und verschickt über den vorhandenen Notifier (wie der Login-Link)
- **Automatische Abos**: Wer ein Thema eröffnet oder darauf antwortet, abonniert es mit
- **Abo-Knöpfe** in Thread-Ansicht, Thread-Liste und Board-Übersicht
- **`/forum/subscriptions`** — Übersicht der eigenen Abos mit Hauptschalter für die Mails
- E-Mail-Vorlage mit Auszug, Verweis auf den Beitrag und Abbestell-Link

## Drei Regeln beim Versand

1. Wer über mehrere Ebenen zugleich abonniert hat, bekommt trotzdem **nur eine** Mail (Entdopplung über die User-Id).
2. Wer den Beitrag selbst geschrieben hat, bekommt keine.
3. Der Hauptschalter im Konto schlägt jedes Abonnement — er lässt die Abos bestehen und stoppt nur die Mails.

Sechs Unit-Tests decken genau diese Regeln ab.

## Warum die Eindeutigkeit im Code sitzt

Das Issue verlangt einen Unique-Constraint. MySQL behandelt `NULL`-Werte in einem eindeutigen Index aber **nicht als gleich** — bei vier nullbaren Spalten könnte ein solcher Index doppelte Abos gar nicht verhindern. Deshalb übernimmt das `ForumSubscriptionRepository::findExisting()`, und die Entity dokumentiert es.

## Robustheit

Ein Zustellfehler darf das Schreiben eines Beitrags nicht scheitern lassen — der Versand fängt `Throwable` ab und protokolliert. Sonst kostet ein hakeliger Mailserver den Nutzer seinen Text.

## Nicht enthalten

Der im Issue als „optional" markierte Digest-Modus (tägliche/wöchentliche Zusammenfassung). Der braucht einen Cron-Lauf und eine eigene Zustands-Tabelle — eigener PR, wenn gewünscht. Die Endpunkte sind Umschalter statt getrennter POST/DELETE-Paare; ein Klick abonniert, der nächste beendet.

## Test Plan

- [x] `vendor/bin/phpunit tests/Security/ tests/Criticalmass/Forum/` — 41 Tests grün
- [x] `vendor/bin/phpstan analyse` (gesamtes Projekt) — keine Fehler
- [ ] Manuell: Thema abonnieren, aus zweitem Konto antworten, Mail prüfen (Mailcatcher auf Port 1080)
- [ ] Manuell: Hauptschalter aus → keine Mail mehr, Abo bleibt bestehen

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR