### PR TITLE
Compare search terms lowercased on both sides

### DIFF
--- a/src/Criticalmass/DataQuery/Query/TitleQuery.php
+++ b/src/Criticalmass/DataQuery/Query/TitleQuery.php
@@ -38,9 +38,11 @@ class TitleQuery extends AbstractQuery implements OrmQueryInterface, ElasticQuer
         $expr = $queryBuilder->expr();
         $alias = $queryBuilder->getRootAliases()[0];
 
+        // LOWER() auf beiden Seiten: PostgreSQL vergleicht LIKE schreibungs-
+        // empfindlich, der API-Parameter soll sich aber wie unter MySQL verhalten.
         $queryBuilder
-            ->andWhere($expr->like(sprintf('%s.title', $alias), ':title'))
-            ->setParameter('title', sprintf('%%%s%%', $this->title))
+            ->andWhere($expr->like(sprintf('LOWER(%s.title)', $alias), ':title'))
+            ->setParameter('title', sprintf('%%%s%%', mb_strtolower($this->title)))
         ;
 
         return $queryBuilder;

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -360,12 +360,15 @@ SQL;
         $qb->setParameter('enabled', true);
 
         if ($query !== '') {
+            // Beide Seiten kleingeschrieben vergleichen: MySQL vergleicht mit der
+            // vorgegebenen Kollation ohnehin schreibungsblind, PostgreSQL dagegen
+            // nicht. Ohne LOWER() faende eine Suche nach "hamburg" dort nichts.
             $likeExpr = $expr->orX(
-                $expr->like('c.title', ':q'),
-                $expr->like('c.description', ':q'),
+                $expr->like('LOWER(c.title)', ':q'),
+                $expr->like('LOWER(c.description)', ':q'),
             );
             $conditions[] = $likeExpr;
-            $qb->setParameter('q', '%' . $query . '%');
+            $qb->setParameter('q', '%' . mb_strtolower($query) . '%');
         }
 
         $qb->where(call_user_func_array([$expr, 'andX'], $conditions))

--- a/src/Repository/LocationRepository.php
+++ b/src/Repository/LocationRepository.php
@@ -38,10 +38,15 @@ class LocationRepository extends ServiceEntityRepository
 
         $builder = $this->createQueryBuilder('l');
 
+        // LOWER() auf beiden Seiten, weil PostgreSQL LIKE schreibungsempfindlich
+        // vergleicht. Hier stehen keine Platzhalter im Muster, der Vergleich ist
+        // also faktisch eine Gleichheit — enthaelt der Ortsname eines Rides ein
+        // % oder _, wirkt es allerdings als Platzhalter. Das ist ein eigener,
+        // aelterer Fehler und bleibt hier unangetastet.
         $builder
-            ->where($builder->expr()->like('l.title', ':locationTitle'))
+            ->where($builder->expr()->like('LOWER(l.title)', ':locationTitle'))
             ->andWhere($builder->expr()->eq('l.city', ':city'))
-            ->setParameter('locationTitle', $ride->getLocation())
+            ->setParameter('locationTitle', mb_strtolower((string) $ride->getLocation()))
             ->setParameter('city', $ride->getCity())
             ->setMaxResults(1);
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -118,12 +118,15 @@ class PostRepository extends ServiceEntityRepository
             ->where($builder->expr()->eq('p.enabled', ':enabled'))
             ->setParameter('enabled', true)
             ->andWhere($builder->expr()->eq('t.enabled', ':enabled'))
+            // Beide Seiten kleingeschrieben: PostgreSQL vergleicht LIKE anders als
+            // MySQL schreibungsempfindlich, eine Suche nach "fahrrad" faende dort
+            // kein "Fahrrad".
             ->andWhere($builder->expr()->orX(
-                $builder->expr()->like('p.message', ':term'),
-                $builder->expr()->like('t.title', ':term')
+                $builder->expr()->like('LOWER(p.message)', ':term'),
+                $builder->expr()->like('LOWER(t.title)', ':term')
             ))
             // % und _ sind LIKE-Platzhalter: "100%" wuerde sonst jeden Beitrag treffen.
-            ->setParameter('term', '%' . addcslashes($term, '%_\\') . '%')
+            ->setParameter('term', '%' . addcslashes(mb_strtolower($term), '%_\\') . '%')
             ->orderBy('p.dateTime', 'DESC');
 
         return $builder->getQuery();

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -790,13 +790,15 @@ SQL;
         $expr = $qb->expr();
 
         if ($query !== '') {
+            // LOWER() auf beiden Seiten, weil PostgreSQL LIKE im Gegensatz zu MySQL
+            // schreibungsempfindlich vergleicht.
             $qb->where(
                 $expr->orX(
-                    $expr->like('r.title', ':q'),
-                    $expr->like('r.description', ':q'),
-                    $expr->like('r.location', ':q')
+                    $expr->like('LOWER(r.title)', ':q'),
+                    $expr->like('LOWER(r.description)', ':q'),
+                    $expr->like('LOWER(r.location)', ':q')
                 )
-            )->setParameter('q', sprintf('%%%s%%', $query));
+            )->setParameter('q', sprintf('%%%s%%', mb_strtolower($query)));
         }
 
         return $qb

--- a/tests/Repository/CaseInsensitiveSearchTest.php
+++ b/tests/Repository/CaseInsensitiveSearchTest.php
@@ -1,0 +1,150 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Criticalmass\DataQuery\Query\TitleQuery;
+use App\Entity\City;
+use App\Repository\CityRepository;
+use App\Repository\PostRepository;
+use App\Repository\RideRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Die Suche muss unabhaengig von der Gross- und Kleinschreibung finden.
+ *
+ * Unter MySQL ist das geschenkt: Die Kollation vergleicht ohnehin schreibungs-
+ * blind, ein reiner Verhaltenstest bestuende hier also auch dann, wenn im Code
+ * gar kein LOWER() staende. PostgreSQL vergleicht LIKE dagegen schreibungs-
+ * empfindlich — eine Suche nach "hamburg" faende dort kein "Hamburg", ohne
+ * Fehlermeldung und ohne Eintrag im Protokoll.
+ *
+ * Deshalb pruefen die ersten Tests die erzeugte Abfrage selbst. Das ist die
+ * einzige Zusicherung, die auf MySQL etwas aussagt. Die Verhaltenstests danach
+ * sichern ab, dass die Suche ueber der Umstellung nicht kaputtgegangen ist.
+ */
+class CaseInsensitiveSearchTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function postRepository(): PostRepository
+    {
+        $repository = static::getContainer()->get(PostRepository::class);
+        self::assertInstanceOf(PostRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function cityRepository(): CityRepository
+    {
+        $repository = static::getContainer()->get(CityRepository::class);
+        self::assertInstanceOf(CityRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function rideRepository(): RideRepository
+    {
+        $repository = static::getContainer()->get(RideRepository::class);
+        self::assertInstanceOf(RideRepository::class, $repository);
+
+        return $repository;
+    }
+
+    public function testForumSearchComparesLowercaseOnBothSides(): void
+    {
+        $query = $this->postRepository()->querySearchInForum('Fahrrad');
+        $dql = $query->getDQL();
+
+        self::assertStringContainsString('LOWER(p.message)', $dql);
+        self::assertStringContainsString('LOWER(t.title)', $dql);
+
+        $parameter = $query->getParameter('term');
+        self::assertNotNull($parameter);
+        self::assertSame('%fahrrad%', $parameter->getValue());
+    }
+
+    public function testForumSearchLowersTheSearchTerm(): void
+    {
+        $parameter = $this->postRepository()->querySearchInForum('FAHRRAD')->getParameter('term');
+
+        self::assertNotNull($parameter);
+        self::assertSame('%fahrrad%', $parameter->getValue(), 'Der Suchbegriff geht kleingeschrieben in die Abfrage.');
+    }
+
+    public function testForumSearchStillEscapesWildcards(): void
+    {
+        $parameter = $this->postRepository()->querySearchInForum('100%')->getParameter('term');
+
+        self::assertNotNull($parameter);
+        self::assertSame('%100\%%', $parameter->getValue(), 'Das Kleinschreiben darf die Maskierung von % nicht aushebeln.');
+    }
+
+    public function testApiTitleQueryComparesLowercaseOnBothSides(): void
+    {
+        $titleQuery = new TitleQuery();
+        $titleQuery->setTitle('Kidical');
+
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('r')
+            ->from(\App\Entity\Ride::class, 'r');
+
+        $dql = $titleQuery->createOrmQuery($builder)->getDQL();
+
+        self::assertStringContainsString('LOWER(r.title)', $dql);
+    }
+
+    public function testApiTitleQueryLowersTheSearchTerm(): void
+    {
+        $titleQuery = new TitleQuery();
+        $titleQuery->setTitle('KIDICAL');
+
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('r')
+            ->from(\App\Entity\Ride::class, 'r');
+
+        $parameter = $titleQuery->createOrmQuery($builder)->getQuery()->getParameter('title');
+
+        self::assertNotNull($parameter);
+        self::assertSame('%kidical%', $parameter->getValue());
+    }
+
+    /**
+     * @return list<array{0: string}>
+     */
+    public static function schreibweisen(): array
+    {
+        return [['Hamburg'], ['hamburg'], ['HAMBURG'], ['hAmBuRg']];
+    }
+
+    #[DataProvider('schreibweisen')]
+    public function testCitySearchFindsHamburgInAnyCase(string $term): void
+    {
+        $treffer = $this->cityRepository()->searchByQuery($term);
+        $namen = array_map(static fn (City $city): string => (string) $city->getCity(), $treffer);
+
+        self::assertContains('Hamburg', $namen, sprintf('Die Suche nach "%s" findet Hamburg nicht.', $term));
+    }
+
+    public function testCitySearchStillReturnsNothingForNonsense(): void
+    {
+        self::assertSame([], $this->cityRepository()->searchByQuery('gibtesnicht' . uniqid()));
+    }
+
+    public function testRideSearchAcceptsMixedCaseWithoutFailing(): void
+    {
+        // Der Bestand der Fixtures ist hier nicht festgelegt; gesichert wird, dass
+        // die Abfrage laeuft und beide Schreibweisen dasselbe liefern.
+        $gross = $this->rideRepository()->searchByQuery('CRITICAL');
+        $klein = $this->rideRepository()->searchByQuery('critical');
+
+        self::assertSame(count($gross), count($klein), 'Gross- und Kleinschreibung liefern dieselbe Trefferzahl.');
+    }
+}


### PR DESCRIPTION
## Summary

Erster Punkt der **Phase 2** (Portabilität) aus der PostGIS-Vorbereitung — und der gefährlichste, weil er als einziger nicht knallt.

MySQL vergleicht `LIKE` wegen der Kollation schreibungsblind, **PostgreSQL nicht**. Nach dem Plattformwechsel fände eine Suche nach „hamburg" kein „Hamburg" — ohne Fehlermeldung, ohne Protokolleintrag, ohne etwas im Monitoring. Nur weniger Treffer, und Nutzerinnen und Nutzer, die schließen, es gebe nichts zu finden.

Fünf Fundstellen, beidseitig in `LOWER()` gefasst:

| Was | Wo |
|---|---|
| Städtesuche | `CityRepository::searchByQuery` |
| Fahrtensuche | `RideRepository::searchByQuery` |
| Forensuche | `PostRepository::querySearchInForum` |
| Ortsabgleich beim Fahrten-Import | `LocationRepository::findLocationForRide` |
| API-Parameter `title` | `DataQuery\Query\TitleQuery` |

`LOWER()` statt `ILIKE`, weil das auf beiden Plattformen gilt — `ILIKE` gibt es nur in PostgreSQL. Die Maskierung von `%` und `_` in der Forensuche bleibt erhalten und wird mitgetestet.

## Was die Tests zeigen — und was nicht

Das ist hier der springende Punkt: **Unter MySQL besteht ein reiner Verhaltenstest auch dann, wenn gar kein `LOWER()` im Code steht.** Ein Test „Suche nach 'hamburg' findet Hamburg" wäre also wertlos als Absicherung.

Die tragenden Zusicherungen sind deshalb die auf die **erzeugte DQL** und den **gebundenen Parameter**. Gegenprobe gemacht: Mit zurückgedrehten Quelländerungen fallen **genau diese vier** um, die Verhaltenstests bleiben grün.

Bei `CityRepository` und `RideRepository` geht das nicht — die Methoden liefern fertige Arrays statt einer Query. Dort sichern nur Verhaltenstests ab, dass die Suche über der Umstellung nicht kaputtgegangen ist. Der eigentliche Beweis fällt dort erst unter PostgreSQL.

## Nebenbefund, nicht angefasst

`LocationRepository::findLocationForRide` vergleicht per `LIKE` **ohne Platzhalter** — faktisch eine Gleichheit. Enthält der Ortsname einer Fahrt ein `%` oder `_`, wirkt es trotzdem als Platzhalter und trifft womöglich den falschen Ort. Ein älterer Fehler eigener Art; im Code als Kommentar vermerkt.

## Test Plan

- Neue `tests/Repository/CaseInsensitiveSearchTest.php`, 11 Tests.
- Gegenprobe mit zurückgedrehten Quelländerungen: 4 Fehlschläge, genau die richtigen.
- Volle Suite gegen eine Wegwerf-MariaDB: **1488 Tests grün**.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR