### PR TITLE
Replace the DBAL 3 calls the UTC types still made

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2335,42 +2335,6 @@ parameters:
 			path: src/Criticalmass/Util/ClassUtil.php
 
 		-
-			message: '#^Call to an undefined method App\\DBAL\\Type\\UTCDateTimeType\:\:getName\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/DBAL/Type/UTCDateTimeType.php
-
-		-
-			message: '#^Call to an undefined static method Doctrine\\DBAL\\Types\\ConversionException\:\:conversionFailedFormat\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: src/DBAL/Type/UTCDateTimeType.php
-
-		-
-			message: '#^Call to an undefined method App\\DBAL\\Type\\UTCDateType\:\:getName\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/DBAL/Type/UTCDateType.php
-
-		-
-			message: '#^Call to an undefined static method Doctrine\\DBAL\\Types\\ConversionException\:\:conversionFailedFormat\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: src/DBAL/Type/UTCDateType.php
-
-		-
-			message: '#^Call to an undefined method App\\DBAL\\Type\\UTCTimeType\:\:getName\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/DBAL/Type/UTCTimeType.php
-
-		-
-			message: '#^Call to an undefined static method Doctrine\\DBAL\\Types\\ConversionException\:\:conversionFailedFormat\(\)\.$#'
-			identifier: staticMethod.notFound
-			count: 1
-			path: src/DBAL/Type/UTCTimeType.php
-
-		-
 			message: '#^Call to an undefined method App\\EntityInterface\\BoardInterface\:\:setLatitude\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/DBAL/Type/UTCDateTimeType.php
+++ b/src/DBAL/Type/UTCDateTimeType.php
@@ -3,9 +3,17 @@
 namespace App\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
+/**
+ * Speichert Zeitstempel grundsaetzlich in UTC und liest sie auch so zurueck.
+ *
+ * Bis auf die Zeitzone verhaelt sich der Typ wie {@see DateTimeType} — inklusive
+ * der Rueckfallebene fuer Werte, die nicht auf das Format der Plattform passen.
+ * PostgreSQL etwa liefert Zeitstempel mit Sekundenbruchteilen, an denen ein
+ * strenges createFromFormat('Y-m-d H:i:s') scheitert.
+ */
 class UTCDateTimeType extends DateTimeType
 {
     private static ?\DateTimeZone $utc = null;
@@ -33,20 +41,18 @@ class UTCDateTimeType extends DateTimeType
             return $value;
         }
 
-        $converted = \DateTime::createFromFormat(
-            $platform->getDateTimeFormatString(),
-            $value,
-            self::getUtc()
-        );
+        $format = $platform->getDateTimeFormatString();
 
-        if (!$converted) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getDateTimeFormatString()
-            );
+        $converted = \DateTime::createFromFormat($format, $value, self::getUtc());
+
+        if (false !== $converted) {
+            return $converted;
         }
 
-        return $converted;
+        try {
+            return new \DateTime($value, self::getUtc());
+        } catch (\Exception $exception) {
+            throw InvalidFormat::new($value, static::class, $format, $exception);
+        }
     }
 }

--- a/src/DBAL/Type/UTCDateType.php
+++ b/src/DBAL/Type/UTCDateType.php
@@ -3,9 +3,17 @@
 namespace App\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 
+/**
+ * Speichert Datumswerte grundsaetzlich in UTC und liest sie auch so zurueck.
+ *
+ * Das Ausrufezeichen vor dem Format ist wesentlich: ohne es uebernimmt
+ * createFromFormat fuer die nicht im Format genannten Felder die aktuelle
+ * Uhrzeit, ein gelesenes Datum traegt dann die Tageszeit des Lesezeitpunkts
+ * statt Mitternacht. {@see DateType} macht es genauso.
+ */
 class UTCDateType extends DateType
 {
     private static ?\DateTimeZone $utc = null;
@@ -33,20 +41,14 @@ class UTCDateType extends DateType
             return $value;
         }
 
-        $converted = \DateTime::createFromFormat(
-            $platform->getDateFormatString(),
-            $value,
-            self::getUtc()
-        );
+        $format = $platform->getDateFormatString();
 
-        if (!$converted) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getDateFormatString()
-            );
+        $converted = \DateTime::createFromFormat('!' . $format, $value, self::getUtc());
+
+        if (false !== $converted) {
+            return $converted;
         }
 
-        return $converted;
+        throw InvalidFormat::new($value, static::class, $format);
     }
 }

--- a/src/DBAL/Type/UTCTimeType.php
+++ b/src/DBAL/Type/UTCTimeType.php
@@ -3,9 +3,14 @@
 namespace App\DBAL\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
 use Doctrine\DBAL\Types\TimeType;
 
+/**
+ * Speichert Uhrzeiten grundsaetzlich in UTC und liest sie auch so zurueck.
+ *
+ * Verhaelt sich ansonsten wie {@see TimeType}.
+ */
 class UTCTimeType extends TimeType
 {
     private static ?\DateTimeZone $utc = null;
@@ -33,20 +38,14 @@ class UTCTimeType extends TimeType
             return $value;
         }
 
-        $converted = \DateTime::createFromFormat(
-            '!' . $platform->getTimeFormatString(),
-            $value,
-            self::getUtc()
-        );
+        $format = $platform->getTimeFormatString();
 
-        if (!$converted) {
-            throw ConversionException::conversionFailedFormat(
-                $value,
-                $this->getName(),
-                $platform->getTimeFormatString()
-            );
+        $converted = \DateTime::createFromFormat('!' . $format, $value, self::getUtc());
+
+        if (false !== $converted) {
+            return $converted;
         }
 
-        return $converted;
+        throw InvalidFormat::new($value, static::class, $format);
     }
 }

--- a/tests/DBAL/Type/UTCTypesTest.php
+++ b/tests/DBAL/Type/UTCTypesTest.php
@@ -1,0 +1,159 @@
+<?php declare(strict_types=1);
+
+namespace Tests\DBAL\Type;
+
+use App\DBAL\Type\UTCDateTimeType;
+use App\DBAL\Type\UTCDateType;
+use App\DBAL\Type\UTCTimeType;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Diese drei Typen liegen auf dem Lesepfad jeder Entity mit Zeitangabe. Getestet
+ * wurden sie bis dahin nie — und enthielten mit getName() und
+ * ConversionException::conversionFailedFormat() zwei Aufrufe, die es in DBAL 4
+ * nicht mehr gibt.
+ */
+class UTCTypesTest extends TestCase
+{
+    private AbstractPlatform $mariaDb;
+    private AbstractPlatform $postgres;
+
+    protected function setUp(): void
+    {
+        $this->mariaDb = new MariaDBPlatform();
+        $this->postgres = new PostgreSQLPlatform();
+    }
+
+    private function type(string $name, string $class): Type
+    {
+        if (!Type::hasType($name)) {
+            Type::addType($name, $class);
+        }
+
+        return Type::getType($name);
+    }
+
+    private function dateTimeType(): UTCDateTimeType
+    {
+        $type = $this->type('test_utc_datetime', UTCDateTimeType::class);
+        self::assertInstanceOf(UTCDateTimeType::class, $type);
+
+        return $type;
+    }
+
+    private function dateType(): UTCDateType
+    {
+        $type = $this->type('test_utc_date', UTCDateType::class);
+        self::assertInstanceOf(UTCDateType::class, $type);
+
+        return $type;
+    }
+
+    private function timeType(): UTCTimeType
+    {
+        $type = $this->type('test_utc_time', UTCTimeType::class);
+        self::assertInstanceOf(UTCTimeType::class, $type);
+
+        return $type;
+    }
+
+    public function testDatabaseValueIsReadAsUtc(): void
+    {
+        $value = $this->dateTimeType()->convertToPHPValue('2026-09-04 17:30:00', $this->mariaDb);
+
+        self::assertInstanceOf(\DateTime::class, $value);
+        self::assertSame('UTC', $value->getTimezone()->getName());
+        self::assertSame('2026-09-04 17:30:00', $value->format('Y-m-d H:i:s'));
+    }
+
+    public function testLocalTimeIsWrittenBackAsUtc(): void
+    {
+        $berlin = new \DateTime('2026-09-04 19:30:00', new \DateTimeZone('Europe/Berlin'));
+
+        self::assertSame(
+            '2026-09-04 17:30:00',
+            $this->dateTimeType()->convertToDatabaseValue($berlin, $this->mariaDb)
+        );
+    }
+
+    /**
+     * PostgreSQL haengt an Zeitstempel Sekundenbruchteile, auf die das
+     * Plattformformat 'Y-m-d H:i:s' nicht passt. Ohne Rueckfallebene scheitert
+     * hier jeder Lesevorgang — genau das waere beim Plattformwechsel passiert.
+     */
+    public function testTimestampWithMicrosecondsIsAccepted(): void
+    {
+        $value = $this->dateTimeType()->convertToPHPValue('2026-09-04 17:30:00.323502', $this->postgres);
+
+        self::assertInstanceOf(\DateTime::class, $value);
+        self::assertSame('UTC', $value->getTimezone()->getName());
+        self::assertSame('2026-09-04 17:30:00', $value->format('Y-m-d H:i:s'));
+    }
+
+    public function testUnparsableTimestampNamesTheTypeAndTheFormat(): void
+    {
+        $this->expectException(InvalidFormat::class);
+        $this->expectExceptionMessage(UTCDateTimeType::class);
+
+        $this->dateTimeType()->convertToPHPValue('kein Zeitstempel', $this->mariaDb);
+    }
+
+    /**
+     * Ein bereits umgewandelter Wert wird unveraendert durchgereicht — dieselbe
+     * Instanz, keine Kopie und keine erneute Zeitzonenrechnung.
+     */
+    public function testAnExistingDateTimeIsPassedThroughUntouched(): void
+    {
+        $existing = new \DateTime('2026-09-04 17:30:00', new \DateTimeZone('Europe/Berlin'));
+
+        self::assertSame($existing, $this->dateTimeType()->convertToPHPValue($existing, $this->mariaDb));
+        self::assertSame($existing, $this->dateType()->convertToPHPValue($existing, $this->mariaDb));
+        self::assertSame($existing, $this->timeType()->convertToPHPValue($existing, $this->mariaDb));
+        self::assertSame('Europe/Berlin', $existing->getTimezone()->getName());
+    }
+
+    /**
+     * Der eigentliche Fehler im Datumstyp: ohne '!' im Format uebernimmt
+     * createFromFormat die aktuelle Uhrzeit, ein gelesenes Datum trug damit die
+     * Tageszeit des Lesezeitpunkts.
+     */
+    public function testDateIsReadAtMidnight(): void
+    {
+        $value = $this->dateType()->convertToPHPValue('2026-09-04', $this->mariaDb);
+
+        self::assertInstanceOf(\DateTime::class, $value);
+        self::assertSame('2026-09-04 00:00:00', $value->format('Y-m-d H:i:s'));
+        self::assertSame('UTC', $value->getTimezone()->getName());
+    }
+
+    public function testUnparsableDateNamesTheType(): void
+    {
+        $this->expectException(InvalidFormat::class);
+        $this->expectExceptionMessage(UTCDateType::class);
+
+        $this->dateType()->convertToPHPValue('kein Datum', $this->mariaDb);
+    }
+
+    public function testTimeIsReadWithoutADate(): void
+    {
+        $value = $this->timeType()->convertToPHPValue('19:30:00', $this->mariaDb);
+
+        self::assertInstanceOf(\DateTime::class, $value);
+        self::assertSame('19:30:00', $value->format('H:i:s'));
+        self::assertSame('1970-01-01', $value->format('Y-m-d'));
+        self::assertSame('UTC', $value->getTimezone()->getName());
+    }
+
+    public function testUnparsableTimeNamesTheType(): void
+    {
+        $this->expectException(InvalidFormat::class);
+        $this->expectExceptionMessage(UTCTimeType::class);
+
+        $this->timeType()->convertToPHPValue('keine Uhrzeit', $this->mariaDb);
+    }
+}


### PR DESCRIPTION
## Summary

Erster von drei Punkten der Altlasten aus der PostGIS-Vorbereitung — dieser brennt unabhängig davon.

- `Type::getName()` und `ConversionException::conversionFailedFormat()` existieren in DBAL 4 **beide nicht mehr**. Der Fehlerpfad aller drei UTC-Typen war damit ein Fatal Error, der nur auf einen unparsbaren Wert wartete.
- Beide Aufrufe standen seit dem DBAL-4-Upgrade in `phpstan-baseline.neon`, waren also bekannt und stummgeschaltet. Die sechs Einträge fallen mit weg.
- Ersatz ist `InvalidFormat::new($value, static::class, $format)` — das Muster, das Doctrine in seinen eigenen Typen verwendet.

Zwei Verhaltenskorrekturen kommen mit, weil sie in denselben Zeilen sitzen:

- **`UTCDateTimeType`** fällt jetzt wie Doctrines `DateTimeType` auf den `DateTime`-Parser zurück, wenn das Plattformformat nicht passt. Ohne das scheitert unter PostgreSQL jeder Zeitstempel mit Sekundenbruchteilen — also praktisch jeder.
- **`UTCDateType`** stellt dem Format ein `!` voran. Ohne das übernimmt `createFromFormat` für die nicht genannten Felder die *aktuelle Uhrzeit*: Ein gelesenes Datum trug bisher die Tageszeit des Lesezeitpunkts statt Mitternacht. Doctrines `DateType` macht das seit jeher richtig. Betrifft `CityCycle::$validFrom` und `$validUntil`, also die Gültigkeit der Tourenmuster.

## Test Plan

- Neue `tests/DBAL/Type/UTCTypesTest.php` mit 9 Tests — die Typen hatten vorher **keine**.
- Gegenprobe gemacht: Mit zurückgedrehten Fixes fallen genau die zwei zuständigen Tests um (`testDateIsReadAtMidnight` schlägt fehl, `testTimestampWithMicrosecondsIsAccepted` läuft in den Fehler). Die Tests prüfen also wirklich, was sie behaupten.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler (843 Dateien), nachdem die sechs Baseline-Einträge entfernt wurden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR