### PR TITLE
Make the application run on PostgreSQL as well as MySQL

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,13 +7,11 @@ parameters:
 
 doctrine:
     dbal:
-        # configure these for your database server
-        driver: 'pdo_mysql'
-        charset: utf8mb4
-        default_table_options:
-            charset: utf8mb4
-            collate: utf8mb4_unicode_ci
-        server_version: 'mariadb-10.9.3'
+        # Treiber, Zeichensatz und Serverversion stehen im DSN, nicht hier.
+        # Standen sie hier, wuerde diese Datei die Plattform festlegen und ein
+        # PostgreSQL-DSN liefe trotzdem gegen die MySQL-Plattform. Zeichensatz
+        # und Kollation waren ohnehin MySQL-eigen; DBAL setzt fuer MySQL von
+        # sich aus utf8mb4.
         url: '%env(resolve:DATABASE_URL)%'
 
         types:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,12 +7,10 @@ parameters:
     locale: de
     secret: '%env(APP_SECRET)%'
     kernel.secret: '%env(APP_SECRET)%'
-    database_driver: pdo_mysql
-    database_host: 127.0.0.1
-    database_port: null
-    database_name: '%env(DATABASE_NAME)%'
-    database_user: '%env(DATABASE_USER)%'
-    database_password: '%env(DATABASE_PASSWORD)%'
+    # Die frueheren database_*-Parameter sind entfallen: Sie wurden nirgends
+    # gelesen, verlangten aber Umgebungsvariablen, die es nicht gibt, und
+    # nannten mit pdo_mysql eine Plattform, die so nicht mehr feststeht.
+    # Die Verbindung kommt allein aus DATABASE_URL.
     track.gap_width: 10
     strava.client_id: '%env(STRAVA_CLIENT_ID)%'
     strava.token: '%env(STRAVA_TOKEN)%'

--- a/src/Criticalmass/DataQuery/Query/CityNameQuery.php
+++ b/src/Criticalmass/DataQuery/Query/CityNameQuery.php
@@ -46,15 +46,18 @@ class CityNameQuery extends AbstractQuery implements OrmQueryInterface, ElasticQ
         if (Ride::class === $this->entityFqcn) {
             $queryBuilder
                 ->join(sprintf('%s.city', $alias), 'c')
-                ->andWhere($queryBuilder->expr()->eq('c.city', ':city'))
+                ->andWhere($queryBuilder->expr()->eq('LOWER(c.city)', ':city'))
             ;
         }
 
         if (City::class === $this->entityFqcn) {
-            $queryBuilder->andWhere($queryBuilder->expr()->eq(sprintf('%s.city', $alias), ':city'));
+            $queryBuilder->andWhere($queryBuilder->expr()->eq(sprintf('LOWER(%s.city)', $alias), ':city'));
         }
 
-        $queryBuilder->setParameter('city', $this->name);
+        // Beide Seiten kleingeschrieben: MySQL vergleicht auch Gleichheit auf
+        // Text schreibungsblind, PostgreSQL nicht. Ohne das faende die
+        // API-Abfrage ?name=hamburg die Stadt "Hamburg" nicht mehr.
+        $queryBuilder->setParameter('city', mb_strtolower($this->name));
 
         return $queryBuilder;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -30,7 +30,13 @@ class User implements SocialNetworkProfileAble, RouteableInterface, PhotoInterfa
     #[Groups(['timelapse', 'post-list'])]
     protected ?int $id = null;
 
-    #[ORM\Column(type: 'json', nullable: true)]
+    /**
+     * jsonb statt json: PostgreSQL kennt fuer den Typ json keinen
+     * Gleichheitsoperator, weshalb dort schon ein schlichtes SELECT DISTINCT
+     * ueber diese Tabelle scheitert — etwa beim Ermitteln der Abonnenten eines
+     * Themas. jsonb hat einen. Unter MySQL bleibt die Angabe folgenlos.
+     */
+    #[ORM\Column(type: 'json', nullable: true, options: ['jsonb' => true])]
     #[Ignore]
     private ?array $roles = [];
 

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -327,7 +327,7 @@ class CityRepository extends ServiceEntityRepository
         $sql = <<<SQL
 SELECT c.*
 FROM city c
-WHERE c.enabled = 1
+WHERE c.enabled = true
   AND c.id != :id
   AND (6371 * acos(
            cos(radians(:lat)) * cos(radians(c.latitude)) * cos(radians(c.longitude) - radians(:lon)) +

--- a/src/Repository/ParticipationRepository.php
+++ b/src/Repository/ParticipationRepository.php
@@ -79,7 +79,11 @@ class ParticipationRepository extends ServiceEntityRepository
             ->select('COUNT(p)')
             ->where($builder->expr()->eq('p.user', ':user'))
             ->setParameter('user', $user)
-            ->andWhere($builder->expr()->eq('p.goingYes', true));
+            // Als Parameter binden, nicht als Literal: Doctrine schreibt ein
+            // literales true in DQL als 1, und PostgreSQL kennt keinen
+            // Vergleich zwischen boolean und integer.
+            ->andWhere($builder->expr()->eq('p.goingYes', ':goingYes'))
+            ->setParameter('goingYes', true);
 
         $query = $builder->getQuery();
 

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -743,7 +743,10 @@ class RideRepository extends ServiceEntityRepository
 
         $rsm->addEntityResult(Ride::class, 'r');
         $rsm->addFieldResult('r', 'id', 'id');
-        $rsm->addFieldResult('r', 'dateTime', 'dateTime');
+        // Durchgehend kleingeschriebene Aliase: PostgreSQL faltet unquotierte
+        // Bezeichner auf Kleinschreibung, ein "r.dateTime" waere dort also
+        // "r.datetime" und existierte nicht.
+        $rsm->addFieldResult('r', 'ride_date_time', 'dateTime');
         $rsm->addFieldResult('r', 'latitude', 'latitude');
         $rsm->addFieldResult('r', 'longitude', 'longitude');
         $rsm->addFieldResult('r', 'title', 'title');
@@ -755,29 +758,39 @@ class RideRepository extends ServiceEntityRepository
         $rsm->addFieldResult('cs', 'cs_id', 'id');
         $rsm->addFieldResult('cs', 'cs_slug', 'slug');
 
+        // Der Spaltenname traegt Grossbuchstaben und muss deshalb gequotet
+        // werden — auf jeder Plattform anders.
+        $dateTimeSpalte = $this->getEntityManager()->getConnection()
+            ->getDatabasePlatform()->quoteSingleIdentifier('dateTime');
+
+        // Die Entfernung steht in einer Unterabfrage, damit sich danach im WHERE
+        // darauf filtern laesst. Vorher stand hier ein HAVING ohne GROUP BY, das
+        // sich auf einen Alias der Auswahl bezog: MySQL laesst beides durchgehen,
+        // PostgreSQL keines von beidem.
         $sql = <<<SQL
-SELECT 
-    r.id,
-    r.dateTime,
-    r.latitude,
-    r.longitude,
-    r.title,
-    r.city_id,
-    c.id AS c_id,
-    cs.id AS cs_id,
-    cs.slug AS cs_slug,
-    (
-        $earthRadius * acos(
-            cos(radians(:latitude)) * cos(radians(r.latitude)) *
-            cos(radians(r.longitude) - radians(:longitude)) +
-            sin(radians(:latitude)) * sin(radians(r.latitude))
-        )
-    ) AS distance
-FROM ride r
-INNER JOIN city c ON r.city_id = c.id
-INNER JOIN cityslug cs ON cs.id = c.main_slug_id
-HAVING distance <= :radius
-ORDER BY r.dateTime DESC
+SELECT * FROM (
+    SELECT
+        r.id,
+        r.$dateTimeSpalte AS ride_date_time,
+        r.latitude,
+        r.longitude,
+        r.title,
+        c.id AS c_id,
+        cs.id AS cs_id,
+        cs.slug AS cs_slug,
+        (
+            $earthRadius * acos(
+                cos(radians(:latitude)) * cos(radians(r.latitude)) *
+                cos(radians(r.longitude) - radians(:longitude)) +
+                sin(radians(:latitude)) * sin(radians(r.latitude))
+            )
+        ) AS distance
+    FROM ride r
+    INNER JOIN city c ON r.city_id = c.id
+    INNER JOIN cityslug cs ON cs.id = c.main_slug_id
+) naehe
+WHERE naehe.distance <= :radius
+ORDER BY naehe.ride_date_time DESC
 LIMIT :limit
 SQL;
 

--- a/tests/Controller/Api/PhotoApi/PhotoApiQueryTest.php
+++ b/tests/Controller/Api/PhotoApi/PhotoApiQueryTest.php
@@ -10,7 +10,7 @@ class PhotoApiQueryTest extends AbstractApiControllerTestCase
     public function testDefaultListExcludesDeletedPhotos(): void
     {
         $conn = $this->entityManager->getConnection();
-        $deletedRows = $conn->fetchAllAssociative('SELECT id FROM photo WHERE deleted = 1');
+        $deletedRows = $conn->fetchAllAssociative('SELECT id FROM photo WHERE deleted = true');
         $this->assertNotEmpty($deletedRows, 'Fixtures must include at least one deleted photo');
         $deletedIds = array_map(fn(array $row) => (int) $row['id'], $deletedRows);
 
@@ -31,7 +31,7 @@ class PhotoApiQueryTest extends AbstractApiControllerTestCase
     public function testDefaultListExcludesDisabledPhotos(): void
     {
         $conn = $this->entityManager->getConnection();
-        $disabledRows = $conn->fetchAllAssociative('SELECT id FROM photo WHERE enabled = 0');
+        $disabledRows = $conn->fetchAllAssociative('SELECT id FROM photo WHERE enabled = false');
         $this->assertNotEmpty($disabledRows, 'Fixtures must include at least one disabled photo');
         $disabledIds = array_map(fn(array $row) => (int) $row['id'], $disabledRows);
 
@@ -73,7 +73,7 @@ class PhotoApiQueryTest extends AbstractApiControllerTestCase
 
         $conn = $this->entityManager->getConnection();
         $hamburgPhotoIds = $conn->fetchFirstColumn(
-            'SELECT p.id FROM photo p JOIN city c ON p.city_id = c.id JOIN cityslug cs ON c.main_slug_id = cs.id WHERE cs.slug = :slug AND p.enabled = 1 AND p.deleted = 0',
+            'SELECT p.id FROM photo p JOIN city c ON p.city_id = c.id JOIN cityslug cs ON c.main_slug_id = cs.id WHERE cs.slug = :slug AND p.enabled = true AND p.deleted = false',
             ['slug' => 'hamburg']
         );
         $hamburgPhotoIds = array_map('intval', $hamburgPhotoIds);

--- a/tests/Controller/Api/TrackApi/TrackApiQueryTest.php
+++ b/tests/Controller/Api/TrackApi/TrackApiQueryTest.php
@@ -12,7 +12,7 @@ class TrackApiQueryTest extends AbstractApiControllerTestCase
     {
         // Query directly via DBAL to bypass any Doctrine filters
         $conn = $this->entityManager->getConnection();
-        $deletedRows = $conn->fetchAllAssociative('SELECT id FROM track WHERE deleted = 1');
+        $deletedRows = $conn->fetchAllAssociative('SELECT id FROM track WHERE deleted = true');
         $this->assertNotEmpty($deletedRows, 'Fixtures must include at least one deleted track');
         $deletedIds = array_map(fn(array $row) => (int) $row['id'], $deletedRows);
 
@@ -34,7 +34,7 @@ class TrackApiQueryTest extends AbstractApiControllerTestCase
     {
         // Query directly via DBAL to bypass any Doctrine filters
         $conn = $this->entityManager->getConnection();
-        $disabledRows = $conn->fetchAllAssociative('SELECT id FROM track WHERE enabled = 0');
+        $disabledRows = $conn->fetchAllAssociative('SELECT id FROM track WHERE enabled = false');
         $this->assertNotEmpty($disabledRows, 'Fixtures must include at least one disabled track');
         $disabledIds = array_map(fn(array $row) => (int) $row['id'], $disabledRows);
 

--- a/tests/Controller/TrackUploadControllerTest.php
+++ b/tests/Controller/TrackUploadControllerTest.php
@@ -140,6 +140,12 @@ class TrackUploadControllerTest extends AbstractControllerTestCase
             ->where('t.ride = :rideId')
             ->setParameter('rideId', $rideId)
             ->orderBy('t.creationDateTime', 'DESC')
+            // Zwei Uploads im selben Test fallen in dieselbe Sekunde, der
+            // Zeitstempel allein entscheidet dann nichts. Ohne einen zweiten,
+            // eindeutigen Schluessel liefert die Datenbank irgendeine der
+            // gleichrangigen Zeilen — MySQL zufaellig die erwartete,
+            // PostgreSQL die andere.
+            ->addOrderBy('t.id', 'DESC')
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();

--- a/tests/DQL/PortableFunctionsTest.php
+++ b/tests/DQL/PortableFunctionsTest.php
@@ -3,6 +3,7 @@
 namespace Tests\DQL;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -24,20 +25,33 @@ class PortableFunctionsTest extends KernelTestCase
     {
         self::bootKernel();
 
-        $this->mysql = static::getContainer()->get('doctrine')->getManager();
+        // Beide Manager werden ausdruecklich aufgebaut, statt den vorhandenen
+        // fuer MySQL zu halten: Laeuft die Testsuite selbst schon gegen
+        // PostgreSQL, waere diese Annahme falsch und der Test pruefte zweimal
+        // dieselbe Plattform.
+        $konfiguration = static::getContainer()->get('doctrine')->getManager()->getConfiguration();
 
-        // Zweiter Manager auf derselben Zuordnung, aber mit PostgreSQL-Plattform.
-        // Es wird nie eine Verbindung aufgebaut.
-        $this->postgres = new EntityManager(
+        $this->mysql = $this->managerFor('pdo_mysql', 'mariadb-10.9.3', $konfiguration);
+        $this->postgres = $this->managerFor('pdo_pgsql', '17', $konfiguration);
+    }
+
+    /**
+     * Der Manager baut nie eine Verbindung auf: DBAL bestimmt die Plattform aus
+     * der serverVersion, und getSQL() erzeugt die Anweisung, ohne sie
+     * auszufuehren.
+     */
+    private function managerFor(string $treiber, string $version, Configuration $konfiguration): EntityManagerInterface
+    {
+        return new EntityManager(
             DriverManager::getConnection([
-                'driver' => 'pdo_pgsql',
-                'serverVersion' => '17',
+                'driver' => $treiber,
+                'serverVersion' => $version,
                 'host' => 'localhost',
                 'dbname' => 'unbenutzt',
                 'user' => 'unbenutzt',
                 'password' => 'unbenutzt',
             ]),
-            $this->mysql->getConfiguration()
+            $konfiguration
         );
     }
 


### PR DESCRIPTION
## Summary

**Phase 3.** Die Anwendung läuft jetzt auf beiden Plattformen: **1502 Tests gegen PostgreSQL 17** und dieselben **1502 gegen MariaDB 10.9**.

Die Konfiguration nennt keine Plattform mehr. `driver`, `charset` und `server_version` standen in `doctrine.yaml` und hätten alles auf MySQL festgenagelt, ganz gleich was im DSN steht — sie gehören ins DSN. Zeichensatz und Kollation waren MySQL-eigen, und DBAL setzt dort von sich aus `utf8mb4` (nachgeprüft: die erzeugten Tabellen behalten `utf8mb4_unicode_ci`). Die unbenutzten `database_*`-Parameter fallen mit weg.

## Vier Fehler, die MySQL verdeckt hatte

Alle vier kamen erst beim **Laufenlassen** heraus, nicht beim Lesen:

| Was | Warum es unter MySQL nicht auffiel |
|---|---|
| `user.roles` ist jetzt **jsonb** | PostgreSQL kennt für `json` keinen Gleichheitsoperator — schon ein schlichtes `SELECT DISTINCT` über die Nutzertabelle scheitert. Genau so sucht das Forum die Abonnenten eines Themas. |
| Die zwei nativen Haversine-Abfragen | Verglichen `boolean = 1`, schrieben eine camelCase-Spalte unquotiert (PostgreSQL faltet auf Kleinschreibung) und filterten in einem `HAVING` ohne `GROUP BY` über einen Auswahl-Alias. Die Entfernung steht jetzt in einer Unterabfrage und lässt sich im `WHERE` filtern. |
| `ParticipationRepository` | Übergab ein literales `true`, das Doctrine als `1` schreibt. |
| `CityNameQuery` | Verglich mit `=`. **MySQLs Kollation macht auch Gleichheit schreibungsblind, PostgreSQL nicht** — `?name=hamburg` fand „Hamburg" nicht mehr. |

Der letzte Punkt ist der wichtigste: **Gleichheit auf Text ist dieselbe Falle wie `LIKE`**, und mein Audit für #1509 hatte nur nach `LIKE` gesucht. Siehe die offene Frage unten.

## Zwei Testfehler

Rohes SQL in den API-Tests verglich Booleans mit `0`/`1`. Und ein Helfer sortierte nach einem Zeitstempel, den sich zwei Uploads derselben Sekunde teilen — welche Zeile zurückkam, war damit **nie entschieden**; MySQL lieferte zufällig die erwartete, PostgreSQL die andere. Jetzt entscheidet die Kennung als zweiter Schlüssel.

## Was noch offen ist — und eine Entscheidung braucht

**Die Anmeldung sucht den Nutzer über einen exakten Textvergleich** (`UserProvider::loadUserByIdentifier` → `findUser(['username' => …])`). Unter PostgreSQL wird daraus ein schreibungsempfindlicher Vergleich: Wer sich mit anderer Groß-/Kleinschreibung anmeldet als gespeichert, käme nicht mehr hinein.

Die Produktivdaten dazu:

| | Anzahl |
|---|---|
| Konten | 21.140 |
| Benutzernamen mit Großbuchstaben | **3.981** |
| Adressen mit Großbuchstaben | **377** |
| Benutzernamen, die nur in der Schreibung kollidieren | **0** |
| Adressen, die nur in der Schreibung kollidieren | **0** |
| Stadt-Slugs mit Großbuchstaben | 0 von 5.853 |

Weil es **keine Kollisionen** gibt, wäre ein schreibungsblinder Vergleich gefahrlos — er kann keine zwei Konten zusammenführen. Ich habe ihn trotzdem **nicht** eingebaut: Eine Änderung an der Anmeldung gehört nicht beiläufig in einen Portabilitäts-PR.

## Test Plan

- Volle Suite gegen **PostgreSQL 17** (Docker): 1502 Tests grün.
- Volle Suite gegen **MariaDB 10.9**: dieselben 1502 grün.
- `doctrine:schema:create` auf beiden, danach `schema:update --dump-sql` = deckungsgleich.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler.

Noch **nicht** enthalten: `jsor/doctrine-postgis`, `CREATE EXTENSION postgis` und der Schema-Filter — die gehören zur Geometrie (Phase 4). Das PostGIS-Image hat kein arm64-Manifest, die Prüfung lief deshalb gegen reines PostgreSQL 17; für Phase 3 ohne Geometrie ist das die richtige Trennung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR