### PR TITLE
Rename the user table to app_user

### DIFF
--- a/migrations/Version20260904130000.php
+++ b/migrations/Version20260904130000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Benennt die Tabelle user in app_user um.
+ *
+ * In PostgreSQL ist user ein reserviertes Wort — es steht dort fuer den
+ * angemeldeten Datenbanknutzer. Doctrine quotet Tabellennamen nicht von sich
+ * aus, und jedes handgeschriebene SQL auf dieser Tabelle waere nach einem
+ * Plattformwechsel eine stille Falle. Der Schritt geschieht deshalb jetzt,
+ * unter MySQL, wo er folgenlos ist, und nicht mitten im Umzug.
+ *
+ * Die Fremdschluessel der 14 verweisenden Tabellen behalten ihre Namen; nur das
+ * Ziel des Verweises aendert sich.
+ */
+final class Version20260904130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename table user to app_user, because user is reserved in PostgreSQL';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('RENAME TABLE user TO app_user');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('RENAME TABLE app_user TO user');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -17,7 +17,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
-#[ORM\Table(name: 'user')]
+// 'user' ist in PostgreSQL ein reserviertes Wort und wird von Doctrine nicht
+// automatisch gequotet; jedes rohe SQL auf dieser Tabelle waere dort eine Falle.
+#[ORM\Table(name: 'app_user')]
 #[ORM\Entity(repositoryClass: 'App\Repository\UserRepository')]
 #[ORM\HasLifecycleCallbacks]
 class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterface, UserInterface, LegacyPasswordAuthenticatedUserInterface


### PR DESCRIPTION
## Summary

Dritter von drei Punkten der Altlasten aus der PostGIS-Vorbereitung. **Baut auf #1497 auf** (Ziel-Branch ist `refactor/migrations-baseline`, nicht `main`) — die Umbenennung braucht die Baseline als Grundlage.

`user` ist in PostgreSQL ein **reserviertes Wort** und steht dort für den angemeldeten Datenbanknutzer. Doctrine quotet Tabellennamen nicht von sich aus, und jedes handgeschriebene SQL auf dieser Tabelle wäre nach dem Plattformwechsel eine stille Falle. Der Schritt geschieht deshalb jetzt, unter MySQL, wo er folgenlos ist, statt mitten im Umzug.

Nur das `#[ORM\Table]`-Attribut nennt den Tabellennamen überhaupt im Code — die übrigen `'user'`-Vorkommen sind Property- und Assoziationsnamen und bleiben unberührt. Es gibt kein rohes SQL auf dieser Tabelle. Die 14 verweisenden Tabellen behalten ihre Fremdschlüsselnamen, nur das Ziel ändert sich.

## Test Plan

- Leere MariaDB → Baseline + Umbenennung → Tabelle heißt `app_user`, `schema:update --dump-sql` sagt „Nothing to update", 16 Fremdschlüsselspalten zeigen auf `app_user`.
- Rückwärts und wieder vorwärts durchgespielt: `migrate` auf die Baseline zurück ergibt `user`, erneutes `migrate` wieder `app_user`.
- Volle Testsuite gegen eine Wegwerf-MariaDB: **1456 Tests grün**.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR