### PR TITLE
Fetch a city's feed items in one request, not one per profile

### DIFF
--- a/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProvider.php
+++ b/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProvider.php
@@ -31,27 +31,21 @@ class FeedItemProvider implements FeedItemProviderInterface
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($profileIds, $page): array {
             $item->expiresAfter(300);
 
-            $allItems = [];
-
             try {
-                foreach ($profileIds as $profileId) {
-                    $items = $this->feedsApiClient->getItems(
-                        profileId: $profileId,
-                        page: $page,
-                        orderDirection: 'desc',
-                    );
-
-                    $allItems = array_merge($allItems, $items);
-                }
+                // One request for all of the city's profiles: the API merges,
+                // orders and paginates them, so a city with ten profiles costs
+                // one round trip and yields one page of items — not ten pages
+                // stacked on top of each other.
+                return $this->feedsApiClient->getItems(
+                    profileIds: $profileIds,
+                    page: $page,
+                    orderDirection: 'desc',
+                );
             } catch (\Throwable) {
                 // The Feeds API being unavailable must not take the page down:
                 // show no social items rather than a 500.
                 return [];
             }
-
-            usort($allItems, fn(FeedItem $a, FeedItem $b) => $b->getDateTime() <=> $a->getDateTime());
-
-            return $allItems;
         });
     }
 

--- a/src/Criticalmass/SocialNetwork/FeedsApi/FeedsApiClient.php
+++ b/src/Criticalmass/SocialNetwork/FeedsApi/FeedsApiClient.php
@@ -130,8 +130,9 @@ class FeedsApiClient implements FeedsApiClientInterface
     }
 
     /** @return FeedItem[] */
+    /** @param list<int>|null $profileIds */
     public function getItems(
-        ?int $profileId = null,
+        ?array $profileIds = null,
         int $page = 1,
         string $orderDirection = 'desc',
     ): array {
@@ -140,8 +141,8 @@ class FeedsApiClient implements FeedsApiClientInterface
             'order[dateTime]' => $orderDirection,
         ];
 
-        if ($profileId) {
-            $query['profile'] = $profileId;
+        if ($profileIds) {
+            $query['profile'] = $profileIds;
         }
 
         $data = $this->request('GET', '/api/items', queryParams: $query);

--- a/src/Criticalmass/SocialNetwork/FeedsApi/FeedsApiClientInterface.php
+++ b/src/Criticalmass/SocialNetwork/FeedsApi/FeedsApiClientInterface.php
@@ -34,10 +34,11 @@ interface FeedsApiClientInterface
     ): array;
 
     /**
+     * @param list<int>|null $profileIds
      * @return FeedItem[]
      */
     public function getItems(
-        ?int $profileId = null,
+        ?array $profileIds = null,
         int $page = 1,
         string $orderDirection = 'desc',
     ): array;

--- a/tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
+++ b/tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
@@ -88,8 +88,8 @@ class FeedItemProviderTest extends TestCase
         $this->assertEmpty($items);
     }
 
-    #[TestDox('fetches feed items for each profile and sorts by date descending')]
-    public function testFetchesAndSortsByDate(): void
+    #[TestDox('asks for all of the city profiles in a single request')]
+    public function testFetchesAllProfilesAtOnce(): void
     {
         $this->setupCachePassthrough();
         $this->profileRepository->method('findByCity')->willReturn([
@@ -97,14 +97,13 @@ class FeedItemProviderTest extends TestCase
             $this->createProfile(20),
         ]);
 
-        $this->feedsApiClient->method('getItems')
-            ->willReturnCallback(function (int $profileId) {
-                if ($profileId === 10) {
-                    return [$this->createFeedItem(1, '2026-03-15T10:00:00+01:00')];
-                }
-
-                return [$this->createFeedItem(2, '2026-03-15T18:00:00+01:00')];
-            });
+        $this->feedsApiClient->expects($this->once())
+            ->method('getItems')
+            ->with([10, 20], 1, 'desc')
+            ->willReturn([
+                $this->createFeedItem(2, '2026-03-15T18:00:00+01:00'),
+                $this->createFeedItem(1, '2026-03-15T10:00:00+01:00'),
+            ]);
 
         $items = $this->provider->getFeedItemsForCity($this->createCity(1));
 
@@ -124,6 +123,7 @@ class FeedItemProviderTest extends TestCase
 
         $this->feedsApiClient->expects($this->once())
             ->method('getItems')
+            ->with([10], 1, 'desc')
             ->willReturn([$this->createFeedItem(1, '2026-03-15T10:00:00+01:00')]);
 
         $items = $this->provider->getFeedItemsForCity($this->createCity(1));


### PR DESCRIPTION
## Summary

- `FeedItemProvider::getFeedItemsForCity()` asked the Feeds API for each of the city's profiles separately and concatenated the answers. That cost one HTTP round trip per profile, and because every answer was a full page of its own, "page 1" of a city with ten profiles was ten pages stacked on top of each other.
- Measured on prod before the change: Köln (10 profiles) rendered **288 posts** in **10–12 s**; Halle 158 posts / 7.8 s; Magdeburg 111 posts / 5.4 s. A city without profiles answers in 0.9 s, so the whole difference sat in this loop. The pagination under the list never actually paged.
- `/api/items` accepts a repeated `profile[]` filter and merges, orders and paginates across all of them, so one request now does the whole job and returns one page of 50. The local `usort` goes with it — the API already orders by `dateTime` descending.

`getItems()` therefore takes `?array $profileIds` instead of `?int $profileId`; it had no other callers.

## Test Plan

- `vendor/bin/phpunit tests/SocialNetwork/` — 87 green; the provider tests now assert a single call carrying all profile ids.
- `vendor/bin/phpstan analyse src/Criticalmass/SocialNetwork tests/SocialNetwork --memory-limit=-1` — no errors.
- Verified against the live API that `?profile[0]=…&profile[1]=…` returns the merged, `dateTime`-ordered collection for exactly those profiles (Köln: `totalItems` 3674, 50 per page).

Note: the Feeds API itself answers this query slowly (5–10 s for one page of 50; the underlying SQL takes 58 ms, so the time is spent above the database). That is a separate issue in socialnetwork-fetcher — this change cuts the number of those requests per page from ten to one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpTcsixuZREWN9UqNMELJ