### PR TITLE
Emit standard SQL from the custom DQL functions

### DIFF
--- a/src/DQL/DateFunction.php
+++ b/src/DQL/DateFunction.php
@@ -12,9 +12,13 @@ class DateFunction extends FunctionNode
 {
     private Node|string|null $arg = null;
 
+    /**
+     * CAST gehoert zum SQL-Standard; die Funktion DATE() gibt es in
+     * PostgreSQL nicht.
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf('DATE(%s)', $this->arg->dispatch($sqlWalker));
+        return sprintf('CAST(%s AS DATE)', $this->arg->dispatch($sqlWalker));
     }
 
     public function parse(Parser $parser): void

--- a/src/DQL/DayFunction.php
+++ b/src/DQL/DayFunction.php
@@ -12,9 +12,12 @@ class DayFunction extends FunctionNode
 {
     private Node|string|null $arg = null;
 
+    /**
+     * EXTRACT gehoert zum SQL-Standard; DAY() kennt nur MySQL.
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf('DAY(%s)', $this->arg->dispatch($sqlWalker));
+        return sprintf('EXTRACT(DAY FROM %s)', $this->arg->dispatch($sqlWalker));
     }
 
     public function parse(Parser $parser): void

--- a/src/DQL/DayOfWeekFunction.php
+++ b/src/DQL/DayOfWeekFunction.php
@@ -10,11 +10,27 @@ use Doctrine\ORM\Query\TokenType;
 
 class DayOfWeekFunction extends FunctionNode
 {
+    use PlatformAware;
+
     private Node|string|null $arg = null;
 
+    /**
+     * Die zweite Funktion ohne Entsprechung im SQL-Standard — und die einzige,
+     * bei der nicht nur der Name abweicht, sondern die Zaehlung: MySQLs
+     * DAYOFWEEK() liefert 1 bis 7 mit Sonntag als 1, PostgreSQLs
+     * EXTRACT(DOW ...) liefert 0 bis 6 mit Sonntag als 0. Ohne das +1 waere
+     * jeder Wochentag um eins verschoben, ohne dass irgendetwas danach
+     * auffiele.
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf('DAYOFWEEK(%s)', $this->arg->dispatch($sqlWalker));
+        $arg = $this->arg->dispatch($sqlWalker);
+
+        if ($this->isPostgreSql($sqlWalker)) {
+            return sprintf('(EXTRACT(DOW FROM %s) + 1)', $arg);
+        }
+
+        return sprintf('DAYOFWEEK(%s)', $arg);
     }
 
     public function parse(Parser $parser): void

--- a/src/DQL/MonthFunction.php
+++ b/src/DQL/MonthFunction.php
@@ -12,9 +12,12 @@ class MonthFunction extends FunctionNode
 {
     private Node|string|null $arg = null;
 
+    /**
+     * EXTRACT gehoert zum SQL-Standard; MONTH() kennt nur MySQL.
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf('MONTH(%s)', $this->arg->dispatch($sqlWalker));
+        return sprintf('EXTRACT(MONTH FROM %s)', $this->arg->dispatch($sqlWalker));
     }
 
     public function parse(Parser $parser): void

--- a/src/DQL/PlatformAware.php
+++ b/src/DQL/PlatformAware.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace App\DQL;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\Query\SqlWalker;
+
+/**
+ * Fuer die beiden DQL-Funktionen, die sich nicht in Standard-SQL ausdruecken
+ * lassen und deshalb wissen muessen, gegen welche Datenbank sie laufen.
+ *
+ * Die uebrigen brauchen das nicht: EXTRACT und CAST beherrschen MySQL und
+ * PostgreSQL gleichermassen.
+ */
+trait PlatformAware
+{
+    protected function isPostgreSql(SqlWalker $sqlWalker): bool
+    {
+        return $sqlWalker->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform;
+    }
+}

--- a/src/DQL/RandFunction.php
+++ b/src/DQL/RandFunction.php
@@ -9,9 +9,15 @@ use Doctrine\ORM\Query\TokenType;
 
 class RandFunction extends FunctionNode
 {
+    use PlatformAware;
+
+    /**
+     * Eine der beiden Funktionen ohne Entsprechung im SQL-Standard: MySQL
+     * schreibt RAND(), PostgreSQL RANDOM().
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return 'RAND()';
+        return $this->isPostgreSql($sqlWalker) ? 'RANDOM()' : 'RAND()';
     }
 
     public function parse(Parser $parser): void

--- a/src/DQL/YearFunction.php
+++ b/src/DQL/YearFunction.php
@@ -12,9 +12,13 @@ class YearFunction extends FunctionNode
 {
     private Node|string|null $arg = null;
 
+    /**
+     * EXTRACT gehoert zum SQL-Standard und wird von MySQL wie von
+     * PostgreSQL verstanden; YEAR() kennt nur MySQL.
+     */
     public function getSql(SqlWalker $sqlWalker): string
     {
-        return sprintf('YEAR(%s)', $this->arg->dispatch($sqlWalker));
+        return sprintf('EXTRACT(YEAR FROM %s)', $this->arg->dispatch($sqlWalker));
     }
 
     public function parse(Parser $parser): void

--- a/tests/DQL/PortableFunctionsTest.php
+++ b/tests/DQL/PortableFunctionsTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace Tests\DQL;
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Die eigenen DQL-Funktionen muessen auf MySQL und auf PostgreSQL gueltiges SQL
+ * erzeugen.
+ *
+ * Beide Zweige lassen sich hier wirklich pruefen, ohne dass ein PostgreSQL
+ * laeuft: DBAL bestimmt die Plattform aus der angegebenen serverVersion, und
+ * getSQL() erzeugt die Anweisung, ohne sie auszufuehren.
+ */
+class PortableFunctionsTest extends KernelTestCase
+{
+    private EntityManagerInterface $mysql;
+    private EntityManagerInterface $postgres;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->mysql = static::getContainer()->get('doctrine')->getManager();
+
+        // Zweiter Manager auf derselben Zuordnung, aber mit PostgreSQL-Plattform.
+        // Es wird nie eine Verbindung aufgebaut.
+        $this->postgres = new EntityManager(
+            DriverManager::getConnection([
+                'driver' => 'pdo_pgsql',
+                'serverVersion' => '17',
+                'host' => 'localhost',
+                'dbname' => 'unbenutzt',
+                'user' => 'unbenutzt',
+                'password' => 'unbenutzt',
+            ]),
+            $this->mysql->getConfiguration()
+        );
+    }
+
+    private function sql(EntityManagerInterface $manager, string $dql): string
+    {
+        return $manager->createQuery($dql)->getSQL();
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function standardFunktionen(): array
+    {
+        return [
+            'YEAR'  => ['SELECT r FROM App\Entity\Ride r WHERE YEAR(r.dateTime) = 2026', 'EXTRACT(YEAR FROM'],
+            'MONTH' => ['SELECT r FROM App\Entity\Ride r WHERE MONTH(r.dateTime) = 9', 'EXTRACT(MONTH FROM'],
+            'DAY'   => ['SELECT r FROM App\Entity\Ride r WHERE DAY(r.dateTime) = 4', 'EXTRACT(DAY FROM'],
+            'DATE'  => ['SELECT r FROM App\Entity\Ride r WHERE DATE(r.dateTime) = CURRENT_DATE()', 'CAST('],
+        ];
+    }
+
+    /**
+     * Vier der sechs Funktionen brauchen gar keine Fallunterscheidung: EXTRACT
+     * und CAST gehoeren zum SQL-Standard und gelten auf beiden Plattformen
+     * gleichermassen.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('standardFunktionen')]
+    public function testStandardFunctionsAreIdenticalOnBothPlatforms(string $dql, string $erwartet): void
+    {
+        $aufMysql = $this->sql($this->mysql, $dql);
+        $aufPostgres = $this->sql($this->postgres, $dql);
+
+        self::assertStringContainsString($erwartet, $aufMysql);
+        self::assertStringContainsString($erwartet, $aufPostgres);
+    }
+
+    public function testRandUsesTheNameEachPlatformKnows(): void
+    {
+        $dql = 'SELECT r FROM App\Entity\Ride r ORDER BY RAND() ASC';
+
+        self::assertStringContainsString('RAND()', $this->sql($this->mysql, $dql));
+
+        $aufPostgres = $this->sql($this->postgres, $dql);
+        self::assertStringContainsString('RANDOM()', $aufPostgres);
+        self::assertStringNotContainsString('RAND()', $aufPostgres);
+    }
+
+    /**
+     * Hier weicht nicht nur der Name ab, sondern die Zaehlung: MySQL zaehlt den
+     * Sonntag als 1, PostgreSQL als 0. Das +1 gleicht das aus — fehlte es,
+     * waere jeder Wochentag um eins verschoben, ohne dass etwas auffiele.
+     */
+    public function testDayOfWeekKeepsTheSameNumbering(): void
+    {
+        $dql = 'SELECT r FROM App\Entity\Ride r WHERE DAYOFWEEK(r.dateTime) = 1';
+
+        self::assertStringContainsString('DAYOFWEEK(', $this->sql($this->mysql, $dql));
+
+        $aufPostgres = $this->sql($this->postgres, $dql);
+        self::assertStringContainsString('EXTRACT(DOW FROM', $aufPostgres);
+        self::assertStringContainsString('+ 1', $aufPostgres);
+    }
+
+    /**
+     * Die Mathematikfunktionen aus beberlei/doctrineextensions liegen im
+     * Namensraum \Mysql\, erzeugen aber Standard-SQL. Issue #1135 verlangt,
+     * sie zu entfernen — fuer die Portabilitaet ist das nicht noetig.
+     */
+    public function testBorrowedMathFunctionsAreAlreadyPortable(): void
+    {
+        $dql = 'SELECT r FROM App\Entity\Ride r WHERE COS(RADIANS(r.latitude)) > 0';
+
+        foreach ([$this->mysql, $this->postgres] as $manager) {
+            $sql = $this->sql($manager, $dql);
+            self::assertStringContainsString('COS(', $sql);
+            self::assertStringContainsString('RADIANS(', $sql);
+        }
+    }
+
+    public function testTheRepositoryQueriesThatUseThemStillRun(): void
+    {
+        $repository = static::getContainer()->get(\App\Repository\RideRepository::class);
+        self::assertInstanceOf(\App\Repository\RideRepository::class, $repository);
+
+        // findRecentRides filtert ueber MONTH() und YEAR().
+        $rides = $repository->findRecentRides(2026, 9, 5);
+
+        self::assertLessThanOrEqual(5, count($rides));
+    }
+}


### PR DESCRIPTION
## Summary

Dritter Punkt der **Phase 2** (Portabilität): die sechs eigenen DQL-Funktionen in `src/DQL/`.

**Vier brauchten gar keine Fallunterscheidung.** `EXTRACT` und `CAST` gehören zum SQL-Standard und gelten auf beiden Plattformen — `YEAR()`, `MONTH()`, `DAY()` und `DATE()` sind dagegen MySQL-Schreibweisen. Sie erzeugen jetzt die Standardform, also identisches SQL überall:

| Funktion | vorher | jetzt |
|---|---|---|
| `YEAR(x)` | `YEAR(x)` | `EXTRACT(YEAR FROM x)` |
| `MONTH(x)` | `MONTH(x)` | `EXTRACT(MONTH FROM x)` |
| `DAY(x)` | `DAY(x)` | `EXTRACT(DAY FROM x)` |
| `DATE(x)` | `DATE(x)` | `CAST(x AS DATE)` |

**Zwei haben keine Entsprechung im Standard** und fragen die Plattform: `RAND()` heißt in PostgreSQL `RANDOM()`, und `DAYOFWEEK` ist der Fall, der still schiefgegangen wäre — **MySQL zählt den Sonntag als 1, PostgreSQLs `EXTRACT(DOW …)` als 0.** Ohne das `+1` wäre jeder Wochentag um eins verschoben gewesen, ohne dass irgendetwas danach auffiele.

## Beide Zweige sind wirklich geprüft

Das ist hier der Kniff: DBAL bestimmt die Plattform aus der angegebenen `serverVersion`, und `getSQL()` erzeugt die Anweisung, **ohne sie auszuführen**. Ein zweiter EntityManager auf derselben Zuordnung, aber mit `pdo_pgsql` und `serverVersion: 17`, baut also echtes PostgreSQL-SQL — ohne dass ein PostgreSQL läuft.

Anders als bei den `LIKE`-Stellen (#1509) ist der PostgreSQL-Pfad damit nicht bloß behauptet, sondern belegt. Gegenprobe: Mit zurückgedrehten Änderungen fallen **sechs von acht** Tests um, genau die sechs Funktionstests.

## Korrektur zu Issue #1135

Dort steht, `beberlei/doctrineextensions` Math-Funktionen müssten entfernt werden. **Für die Portabilität stimmt das nicht:** Sie liegen zwar im Namensraum `\Mysql\`, erzeugen aber `COS`, `SIN`, `RADIANS`, `POWER` und `ASIN` — schlichtes Standard-SQL, das PostgreSQL genauso kennt. Ein Test hält das fest. Ersetzt werden sie erst durch #1141, und dann aus einem anderen Grund (PostGIS statt Haversine).

## Test Plan

- Neue `tests/DQL/PortableFunctionsTest.php`, 8 Tests, beide Plattformen.
- Gegenprobe: 6 Fehlschläge mit zurückgedrehten Änderungen.
- Volle Suite gegen eine Wegwerf-MariaDB: **1502 Tests grün**.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR