### PR TITLE
Group by identifiers so the queries survive a strict database

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3481,32 +3481,8 @@ parameters:
 			path: src/Repository/PhotoRepository.php
 
 		-
-			message: '#^Method App\\Repository\\PhotoRepository\:\:findRidesForGallery\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Repository/PhotoRepository.php
-
-		-
-			message: '#^Method App\\Repository\\PhotoRepository\:\:findRidesWithPhotoCounter\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Repository/PhotoRepository.php
-
-		-
-			message: '#^Method App\\Repository\\PhotoRepository\:\:findRidesWithPhotoCounterByUser\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Repository/PhotoRepository.php
-
-		-
 			message: '#^Method App\\Repository\\PhotoRepository\:\:findSomePhotos\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Repository/PhotoRepository.php
-
-		-
-			message: '#^Variable \$photo in PHPDoc tag @var does not match any variable in the foreach loop\: \$result, \$row$#'
-			identifier: varTag.differentVariable
 			count: 1
 			path: src/Repository/PhotoRepository.php
 

--- a/src/Repository/PhotoRepository.php
+++ b/src/Repository/PhotoRepository.php
@@ -18,27 +18,83 @@ class PhotoRepository extends ServiceEntityRepository
         parent::__construct($registry, Photo::class);
     }
 
+    /**
+     * Je Tour, zu der die Person Fotos beigesteuert hat, die Tour und die Anzahl.
+     *
+     * Frueher stand in der Auswahl ein beliebiges Foto der Gruppe: MySQL sucht
+     * sich dann stillschweigend eine Zeile aus, PostgreSQL lehnt die Abfrage ab,
+     * weil die Spalten weder gruppiert noch aggregiert sind. Gebraucht wurde
+     * ohnehin nur die Tour dahinter.
+     *
+     * Die Abfrage geht deshalb von Ride aus statt von Photo — eine verbundene
+     * Kennung auszuwaehlen, ohne ihre Wurzel mitzunehmen, ist in DQL selbst
+     * schon ein Fehler.
+     *
+     * @return list<array{0: Ride, 1: int}>
+     */
     public function findRidesWithPhotoCounterByUser(User $user): array
     {
-        $builder = $this->createQueryBuilder('photo');
+        $builder = $this->getEntityManager()->createQueryBuilder();
 
-        $builder
-            ->select('photo')
-            ->addSelect('ride')
-            ->addSelect('city')
-            ->addSelect('COUNT(photo)')
+        $rows = $builder
+            ->select('ride.id AS rideId')
+            ->addSelect('COUNT(photo.id) AS photoCount')
+            ->from(Ride::class, 'ride')
+            ->innerJoin('ride.photos', 'photo')
             ->where($builder->expr()->eq('photo.deleted', ':deleted'))
             ->setParameter('deleted', false)
             ->andWhere($builder->expr()->eq('photo.user', ':user'))
             ->setParameter('user', $user)
-            ->groupBy('photo.ride')
-            ->join('photo.ride', 'ride')
-            ->join('ride.city', 'city')
-            ->orderBy('ride.dateTime', 'desc');
+            ->groupBy('ride.id')
+            ->addGroupBy('ride.dateTime')
+            ->orderBy('ride.dateTime', 'DESC')
+            ->getQuery()
+            ->getResult();
 
-        $query = $builder->getQuery();
+        return $this->ridesForCountedRows($rows);
+    }
 
-        return $query->getResult();
+    /**
+     * Laedt die Touren zu einer gruppierten Zaehlung nach und behaelt deren
+     * Reihenfolge bei. Die Stadt kommt mit, damit die Anzeige nicht je Zeile
+     * nachfragen muss.
+     *
+     * @param list<array{rideId: int, photoCount: int|string}> $rows
+     * @return list<array{0: Ride, 1: int}>
+     */
+    private function ridesForCountedRows(array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        $rides = $this->getEntityManager()->createQueryBuilder()
+            ->select('ride')
+            ->addSelect('city')
+            ->from(Ride::class, 'ride')
+            ->innerJoin('ride.city', 'city')
+            ->where('ride.id IN (:ids)')
+            ->setParameter('ids', array_column($rows, 'rideId'))
+            ->getQuery()
+            ->getResult();
+
+        $byId = [];
+
+        foreach ($rides as $ride) {
+            $byId[$ride->getId()] = $ride;
+        }
+
+        $result = [];
+
+        foreach ($rows as $row) {
+            $ride = $byId[$row['rideId']] ?? null;
+
+            if ($ride instanceof Ride) {
+                $result[] = [$ride, (int) $row['photoCount']];
+            }
+        }
+
+        return $result;
     }
 
     public function findPhotosWithoutExifData(?int $limit = null, ?int $offset = null, bool $fetchExistingData = false): array
@@ -97,61 +153,25 @@ class PhotoRepository extends ServiceEntityRepository
     }
 
     /**
+     * Touren einer Stadt mit der Anzahl ihrer Fotos.
+     *
+     * Wie bei findRidesWithPhotoCounterByUser geht die Abfrage von Ride aus:
+     * Vorher wurde ein beliebiges Foto der Gruppe ausgewaehlt, was PostgreSQL
+     * ablehnt. Die Rueckgabeform bleibt unveraendert.
+     *
      * @deprecated
+     *
+     * @return array{rides: array<string, Ride>, counter: array<string, int>}
      */
-    public function findRidesForGallery(?City $city = null): array
+    public function findRidesWithPhotoCounter(?City $city = null): array
     {
-        $builder = $this->createQueryBuilder('photo');
+        $builder = $this->getEntityManager()->createQueryBuilder();
 
         $builder
-            ->select('photo')
-            ->addSelect('ride')
-            ->addSelect('city')
-            ->addSelect('COUNT(photo)')
-            ->addSelect('featuredPhoto')
-            ->where($builder->expr()->eq('photo.deleted', 0));
-
-        if ($city) {
-            $builder
-                ->andWhere($builder->expr()->eq('photo.city', ':city'))
-                ->setParameter('city', $city);
-        }
-
-        $builder
-            ->join('photo.ride', 'ride')
-            ->join('ride.city', 'city')
-            ->leftJoin('ride.featuredPhoto', 'featuredPhoto')
-            ->orderBy('ride.dateTime', 'desc')
-            ->groupBy('ride');
-
-        $query = $builder->getQuery();
-        $result = $query->getResult();
-
-        $galleryResult = [];
-
-        foreach ($result as $row) {
-            $ride = $row[0]->getRide();
-            $counter = $row[1];
-
-            $key = $ride->getDateTime()->format('Y-m-d') . '_' . $ride->getId();
-
-            $galleryResult[$key]['ride'] = $ride;
-            $galleryResult[$key]['counter'] = $counter;
-        }
-
-        return $galleryResult;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function findRidesWithPhotoCounter(?City $city = null)
-    {
-        $builder = $this->createQueryBuilder('photo');
-
-        $builder
-            ->select('photo')
-            ->addSelect('COUNT(photo)')
+            ->select('ride.id AS rideId')
+            ->addSelect('COUNT(photo.id) AS photoCount')
+            ->from(Ride::class, 'ride')
+            ->innerJoin('ride.photos', 'photo')
             ->where($builder->expr()->eq('photo.deleted', ':deleted'))
             ->setParameter('deleted', false);
 
@@ -162,33 +182,23 @@ class PhotoRepository extends ServiceEntityRepository
         }
 
         $builder
-            ->groupBy('photo.ride')
-            ->join('photo.ride', 'ride')
-            ->orderBy('ride.dateTime', 'desc');
+            ->groupBy('ride.id')
+            ->addGroupBy('ride.dateTime')
+            ->orderBy('ride.dateTime', 'DESC');
 
-        $query = $builder->getQuery();
-        $result = $query->getResult();
+        $rides = [];
+        $counter = [];
 
-        $rides = array();
-        $counter = array();
-
-        /**
-         * @var Photo $photo
-         */
-        foreach ($result as $row) {
-            /**
-             * @var Ride $ride
-             */
-            $ride = $row[0]->getRide();
+        foreach ($this->ridesForCountedRows($builder->getQuery()->getResult()) as [$ride, $anzahl]) {
             $key = $ride->getDateTime()->format('Y-m-d') . '_' . $ride->getId();
 
             $rides[$key] = $ride;
-            $counter[$key] = $row[1];
+            $counter[$key] = $anzahl;
         }
 
         return [
             'rides' => $rides,
-            'counter' => $counter
+            'counter' => $counter,
         ];
     }
 

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -416,11 +416,17 @@ class RideRepository extends ServiceEntityRepository
     {
         $builder = $this->createQueryBuilder('r');
 
+        // Ein Ortsname kommt ueber die Jahre mit leicht abweichenden Koordinaten
+        // vor — auf der Produktion bis zu 18 Paare fuer denselben Ort. MySQL
+        // greift sich davon stillschweigend eines heraus, PostgreSQL lehnt die
+        // Abfrage ab, weil die Koordinaten weder gruppiert noch aggregiert sind.
+        // Der Mittelwert liefert statt einer beliebigen Zeile den Schwerpunkt
+        // aller erfassten Punkte und bleibt bei einer Zeile je Ortsname.
         $builder
             ->select([
                 'r.location',
-                'r.latitude',
-                'r.longitude'
+                'AVG(r.latitude) AS latitude',
+                'AVG(r.longitude) AS longitude'
             ])
             ->where($builder->expr()->eq('r.city', ':city'))
             ->andWhere($builder->expr()->isNotNull('r.location'))

--- a/templates/PhotoManagement/user_list.html.twig
+++ b/templates/PhotoManagement/user_list.html.twig
@@ -29,31 +29,31 @@
                     </thead>
                     <tbody>
                     {% for row in result %}
-                        {% set photo = row[0] %}
+                        {% set ride = row[0] %}
                         {% set counter = row[1] %}
                         <tr>
                             <td>
-                                {{ photo.ride.dateTime.format('d. m. Y') }}
+                                {{ ride.dateTime.format('d. m. Y') }}
                             </td>
                             <td>
-                                <a href="{{ object_path(photo.ride.city) }}">
-                                    {{ photo.ride.city.city }}
+                                <a href="{{ object_path(ride.city) }}">
+                                    {{ ride.city.city }}
                                 </a>
                             </td>
                             <td>
-                                <a href="{{ object_path(photo.ride) }}">
-                                    {{ photo.ride.title }}
+                                <a href="{{ object_path(ride) }}">
+                                    {{ ride.title }}
                                 </a>
                             </td>
                             <td>
-                                <a href="{{ object_path(photo.ride, 'caldera_criticalmass_photo_manage') }}">
+                                <a href="{{ object_path(ride, 'caldera_criticalmass_photo_manage') }}">
                                     {{ counter }}
                                 </a>
                             </td>
                             <td>
                                 <div class="btn-group" role="group" aria-label="...">
                                     <a class="btn btn-secondary btn-xs" title="Herunterladen"
-                                       href="{{ object_path(photo.ride, 'caldera_criticalmass_photo_manage') }}">
+                                       href="{{ object_path(ride, 'caldera_criticalmass_photo_manage') }}">
                                         <i class="far fa-images"></i>
                                     </a>
                                 </div>

--- a/tests/Repository/GroupedQueryPortabilityTest.php
+++ b/tests/Repository/GroupedQueryPortabilityTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\City;
+use App\Entity\Ride;
+use App\Entity\User;
+use App\Repository\CityRepository;
+use App\Repository\PhotoRepository;
+use App\Repository\RideRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Abfragen mit GROUP BY muessen auch unter strenger Auslegung durchgehen.
+ *
+ * MySQL erlaubt es normalerweise, Spalten auszuwaehlen, die weder gruppiert noch
+ * aggregiert sind, und sucht sich dann stillschweigend eine Zeile aus.
+ * PostgreSQL lehnt das ab. Diese Tests fahren dieselben Abfragen, die die
+ * Anwendung fahert — laeuft die Datenbank mit ONLY_FULL_GROUP_BY, gilt hier
+ * dieselbe Strenge wie unter PostgreSQL.
+ */
+class GroupedQueryPortabilityTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function photoRepository(): PhotoRepository
+    {
+        $repository = static::getContainer()->get(PhotoRepository::class);
+        self::assertInstanceOf(PhotoRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function anyCity(): City
+    {
+        $city = $this->entityManager->getRepository(City::class)->findOneBy([]);
+        self::assertInstanceOf(City::class, $city);
+
+        return $city;
+    }
+
+    private function anyUser(): User
+    {
+        $user = $this->entityManager->getRepository(User::class)->findOneBy([]);
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+
+    public function testRidesWithPhotoCounterByUserRuns(): void
+    {
+        $rows = $this->photoRepository()->findRidesWithPhotoCounterByUser($this->anyUser());
+
+        // Dass die Abfrage ueberhaupt durchlaeuft, ist hier die halbe Aussage:
+        // unter ONLY_FULL_GROUP_BY wuerde die alte Fassung mit einer Ausnahme
+        // abbrechen statt sich stillschweigend eine Zeile auszusuchen.
+        $zeitpunkte = [];
+
+        foreach ($rows as $row) {
+            self::assertInstanceOf(Ride::class, $row[0], 'Die erste Spalte ist die Tour, nicht mehr ein beliebiges Foto.');
+            self::assertGreaterThan(0, $row[1], 'Gezaehlt wird mindestens ein Foto je Zeile.');
+            $zeitpunkte[] = $row[0]->getDateTime()->getTimestamp();
+        }
+
+        $absteigend = $zeitpunkte;
+        rsort($absteigend);
+        self::assertSame($absteigend, $zeitpunkte, 'Die Sortierung nach Datum ueberlebt das Nachladen der Touren.');
+    }
+
+    public function testRidesWithPhotoCounterRuns(): void
+    {
+        $result = $this->photoRepository()->findRidesWithPhotoCounter($this->anyCity());
+
+        self::assertArrayHasKey('rides', $result);
+        self::assertArrayHasKey('counter', $result);
+        self::assertSame(array_keys($result['rides']), array_keys($result['counter']), 'Beide Teillisten sind gleich verschluesselt.');
+
+        foreach ($result['rides'] as $key => $ride) {
+            self::assertInstanceOf(Ride::class, $ride);
+            self::assertGreaterThan(0, $result['counter'][$key]);
+        }
+    }
+
+    public function testRidesWithPhotoCounterWithoutCityRuns(): void
+    {
+        $result = $this->photoRepository()->findRidesWithPhotoCounter();
+
+        self::assertArrayHasKey('rides', $result);
+        self::assertArrayHasKey('counter', $result);
+    }
+
+    public function testLocationsForCityReturnOneRowPerName(): void
+    {
+        $repository = static::getContainer()->get(RideRepository::class);
+        self::assertInstanceOf(RideRepository::class, $repository);
+
+        $rows = $repository->getLocationsForCity($this->anyCity());
+
+        $namen = array_column($rows, 'location');
+        self::assertSame(
+            count($namen),
+            count(array_unique($namen)),
+            'Je Ortsname genau eine Zeile — sonst waere aus dem Mittelwert nichts geworden.'
+        );
+
+        foreach ($rows as $row) {
+            self::assertArrayHasKey('latitude', $row);
+            self::assertArrayHasKey('longitude', $row);
+            if ($row['latitude'] !== null) {
+                self::assertIsNumeric($row['latitude']);
+                self::assertIsNumeric($row['longitude']);
+            }
+        }
+    }
+
+    /**
+     * Die Abfrage muss von der Entity ausgehen, die sie liefert. Eine verbundene
+     * Kennung ohne ihre Wurzel auszuwaehlen ist in DQL ein Fehler — genau daran
+     * ist am 4. September die Feed-Aufwaermung gescheitert.
+     */
+    public function testGroupedQueriesGroupByIdentifiers(): void
+    {
+        $builder = $this->entityManager->createQueryBuilder()
+            ->select('ride')
+            ->addSelect('COUNT(photo.id)')
+            ->from(Ride::class, 'ride')
+            ->innerJoin('ride.photos', 'photo')
+            ->groupBy('ride.id');
+
+        $sql = $builder->getQuery()->getSQL();
+
+        self::assertStringContainsString('GROUP BY', $sql);
+        self::assertMatchesRegularExpression('/GROUP BY [a-z0-9_]+\.id/i', $sql, 'Gruppiert wird ueber den Primaerschluessel.');
+    }
+
+    public function testCitySearchStillWorksAlongsideTheGroupedQueries(): void
+    {
+        $repository = static::getContainer()->get(CityRepository::class);
+        self::assertInstanceOf(CityRepository::class, $repository);
+
+        $treffer = $repository->searchByQuery('Hamburg');
+        $namen = array_map(static fn (City $city): string => (string) $city->getCity(), $treffer);
+
+        self::assertContains('Hamburg', $namen);
+    }
+}


### PR DESCRIPTION
## Summary

Zweiter Punkt der **Phase 2** (Portabilität). MySQL lässt Abfragen zu, die Spalten auswählen, die weder gruppiert noch aggregiert sind, und sucht sich stillschweigend eine Zeile aus. **PostgreSQL lehnt das ab.** Vier Abfragen haben sich darauf verlassen.

**Drei davon wählten ein beliebiges Foto der Gruppe aus, nur um an dessen Tour zu kommen** — was zusätzlich für sich genommen schon ein DQL-Fehler ist: Eine verbundene Kennung ohne ihre Wurzel auszuwählen ist genau das, woran heute die Feed-Aufwärmung gescheitert ist (`Cannot select entity through identification variables without choosing at least one root entity alias`). Sie gehen jetzt von `Ride` aus, gruppieren nur über die Kennung und laden die Touren in einer zweiten Abfrage nach — eine Anweisung mehr, dafür unter jeder Auslegung gültig und ohne N+1.

**Die vierte, `getLocationsForCity`,** nahm ein beliebiges Koordinatenpaar je Ortsname. Auf der Produktion trägt ein Name **bis zu 18 verschiedene Paare** („Hofgarten" in Bonn) — die Auswahl war also nie aussagekräftig. Der Mittelwert liefert den Schwerpunkt der erfassten Punkte und bleibt bei einer Zeile je Name.

`findRidesForGallery` hatte **keine Aufrufer** und war bereits als veraltet markiert — gelöscht statt portiert.

## Verhaltensänderungen

| Was | Vorher | Jetzt |
|---|---|---|
| `findRidesWithPhotoCounterByUser` | Zeilen `[Photo, Anzahl]` | Zeilen `[Ride, Anzahl]` — das Template nutzte das Foto ohnehin nur als Umweg zur Tour (`photo.ride.…`), es ist entsprechend angepasst |
| `getLocationsForCity` | beliebiges Koordinatenpaar | Mittelwert aller Paare des Ortsnamens |
| `findRidesWithPhotoCounter` | — | Rückgabeform unverändert, Template unberührt |

## Wie das geprüft ist

Die Tests laufen gegen **MariaDB mit `ONLY_FULL_GROUP_BY`**. Das ist die entscheidende Zutat: Damit gilt hier und jetzt dieselbe Strenge wie unter PostgreSQL — sogar eine schärfere, denn **MariaDB erkennt keine funktionale Abhängigkeit vom Primärschlüssel**, PostgreSQL schon. Ein erster Entwurf, der nur nach `ride.id` gruppierte und die ganze Entity auswählte, wäre unter PostgreSQL gültig gewesen, ist hier aber durchgefallen (`'r0_.slug' isn't in GROUP BY`) — und ist deshalb nochmals umgebaut worden.

**Die volle Suite läuft unter dieser Einstellung durch.** In den getesteten Pfaden verlässt sich also nichts mehr auf die lockere Auslegung.

## Test Plan

- Neue `tests/Repository/GroupedQueryPortabilityTest.php`, 6 Tests, gegen `ONLY_FULL_GROUP_BY`.
- Volle Suite gegen dieselbe Datenbank: **1483 Tests grün**.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler; vier Baseline-Einträge sind durch die neuen Typangaben und die gelöschte Methode hinfällig geworden und entfernt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR