### PR TITLE
Produktions-Logging auf echte Fehler beschränken

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -7,14 +7,13 @@ when@prod:
                 type: fingers_crossed
                 action_level: error
                 handler: nested
-                excluded_http_codes: [400, 404, 405]
+                excluded_http_codes: [400, 401, 403, 404, 405, 410]
             nested:
                 type: stream
                 path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: warning
             deprecation:
-                type: stream
-                path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+                type: "null"
                 channels: ["deprecation"]
             console:
                 type:   console


### PR DESCRIPTION
## Problem

`var/log/prod.deprecations.log` war auf **32,4 GB** angewachsen und wuchs um rund
570 MB pro Tag — für gerade einmal drei verschiedene Meldungen. Dem
`deprecation`-Handler fehlte ein `level`, wodurch monolog auf `DEBUG`
zurückfiel und jede `deprecation.INFO` mit vollem Exception-Objekt wegschrieb.

## Änderung

- `deprecation`-Handler auf `type: "null"` (Symfony-Empfehlung für Produktion)
- `excluded_http_codes` um 400, 401, 403 und 410 erweitert

Der `nested`-Handler bleibt auf `level: warning`, da er hinter `fingers_crossed`
mit `action_level: error` hängt und damit nur bei echten Fehlern schreibt — die
gepufferten Warnungen liefern dann nützlichen Kontext.

Behebt das Logvolumen aus #1500. Die inhaltlichen Ursachen der Deprecations sind
in #1499 und #1265 erfasst.

## Verifikation

Auf server2 bereits angewendet und nachgemessen: nach 20 Requests gegen die Seite
sind die Logdateien +0 Bytes gewachsen.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtdgN7C4yLo1hDmLqVcoRu
