### PR TITLE
Warm the feed item cache from cron instead of on the first visit

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,6 +22,12 @@ parameters:
     facebook.default_token: '%env(FACEBOOK_DEFAULT_TOKEN)%'
     photo_tsv.access_key: '%env(PHOTO_TSV_ACCESS_KEY)%'
     timeline.ttl: 60
+
+    # Feed items are pulled from feeds.maltehuebner.dev and refreshed by
+    # criticalmass:social-network:warm-feeds-cache every 30 minutes. The TTL has
+    # to outlive a couple of missed cron runs, otherwise a visitor pays for the
+    # API call the cron was supposed to have made.
+    feeds.cache_ttl: 5400
     notification.mail.sender_address: '%env(MAILER_SENDER)%'
     request_listener.http_port: 80
     request_listener.https_port: 443
@@ -65,6 +71,7 @@ services:
             cachePrefix: 'media/cache'
             $feedsApiUrl: '%env(FEEDS_API_URL)%'
             $feedsApiToken: '%env(FEEDS_API_TOKEN)%'
+            $feedsCacheTtl: '%feeds.cache_ttl%'
 
     App\:
         resource: '../src/*'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4773,19 +4773,19 @@ parameters:
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with named argument \$limit, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
-			count: 2
+			count: 3
 			path: tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with named argument \$since, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
-			count: 2
+			count: 3
 			path: tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
 
 		-
 			message: '#^Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker\:\:with\(\) invoked with named argument \$until, but it''s not allowed because of @no\-named\-arguments\.$#'
 			identifier: argument.named
-			count: 2
+			count: 3
 			path: tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
 
 		-

--- a/src/Command/SocialNetwork/WarmFeedsCacheCommand.php
+++ b/src/Command/SocialNetwork/WarmFeedsCacheCommand.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace App\Command\SocialNetwork;
+
+use App\Criticalmass\SocialNetwork\FeedsApi\FeedItemProviderInterface;
+use App\Repository\SocialNetworkProfileRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'criticalmass:social-network:warm-feeds-cache',
+    description: 'Refreshes the cached feed items for every city and the timeline',
+)]
+class WarmFeedsCacheCommand extends Command
+{
+    public function __construct(
+        private readonly FeedItemProviderInterface $feedItemProvider,
+        private readonly SocialNetworkProfileRepository $profileRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('cities-only', null, InputOption::VALUE_NONE, 'Skip the timeline windows');
+        $this->addOption('timeline-only', null, InputOption::VALUE_NONE, 'Skip the city pages');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $failures = 0;
+
+        if (!$input->getOption('cities-only')) {
+            $failures += $this->warmTimeline($io);
+        }
+
+        if (!$input->getOption('timeline-only')) {
+            $failures += $this->warmCities($io);
+        }
+
+        if ($failures > 0) {
+            $io->warning(sprintf('%d entries could not be refreshed', $failures));
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function warmTimeline(SymfonyStyle $io): int
+    {
+        $failures = 0;
+
+        foreach ($this->timelineWindows() as $label => [$since, $until]) {
+            try {
+                $items = $this->feedItemProvider->getTimelineItems(
+                    since: $since,
+                    until: $until,
+                    refresh: true,
+                );
+
+                $io->writeln(sprintf('timeline %s: %d items', $label, count($items)));
+            } catch (\Throwable $exception) {
+                $io->error(sprintf('timeline %s failed: %s', $label, $exception->getMessage()));
+                ++$failures;
+            }
+        }
+
+        return $failures;
+    }
+
+    private function warmCities(SymfonyStyle $io): int
+    {
+        $cities = $this->profileRepository->findCitiesWithFeedsProfiles();
+
+        $io->writeln(sprintf('Warming %d cities', count($cities)));
+
+        $failures = 0;
+        $itemCount = 0;
+
+        $progressBar = $io->createProgressBar(count($cities));
+
+        foreach ($cities as $city) {
+            try {
+                $itemCount += count($this->feedItemProvider->getFeedItemsForCity($city, refresh: true));
+            } catch (\Throwable $exception) {
+                $io->error(sprintf('city %s failed: %s', $city->getCity(), $exception->getMessage()));
+                ++$failures;
+            }
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $io->newLine(2);
+        $io->writeln(sprintf('%d cities warmed, %d items cached', count($cities) - $failures, $itemCount));
+
+        return $failures;
+    }
+
+    /**
+     * The windows the pages actually ask for: the front page shows the last
+     * month, /timeline the current one, and the month before that is one click
+     * away. They are day-aligned by the provider, so warming them here hits the
+     * same cache entries a visitor will.
+     *
+     * @return array<string, array{\DateTimeImmutable, \DateTimeImmutable}>
+     */
+    private function timelineWindows(): array
+    {
+        $now = new \DateTimeImmutable();
+        $currentMonth = $now->modify('first day of this month');
+        $previousMonth = $currentMonth->modify('-1 month');
+
+        return [
+            'front page' => [$now->modify('-1 month'), $now],
+            'current month' => [$currentMonth, $currentMonth->modify('last day of this month')],
+            'previous month' => [$previousMonth, $previousMonth->modify('last day of this month')],
+        ];
+    }
+}

--- a/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProvider.php
+++ b/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProvider.php
@@ -14,11 +14,12 @@ class FeedItemProvider implements FeedItemProviderInterface
         private readonly FeedsApiClientInterface $feedsApiClient,
         private readonly SocialNetworkProfileRepository $profileRepository,
         private readonly CacheInterface $cache,
+        private readonly int $feedsCacheTtl,
     ) {
     }
 
     /** @return FeedItem[] */
-    public function getFeedItemsForCity(City $city, int $page = 1): array
+    public function getFeedItemsForCity(City $city, int $page = 1, bool $refresh = false): array
     {
         $profileIds = $this->getFeedsProfileIdsForCity($city);
 
@@ -29,7 +30,7 @@ class FeedItemProvider implements FeedItemProviderInterface
         $cacheKey = sprintf('feeds_city_%d_page_%d', $city->getId(), $page);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($profileIds, $page): array {
-            $item->expiresAfter(300);
+            $item->expiresAfter($this->feedsCacheTtl);
 
             try {
                 // One request for all of the city's profiles: the API merges,
@@ -46,7 +47,7 @@ class FeedItemProvider implements FeedItemProviderInterface
                 // show no social items rather than a 500.
                 return [];
             }
-        });
+        }, $refresh ? INF : null);
     }
 
     /** @return FeedItem[] */
@@ -54,13 +55,22 @@ class FeedItemProvider implements FeedItemProviderInterface
         ?\DateTimeInterface $since = null,
         ?\DateTimeInterface $until = null,
         ?int $limit = null,
+        bool $refresh = false,
     ): array {
-        $sinceKey = $since ? $since->format('Y-m-d-H') : 'none';
-        $untilKey = $until ? $until->format('Y-m-d-H') : 'none';
+        // The callers hand in "now" and "a month ago", which would give every
+        // request of a new hour its own cache key and thus its own trip to the
+        // API. Whole days are the granularity a timeline is read at anyway, so
+        // both the query and the key use them — that is what makes the entry
+        // survive long enough for the warming cron to keep it hot.
+        $since = self::startOfDay($since);
+        $until = self::startOfNextDay($until);
+
+        $sinceKey = $since?->format('Y-m-d') ?? 'none';
+        $untilKey = $until?->format('Y-m-d') ?? 'none';
         $cacheKey = sprintf('feeds_timeline_%s_%s_%d', $sinceKey, $untilKey, $limit ?? 0);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($since, $until, $limit): array {
-            $item->expiresAfter(300);
+            $item->expiresAfter($this->feedsCacheTtl);
 
             try {
                 return $this->feedsApiClient->getTimelineItems(
@@ -73,10 +83,28 @@ class FeedItemProvider implements FeedItemProviderInterface
                 // A Feeds API outage must not break the timeline/home page.
                 return [];
             }
-        });
+        }, $refresh ? INF : null);
     }
 
-    /** @return int[] */
+    public static function startOfDay(?\DateTimeInterface $dateTime): ?\DateTimeImmutable
+    {
+        return $dateTime === null
+            ? null
+            : \DateTimeImmutable::createFromInterface($dateTime)->setTime(0, 0);
+    }
+
+    /**
+     * The upper bound is exclusive in spirit — a timeline for "March" must
+     * contain what was posted on the 31st, not stop at its midnight.
+     */
+    public static function startOfNextDay(?\DateTimeInterface $dateTime): ?\DateTimeImmutable
+    {
+        return $dateTime === null
+            ? null
+            : \DateTimeImmutable::createFromInterface($dateTime)->setTime(0, 0)->modify('+1 day');
+    }
+
+    /** @return list<int> */
     private function getFeedsProfileIdsForCity(City $city): array
     {
         $profiles = $this->profileRepository->findByCity($city);

--- a/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProviderInterface.php
+++ b/src/Criticalmass/SocialNetwork/FeedsApi/FeedItemProviderInterface.php
@@ -8,12 +8,13 @@ use App\Entity\City;
 interface FeedItemProviderInterface
 {
     /** @return FeedItem[] */
-    public function getFeedItemsForCity(City $city, int $page = 1): array;
+    public function getFeedItemsForCity(City $city, int $page = 1, bool $refresh = false): array;
 
     /** @return FeedItem[] */
     public function getTimelineItems(
         ?\DateTimeInterface $since = null,
         ?\DateTimeInterface $until = null,
         ?int $limit = null,
+        bool $refresh = false,
     ): array;
 }

--- a/src/Repository/SocialNetworkProfileRepository.php
+++ b/src/Repository/SocialNetworkProfileRepository.php
@@ -156,6 +156,28 @@ class SocialNetworkProfileRepository extends ServiceEntityRepository
     }
 
     /**
+     * Every city that has at least one profile registered with the Feeds API —
+     * the set worth warming a cache for.
+     *
+     * @return list<City>
+     */
+    public function findCitiesWithFeedsProfiles(): array
+    {
+        $builder = $this->createQueryBuilder('snp');
+
+        return $builder
+            ->select('c')
+            ->join('snp.city', 'c')
+            ->where($builder->expr()->isNotNull('snp.feedsProfileId'))
+            ->andWhere($builder->expr()->eq('snp.enabled', ':enabled'))
+            ->setParameter('enabled', true)
+            ->groupBy('c.id')
+            ->orderBy('c.city', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * Maps feeds profile ids to the network identifier they were registered
      * under, so feed items coming back from the Feeds API (which only carries
      * the profile id) can be attributed to a network again.

--- a/tests/Command/SocialNetwork/WarmFeedsCacheCommandTest.php
+++ b/tests/Command/SocialNetwork/WarmFeedsCacheCommandTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Command\SocialNetwork;
+
+use App\Command\SocialNetwork\WarmFeedsCacheCommand;
+use App\Criticalmass\SocialNetwork\FeedsApi\FeedItemProviderInterface;
+use App\Entity\City;
+use App\Repository\SocialNetworkProfileRepository;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[TestDox('WarmFeedsCacheCommand')]
+class WarmFeedsCacheCommandTest extends TestCase
+{
+    private FeedItemProviderInterface&MockObject $feedItemProvider;
+    private SocialNetworkProfileRepository&MockObject $profileRepository;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->feedItemProvider = $this->createMock(FeedItemProviderInterface::class);
+        $this->profileRepository = $this->createMock(SocialNetworkProfileRepository::class);
+
+        $application = new Application();
+        $application->add(new WarmFeedsCacheCommand($this->feedItemProvider, $this->profileRepository));
+
+        $this->commandTester = new CommandTester($application->find('criticalmass:social-network:warm-feeds-cache'));
+    }
+
+    #[TestDox('refreshes every city that has feeds profiles')]
+    public function testRefreshesEveryCity(): void
+    {
+        $this->profileRepository->method('findCitiesWithFeedsProfiles')->willReturn([
+            $this->createCity('Hamburg'),
+            $this->createCity('Magdeburg'),
+        ]);
+
+        $this->feedItemProvider->expects($this->exactly(2))
+            ->method('getFeedItemsForCity')
+            ->with($this->isInstanceOf(City::class), 1, true)
+            ->willReturn([]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->execute(['--cities-only' => true]));
+        $this->assertStringContainsString('2 cities warmed', $this->commandTester->getDisplay());
+    }
+
+    #[TestDox('refreshes the three timeline windows the pages ask for')]
+    public function testRefreshesTimelineWindows(): void
+    {
+        $this->feedItemProvider->expects($this->exactly(3))
+            ->method('getTimelineItems')
+            ->with(
+                $this->isInstanceOf(\DateTimeInterface::class),
+                $this->isInstanceOf(\DateTimeInterface::class),
+                null,
+                true,
+            )
+            ->willReturn([]);
+
+        $this->assertSame(Command::SUCCESS, $this->commandTester->execute(['--timeline-only' => true]));
+    }
+
+    #[TestDox('keeps going when a single city fails and reports failure')]
+    public function testSurvivesASingleFailure(): void
+    {
+        $this->profileRepository->method('findCitiesWithFeedsProfiles')->willReturn([
+            $this->createCity('Hamburg'),
+            $this->createCity('Magdeburg'),
+        ]);
+
+        $calls = 0;
+        $this->feedItemProvider->method('getFeedItemsForCity')
+            ->willReturnCallback(function () use (&$calls): array {
+                if (++$calls === 1) {
+                    throw new \RuntimeException('Feeds API returned status 502');
+                }
+
+                return [];
+            });
+
+        $this->assertSame(Command::FAILURE, $this->commandTester->execute(['--cities-only' => true]));
+        $this->assertSame(2, $calls);
+        $this->assertStringContainsString('1 cities warmed', $this->commandTester->getDisplay());
+    }
+
+    private function createCity(string $name): City&MockObject
+    {
+        $city = $this->createMock(City::class);
+        $city->method('getCity')->willReturn($name);
+
+        return $city;
+    }
+}

--- a/tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
+++ b/tests/SocialNetwork/FeedsApi/FeedItemProviderTest.php
@@ -17,10 +17,18 @@ use Symfony\Contracts\Cache\ItemInterface;
 #[TestDox('FeedItemProvider')]
 class FeedItemProviderTest extends TestCase
 {
+    private const int CACHE_TTL = 5400;
+
     private FeedsApiClientInterface&MockObject $feedsApiClient;
     private CacheInterface&MockObject $cache;
     private MockObject $profileRepository;
     private FeedItemProvider $provider;
+
+    /** @var list<string> */
+    private array $cacheKeys = [];
+
+    /** @var list<float|null> */
+    private array $cacheBetas = [];
 
     protected function setUp(): void
     {
@@ -36,12 +44,16 @@ class FeedItemProviderTest extends TestCase
             $this->feedsApiClient,
             $this->profileRepository,
             $this->cache,
+            self::CACHE_TTL,
         );
     }
 
     private function setupCachePassthrough(): void
     {
-        $this->cache->method('get')->willReturnCallback(function (string $key, callable $callback) {
+        $this->cache->method('get')->willReturnCallback(function (string $key, callable $callback, ?float $beta = null) {
+            $this->cacheKeys[] = $key;
+            $this->cacheBetas[] = $beta;
+
             $item = $this->createMock(ItemInterface::class);
             $item->method('expiresAfter')->willReturn($item);
 
@@ -170,8 +182,9 @@ class FeedItemProviderTest extends TestCase
             ->method('getTimelineItems')
             ->with(
                 limit: null,
-                since: $since,
-                until: $until,
+                // Day-aligned by the provider: the 15th belongs to the window.
+                since: new \DateTimeImmutable('2026-03-01 00:00:00'),
+                until: new \DateTimeImmutable('2026-03-16 00:00:00'),
             )
             ->willReturn([]);
 
@@ -210,5 +223,60 @@ class FeedItemProviderTest extends TestCase
         $items = $this->provider->getFeedItemsForCity($this->createCity(5), 1);
 
         $this->assertCount(1, $items);
+    }
+
+    #[TestDox('gives every timeline window a key of whole days, so it does not rotate hourly')]
+    public function testTimelineKeyIsDayAligned(): void
+    {
+        $this->setupCachePassthrough();
+        $this->feedsApiClient->method('getTimelineItems')->willReturn([]);
+
+        $this->provider->getTimelineItems(
+            new \DateTimeImmutable('2026-03-01 07:13:00'),
+            new \DateTimeImmutable('2026-03-31 19:45:00'),
+        );
+
+        $this->provider->getTimelineItems(
+            new \DateTimeImmutable('2026-03-01 22:58:00'),
+            new \DateTimeImmutable('2026-03-31 02:04:00'),
+        );
+
+        // Same day, same entry — the hour the visitor arrives must not matter.
+        $this->assertSame(['feeds_timeline_2026-03-01_2026-04-01_0'], array_unique($this->cacheKeys));
+    }
+
+    #[TestDox('queries the whole of the last day of the window')]
+    public function testTimelineWindowCoversItsLastDay(): void
+    {
+        $this->setupCachePassthrough();
+
+        $this->feedsApiClient->expects($this->once())
+            ->method('getTimelineItems')
+            ->with(
+                limit: null,
+                since: new \DateTimeImmutable('2026-03-01 00:00:00'),
+                until: new \DateTimeImmutable('2026-04-01 00:00:00'),
+            )
+            ->willReturn([]);
+
+        $this->provider->getTimelineItems(
+            new \DateTimeImmutable('2026-03-01 07:13:00'),
+            new \DateTimeImmutable('2026-03-31 19:45:00'),
+        );
+    }
+
+    #[TestDox('forces a recomputation when asked to refresh')]
+    public function testRefreshBypassesTheCachedValue(): void
+    {
+        $this->setupCachePassthrough();
+        $this->profileRepository->method('findByCity')->willReturn([$this->createProfile(10)]);
+        $this->feedsApiClient->method('getItems')->willReturn([]);
+        $this->feedsApiClient->method('getTimelineItems')->willReturn([]);
+
+        $this->provider->getFeedItemsForCity($this->createCity(1));
+        $this->provider->getFeedItemsForCity($this->createCity(1), refresh: true);
+        $this->provider->getTimelineItems(refresh: true);
+
+        $this->assertSame([null, INF, INF], $this->cacheBetas);
     }
 }


### PR DESCRIPTION
## Summary

- Feed items were cached for **five minutes**, so roughly every fifth minute a visitor paid for the round trip to feeds.maltehuebner.dev themselves — once for the timeline, once per city page.
- New command **`criticalmass:social-network:warm-feeds-cache`** refreshes those entries ahead of time: the 288 cities that have a profile registered with the Feeds API, plus the three timeline windows the pages actually ask for (front page, current month, previous month). It keeps going when a single city fails and exits non-zero if any did.
- TTL moved from a hardcoded 300 s to the parameter **`feeds.cache_ttl`, 90 minutes** — comfortably more than the 30-minute cron interval, so two missed runs still leave a warm cache behind.
- Warming is a `beta` of `INF` on the *same* cache entry the pages read, so the warm and the cold path cannot drift apart.

### The timeline key had to become stable first

`getTimelineItems()` built its key from `format('Y-m-d-H')`, and its callers hand in "now" and "a month ago". Every new hour opened a new entry, which no warming interval could have kept up with. Key **and** query now use whole days.

That closes an off-by-one on the way: `TimelineController` ends a month's window at `new DateTime('2026-03-31')`, i.e. **midnight**, so everything posted on the last day of a month was missing from that month's timeline. Rounding the upper bound up to the next midnight includes it.

## Cron

Runs as the vhost user, every 30 minutes, `flock`ed against overlap — same shape as the existing activity-score job:

```
*/30 * * * * cd /var/www/vhosts/criticalmass.one/criticalmass && /usr/bin/flock -n var/warm-feeds-cache.lock /opt/plesk/php/8.5/bin/php bin/console criticalmass:social-network:warm-feeds-cache --env=prod >> var/log/cron-warm-feeds-cache.log 2>&1
```

A full run is ~288 requests against an API that answers a city in 0.5–1.3 s, so a couple of minutes.

## Test Plan

- `vendor/bin/phpunit tests/SocialNetwork tests/Command` — 107 green, including new cases for the day-aligned key, the window covering its last day, `refresh` forcing recomputation, and the command surviving a failing city.
- `vendor/bin/phpstan analyse --memory-limit=-1` — no errors (baseline counts for the existing `with()` named-argument entries bumped 2 → 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpTcsixuZREWN9UqNMELJ