### PR TITLE
Fix the DQL behind the feed cache warming

### DIFF
--- a/src/DataFixtures/SocialNetworkProfileFixtures.php
+++ b/src/DataFixtures/SocialNetworkProfileFixtures.php
@@ -38,6 +38,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
             $adminUser,
             'twitter',
             'https://twitter.com/criticalmassHH',
+            9001,
         );
         $this->addReference(self::HAMBURG_TWITTER_REFERENCE, $hamburgTwitter);
         $manager->persist($hamburgTwitter);
@@ -47,6 +48,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
             $adminUser,
             'facebook_page',
             'https://www.facebook.com/CriticalMassHamburg',
+            9002,
         );
         $this->addReference(self::HAMBURG_FACEBOOK_REFERENCE, $hamburgFacebook);
         $manager->persist($hamburgFacebook);
@@ -56,6 +58,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
             $adminUser,
             'instagram_profile',
             'https://www.instagram.com/criticalmass_hamburg',
+            9003,
         );
         $this->addReference(self::HAMBURG_INSTAGRAM_REFERENCE, $hamburgInstagram);
         $manager->persist($hamburgInstagram);
@@ -65,6 +68,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
             $adminUser,
             'twitter',
             'https://twitter.com/CMBerlin',
+            9004,
         );
         $this->addReference(self::BERLIN_TWITTER_REFERENCE, $berlinTwitter);
         $manager->persist($berlinTwitter);
@@ -104,6 +108,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
         User $createdBy,
         string $network,
         string $identifier,
+        ?int $feedsProfileId = null,
     ): SocialNetworkProfile {
         return (new SocialNetworkProfile())
             ->setCity($city)
@@ -113,6 +118,7 @@ class SocialNetworkProfileFixtures extends Fixture implements DependentFixtureIn
             ->setEnabled(true)
             ->setAutoPublish(true)
             ->setAutoFetch(true)
+            ->setFeedsProfileId($feedsProfileId)
             ->setCreatedAt(new \DateTime());
     }
 

--- a/src/Repository/SocialNetworkProfileRepository.php
+++ b/src/Repository/SocialNetworkProfileRepository.php
@@ -163,15 +163,23 @@ class SocialNetworkProfileRepository extends ServiceEntityRepository
      */
     public function findCitiesWithFeedsProfiles(): array
     {
-        $builder = $this->createQueryBuilder('snp');
+        $builder = $this->getEntityManager()->createQueryBuilder();
+
+        // City is the root here rather than the profile: selecting a joined
+        // alias without its root is a semantical error in DQL, and an EXISTS
+        // gives us each city once without a GROUP BY over all of its columns.
+        $subQuery = $this->createQueryBuilder('snp')
+            ->select('1')
+            ->where('snp.city = c')
+            ->andWhere($builder->expr()->isNotNull('snp.feedsProfileId'))
+            ->andWhere($builder->expr()->eq('snp.enabled', ':enabled'))
+            ->getDQL();
 
         return $builder
             ->select('c')
-            ->join('snp.city', 'c')
-            ->where($builder->expr()->isNotNull('snp.feedsProfileId'))
-            ->andWhere($builder->expr()->eq('snp.enabled', ':enabled'))
+            ->from(City::class, 'c')
+            ->where($builder->expr()->exists($subQuery))
             ->setParameter('enabled', true)
-            ->groupBy('c.id')
             ->orderBy('c.city', 'ASC')
             ->getQuery()
             ->getResult();

--- a/tests/Repository/SocialNetworkProfileRepositoryTest.php
+++ b/tests/Repository/SocialNetworkProfileRepositoryTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\City;
+use App\Entity\SocialNetworkProfile;
+use App\Repository\SocialNetworkProfileRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[TestDox('SocialNetworkProfileRepository')]
+class SocialNetworkProfileRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private SocialNetworkProfileRepository $repository;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+        $repository = $this->entityManager->getRepository(SocialNetworkProfile::class);
+        \assert($repository instanceof SocialNetworkProfileRepository);
+
+        $this->repository = $repository;
+    }
+
+    #[TestDox('returns only the cities that have a profile registered with the Feeds API')]
+    public function testFindCitiesWithFeedsProfiles(): void
+    {
+        $cityNames = array_map(
+            fn(City $city): ?string => $city->getCity(),
+            $this->repository->findCitiesWithFeedsProfiles(),
+        );
+
+        $this->assertContains('Hamburg', $cityNames);
+        $this->assertContains('Berlin', $cityNames);
+
+        // Munich's profile carries no feeds id, so there is nothing to warm.
+        $this->assertNotContains('Munich', $cityNames);
+    }
+
+    #[TestDox('lists every city once, however many profiles it has')]
+    public function testFindCitiesWithFeedsProfilesHasNoDuplicates(): void
+    {
+        $cityNames = array_map(
+            fn(City $city): ?string => $city->getCity(),
+            $this->repository->findCitiesWithFeedsProfiles(),
+        );
+
+        // Hamburg has three profiles with a feeds id.
+        $this->assertSame(array_unique($cityNames), $cityNames);
+    }
+
+    #[TestDox('maps feeds profile ids back to their network identifier')]
+    public function testFindNetworkIdentifiersByFeedsProfileIds(): void
+    {
+        $networkIdentifiers = $this->repository->findNetworkIdentifiersByFeedsProfileIds([9001, 9003]);
+
+        $this->assertSame([9001 => 'twitter', 9003 => 'instagram_profile'], $networkIdentifiers);
+    }
+
+    #[TestDox('asks nothing of the database for an empty id list')]
+    public function testFindNetworkIdentifiersWithoutIds(): void
+    {
+        $this->assertSame([], $this->repository->findNetworkIdentifiersByFeedsProfileIds([]));
+    }
+}


### PR DESCRIPTION
## Summary

`findCitiesWithFeedsProfiles()` (added in #1505) selected the joined alias `c` while the query was rooted in `SocialNetworkProfile`. DQL rejects that:

```
[Semantical Error] Cannot select entity through identification variables
without choosing at least one root entity alias.
```

So `criticalmass:social-network:warm-feeds-cache` died on its first production run before warming a single city. The query is now rooted in `City` and picks its rows with an `EXISTS` over the profiles, which also drops the `GROUP BY` over every city column.

## Why CI was green

The DQL is only parsed once an EntityManager runs it, so the unit tests around the command could not see it. The repository now has a `KernelTestCase` next to the other repository tests, and four fixture profiles carry a `feedsProfileId` so the query has something to find. Munich deliberately keeps none, which lets the test tell selection apart from "returns everything".

## Test Plan

- `vendor/bin/phpstan analyse --memory-limit=-1` — no errors.
- New `tests/Repository/SocialNetworkProfileRepositoryTest.php` covers `findCitiesWithFeedsProfiles()` (contents + no duplicates) and `findNetworkIdentifiersByFeedsProfileIds()`; these need the CI database, which is where the original bug would have surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpTcsixuZREWN9UqNMELJ