### PR TITLE
Stop quoting a column name PostgreSQL folds anyway

### DIFF
--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -758,11 +758,11 @@ class RideRepository extends ServiceEntityRepository
         $rsm->addFieldResult('cs', 'cs_id', 'id');
         $rsm->addFieldResult('cs', 'cs_slug', 'slug');
 
-        // Der Spaltenname traegt Grossbuchstaben und muss deshalb gequotet
-        // werden — auf jeder Plattform anders.
-        $dateTimeSpalte = $this->getEntityManager()->getConnection()
-            ->getDatabasePlatform()->quoteSingleIdentifier('dateTime');
-
+        // Der Spaltenname bleibt unquotiert. Doctrine legt die Spalte selbst
+        // unquotiert an, PostgreSQL faltet sie also auf "datetime" — und
+        // dieselbe Faltung trifft die Abfrage. Ein "dateTime" in
+        // Anfuehrungszeichen wuerde dort dagegen ins Leere greifen.
+        //
         // Die Entfernung steht in einer Unterabfrage, damit sich danach im WHERE
         // darauf filtern laesst. Vorher stand hier ein HAVING ohne GROUP BY, das
         // sich auf einen Alias der Auswahl bezog: MySQL laesst beides durchgehen,
@@ -771,7 +771,7 @@ class RideRepository extends ServiceEntityRepository
 SELECT * FROM (
     SELECT
         r.id,
-        r.$dateTimeSpalte AS ride_date_time,
+        r.dateTime AS ride_date_time,
         r.latitude,
         r.longitude,
         r.title,

--- a/tests/Repository/NativeGeoQueryTest.php
+++ b/tests/Repository/NativeGeoQueryTest.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\City;
+use App\Entity\Location;
+use App\Entity\Ride;
+use App\Repository\CityRepository;
+use App\Repository\RideRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Die beiden Umkreissuchen laufen als handgeschriebenes SQL an DQL vorbei.
+ *
+ * Genau deshalb brauchen sie einen Test, der sie wirklich ausfuehrt: Ein Fehler
+ * darin faellt sonst weder PHPStan noch der uebrigen Suite auf. Beim Umstieg auf
+ * PostgreSQL ist mir hier ein Spaltenname in Anfuehrungszeichen geraten, den es
+ * dort nicht gibt — unbemerkt, weil diese Abfragen von keinem Test beruehrt
+ * wurden.
+ *
+ * Zum Spaltennamen: Doctrine legt "dateTime" unquotiert an, PostgreSQL faltet
+ * ihn also auf "datetime". Dieselbe Faltung trifft die Abfrage, solange auch sie
+ * nicht quotet — ein "dateTime" in Anfuehrungszeichen griffe dagegen ins Leere.
+ */
+class NativeGeoQueryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function rideRepository(): RideRepository
+    {
+        $repository = static::getContainer()->get(RideRepository::class);
+        self::assertInstanceOf(RideRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function cityRepository(): CityRepository
+    {
+        $repository = static::getContainer()->get(CityRepository::class);
+        self::assertInstanceOf(CityRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function hamburg(): City
+    {
+        $city = $this->entityManager->getRepository(City::class)->findOneBy(['city' => 'Hamburg']);
+        self::assertInstanceOf(City::class, $city);
+
+        return $city;
+    }
+
+    /**
+     * Ein Ort auf der Startkoordinate einer vorhandenen Fahrt — so trifft die
+     * Umkreissuche auch wirklich etwas.
+     */
+    private function ortAnEinerFahrt(): Location
+    {
+        $ride = $this->entityManager->getRepository(Ride::class)->findOneBy(['city' => $this->hamburg()]);
+        self::assertInstanceOf(Ride::class, $ride);
+        self::assertNotNull($ride->getLatitude(), 'Die Fahrt braucht Koordinaten, sonst prueft der Test nichts.');
+
+        $location = (new Location())
+            ->setCity($this->hamburg())
+            ->setTitle('Testort ' . uniqid())
+            ->setLatitude($ride->getLatitude())
+            ->setLongitude($ride->getLongitude());
+
+        $this->entityManager->persist($location);
+        $this->entityManager->flush();
+
+        return $location;
+    }
+
+    public function testRidesForLocationRunsAndFillsTheEntities(): void
+    {
+        $location = $this->ortAnEinerFahrt();
+
+        $rides = $this->rideRepository()->findRidesForLocation($location, 5000.0, 10);
+
+        self::assertNotEmpty($rides, 'Auf der eigenen Koordinate muss die Umkreissuche etwas finden.');
+
+        foreach ($rides as $ride) {
+            self::assertInstanceOf(Ride::class, $ride);
+            // Das Datum kommt ueber einen Alias aus der Unterabfrage; ist der
+            // Spaltenname falsch, bleibt es leer oder die Abfrage bricht ab.
+            self::assertNotNull($ride->getDateTime(), 'Die Fahrt traegt ihr Datum.');
+            self::assertNotNull($ride->getCity(), 'Die Stadt ist mitgeladen.');
+        }
+
+        $this->entityManager->remove($location);
+        $this->entityManager->flush();
+    }
+
+    public function testRidesForLocationRespectsTheRadius(): void
+    {
+        $location = $this->ortAnEinerFahrt();
+
+        $nah = $this->rideRepository()->findRidesForLocation($location, 100.0, 25);
+        $weit = $this->rideRepository()->findRidesForLocation($location, 100000.0, 25);
+
+        self::assertLessThanOrEqual(count($weit), count($nah), 'Ein groesserer Umkreis findet nicht weniger.');
+
+        $this->entityManager->remove($location);
+        $this->entityManager->flush();
+    }
+
+    public function testLocationWithoutCoordinatesReturnsNothing(): void
+    {
+        $location = (new Location())
+            ->setCity($this->hamburg())
+            ->setTitle('Ort ohne Koordinaten ' . uniqid());
+
+        self::assertSame([], $this->rideRepository()->findRidesForLocation($location));
+    }
+
+    public function testNearCitiesRuns(): void
+    {
+        $treffer = $this->cityRepository()->findNearCities($this->hamburg(), 5, 500.0);
+
+        foreach ($treffer as $city) {
+            self::assertInstanceOf(City::class, $city);
+            self::assertNotSame('Hamburg', $city->getCity(), 'Die Ausgangsstadt zaehlt nicht als Nachbarin.');
+        }
+
+        self::assertLessThanOrEqual(5, count($treffer));
+    }
+
+    public function testNearCitiesOnlyReturnsEnabledCities(): void
+    {
+        foreach ($this->cityRepository()->findNearCities($this->hamburg(), 15, 2000.0) as $city) {
+            self::assertTrue($city->getEnabled(), 'Abgeschaltete Staedte bleiben aussen vor.');
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Ein Fehler, den ich selbst in #1512 eingebaut habe.**

Doctrine legt die Spalte `dateTime` **unquotiert** an — PostgreSQL faltet sie also auf `datetime`. Dieselbe Faltung trifft eine Abfrage, die ebenfalls nicht quotet, weshalb das ursprüngliche `r.dateTime` dort seit jeher richtig war. Mein `quoteSingleIdentifier('dateTime')` erzeugt dagegen `"dateTime"`, und **diese Spalte gibt es nicht**:

```
ERROR:  column "dateTime" does not exist
```

Die Fahrtensuche im Umkreis eines Ortes (`/location/…`) wäre nach dem Plattformwechsel damit gescheitert.

Nachgeprüft auf der neu angelegten Produktivdatenbank: Von 389 Spalten trägt **keine einzige** einen Großbuchstaben — außer den dreien, die ich beim Transfer selbst gequotet angelegt habe.

## Warum es durchgerutscht ist

Zwei Gründe, beide unangenehm:

1. **Das Audit hinter dem Plan behauptete**, camelCase müsse unter PostgreSQL gequotet werden. Ich habe das übernommen, ohne nachzusehen, wie die Spalte tatsächlich heißt.
2. **Die beiden handgeschriebenen Geo-Abfragen hatten keinen einzigen Test.** Sie laufen an DQL vorbei, also fasst sie weder PHPStan noch die übrige Suite an — die vollen 1502 Tests gegen PostgreSQL waren grün, während diese Abfrage kaputt war.

## Was jetzt anders ist

`tests/Repository/NativeGeoQueryTest.php` führt beide nativen Abfragen wirklich aus: `RideRepository::findRidesForLocation` und `CityRepository::findNearCities`. Gegenprobe: Stellt man das falsche Quoting wieder her, fallen zwei der fünf Tests um.

Die übrige Umbauarbeit aus #1512 an dieser Abfrage bleibt — das `HAVING` ohne `GROUP BY` über einen Auswahl-Alias war ein echtes Problem und ist weiterhin durch die Unterabfrage gelöst.

## Test Plan

- Neue `tests/Repository/NativeGeoQueryTest.php`, 5 Tests, beide nativen Abfragen.
- Gegenprobe mit wiederhergestelltem Quoting: 2 Fehlschläge.
- Volle Suite gegen **PostgreSQL 17**: 1512 grün. Gegen **MariaDB 10.9**: dieselben 1512 grün.
- `vendor/bin/phpstan analyse` projektweit ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR