### PR TITLE
Run CI on pushes to main, not only on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,15 @@ name: CI
 # Auch gestapelte Pull Requests pruefen: Wenn nur PRs gegen main laufen, bleibt
 # jeder Zwischenschritt einer Kette ungeprueft, und die Fehler tauchen erst auf,
 # wenn alles zusammen in main liegt.
+#
+# Und main selbst pruefen: Ein PR wird gegen den Stand getestet, den main beim
+# Oeffnen hatte. Liegen zwei gruene PRs zusammen in main, ist das keine Aussage
+# ueber main — genau so kam main nach dem MCP-Stack rot heraus. Ohne diesen
+# Trigger bleibt nur, es von Hand zu pruefen.
 on:
   pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
   phpstan:


### PR DESCRIPTION
## Summary

Die CI lief bisher **ausschließlich auf `pull_request`** — für `main` gab es gar keinen Lauf.

Ein PR wird gegen den Stand getestet, den `main` beim Öffnen hatte. Zwei grüne PRs, die zusammen in `main` liegen, sind deshalb **keine Aussage über `main`**. Genau so kam `main` nach dem Mergen des MCP-Stacks rot heraus (#1481), und genau deshalb musste ich die drei PostGIS-PRs (#1496, #1497, #1504) heute von Hand gegen `main` prüfen, nachdem dort zwischenzeitlich fremde Merges gelandet waren.

Ein `push`-Trigger auf `main` schließt die Lücke.

## Test Plan

- Der Lauf dieses PRs beweist, dass der `pull_request`-Trigger unverändert greift.
- Nach dem Merge muss ein Lauf mit dem Ereignis `push` auf `main` erscheinen — das ist die eigentliche Probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR