### PR TITLE
Keep the warming progress bar out of the cron log

### DIFF
--- a/src/Command/SocialNetwork/WarmFeedsCacheCommand.php
+++ b/src/Command/SocialNetwork/WarmFeedsCacheCommand.php
@@ -84,7 +84,9 @@ class WarmFeedsCacheCommand extends Command
         $failures = 0;
         $itemCount = 0;
 
-        $progressBar = $io->createProgressBar(count($cities));
+        // Under cron the output goes to a log file, where a progress bar is not
+        // a bar but one line per city, 48 times a day. Only a terminal gets one.
+        $progressBar = $io->isDecorated() ? $io->createProgressBar(count($cities)) : null;
 
         foreach ($cities as $city) {
             try {
@@ -94,11 +96,14 @@ class WarmFeedsCacheCommand extends Command
                 ++$failures;
             }
 
-            $progressBar->advance();
+            $progressBar?->advance();
         }
 
-        $progressBar->finish();
-        $io->newLine(2);
+        if ($progressBar !== null) {
+            $progressBar->finish();
+            $io->newLine(2);
+        }
+
         $io->writeln(sprintf('%d cities warmed, %d items cached', count($cities) - $failures, $itemCount));
 
         return $failures;


### PR DESCRIPTION
## Summary

`criticalmass:social-network:warm-feeds-cache` draws a progress bar over its 288 cities. In a terminal that is one line being redrawn; piped into a log file it is 288 lines, 48 times a day — about 14,000 lines of noise that would bury the one line that matters and any failing city.

The bar is now only created when the output is decorated. The summary and the per-city errors are unaffected, so the cron log keeps exactly what one wants to read there.

## Test Plan

- `vendor/bin/phpunit tests/Command/SocialNetwork` — green; `CommandTester` runs undecorated, so the existing assertions on the summary line already cover the no-bar path.
- `vendor/bin/phpstan analyse src/Command/SocialNetwork --memory-limit=-1` — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KpTcsixuZREWN9UqNMELJ