### PR TITLE
Run the tests against PostgreSQL, the platform production uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,18 +39,20 @@ jobs:
     name: PHPUnit
     runs-on: ubuntu-latest
 
+    # Seit dem 5. September 2026 laeuft die Produktion auf PostgreSQL 17. Die CI
+    # prueft deshalb dagegen — eine Suite gegen MariaDB waere seither keine
+    # Aussage mehr ueber das, was tatsaechlich laeuft.
     services:
-      mysql:
-        image: mariadb:10.9
+      postgres:
+        image: postgres:17
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: criticalmass
-          MYSQL_USER: criticalmass
-          MYSQL_PASSWORD: criticalmass
+          POSTGRES_DB: criticalmass
+          POSTGRES_USER: criticalmass
+          POSTGRES_PASSWORD: criticalmass
         ports:
-          - 3306:3306
+          - 5432:5432
         options: >-
-          --health-cmd="mariadb-admin ping -proot"
+          --health-cmd="pg_isready -U criticalmass"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -61,7 +63,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.5'
-          extensions: intl, pdo_mysql
+          extensions: intl, pdo_pgsql
 
       - uses: actions/cache@v4
         with:
@@ -73,10 +75,14 @@ jobs:
 
       - run: cp .env.dist .env
 
+      # Achtung fuer den Tag, an dem PostGIS dazukommt: test:db:reset raeumt mit
+      # "schema:drop --full-database" die ganze Datenbank ab — unter PostGIS
+      # gehoerte spatial_ref_sys mit dazu, und die Extension waere danach kaputt.
+      # Solange die CI auf reinem PostgreSQL laeuft, ist es unbedenklich.
       - run: composer test:db:reset
         env:
-          DATABASE_URL: "mysql://criticalmass:criticalmass@127.0.0.1:3306/criticalmass?charset=utf8mb4"
+          DATABASE_URL: "postgresql://criticalmass:criticalmass@127.0.0.1:5432/criticalmass?serverVersion=17&charset=utf8"
 
       - run: composer test:run
         env:
-          DATABASE_URL: "mysql://criticalmass:criticalmass@127.0.0.1:3306/criticalmass?charset=utf8mb4"
+          DATABASE_URL: "postgresql://criticalmass:criticalmass@127.0.0.1:5432/criticalmass?serverVersion=17&charset=utf8"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **criticalmass.in** — web platform for coordinating and documenting Critical Mass bicycle rides worldwide. Manages cities, rides/events, participants, GPS tracks, photos, forums, and statistics.
 
-**Stack:** Symfony 7.4 (LTS), Doctrine ORM 3 / DBAL 4, PHP 8.2+, MariaDB 10.9+, Bootstrap 5, Webpack Encore with Stimulus
+**Stack:** Symfony 7.4 (LTS), Doctrine ORM 3 / DBAL 4, PHP 8.2+, **PostgreSQL 17** (seit 05.09.2026; vorher MariaDB, siehe unten), Bootstrap 5, Webpack Encore with Stimulus
 
 ## Common Commands
 
@@ -17,8 +17,9 @@ composer test:run          # Just run PHPUnit (no DB reset)
 composer test:api          # Only API test suite
 vendor/bin/phpunit tests/Path/To/TestFile.php              # Single test file
 vendor/bin/phpunit --filter testMethodName                  # Single test method
-# Controller/DB tests need MariaDB up (docker-compose up); otherwise they fail with
-# "getaddrinfo for mysql failed". Pure unit tests (no DB) run standalone.
+# Controller/DB tests brauchen eine laufende Datenbank; reine Unit-Tests laufen ohne.
+# Die CI faehrt PostgreSQL 17, wie die Produktion. Der Code ist portabel geblieben
+# und besteht die Suite auch gegen MariaDB — das ist aber nicht mehr die Zielplattform.
 # Use `php bin/console ...` (the bare `bin/console` may report "permission denied").
 ```
 
@@ -49,6 +50,16 @@ php bin/console doctrine:migrations:version 'DoctrineMigrations\Version202609041
 # DELETE FROM doctrine_migration_versions WHERE version <> 'DoctrineMigrations\\Version20260904120000';
 ```
 
+**Die Baseline taugt nur fuer MySQL.** Sie enthaelt `ENGINE`, `AUTO_INCREMENT` und
+`LONGTEXT`; auf der Produktion ist sie als erledigt eingetragen, aber eine frische
+Installation gegen PostgreSQL scheitert daran. Entweder bekommt sie eine
+Plattformweiche, oder frische Installationen laufen ausdruecklich ueber
+`doctrine:schema:create`. Offener Punkt.
+
+**Spaltennamen sind in PostgreSQL kleingeschrieben.** Doctrine legt sie unquotiert an,
+PostgreSQL faltet sie: `dateTime` heisst dort `datetime`. In rohem SQL camelCase
+deshalb **nicht** quoten — `"dateTime"` greift ins Leere.
+
 **Vorsicht bei `schema:update`:** Das Produktivschema weicht in 18 Punkten vom Entity-Modell
 ab. 13 davon sind folgenlose `(DC2Type:…)`-Spaltenkommentare, aber vier Spalten kennt kein
 Entity mehr und sie enthalten Daten (`track.estimate_id`, `track.md5Hash`, `track.geoJson`,
@@ -73,6 +84,11 @@ yarn build        # Production build
 ### Docker Services
 ```bash
 docker-compose up -d      # MariaDB (port 8002), Redis, Memcached, Mailcatcher (port 1080)
+# Achtung: docker-compose.yaml faehrt noch MariaDB. Fuer einen Lauf gegen die
+# Zielplattform stattdessen einen Wegwerf-Container nehmen:
+#   docker run -d --name pg -p 55432:5432 -e POSTGRES_PASSWORD=postgres \
+#     -e POSTGRES_DB=cm postgres:17
+# und in .env.test.local eine passende DATABASE_URL setzen.
 ```
 
 ## Architecture


### PR DESCRIPTION
## Summary

criticalmass.in läuft **seit dem 5. September auf PostgreSQL 17**. Eine Suite gegen MariaDB sagt seither nichts mehr über das aus, was tatsächlich läuft.

- Dienst `mariadb:10.9` → `postgres:17`
- Erweiterung `pdo_mysql` → `pdo_pgsql`
- `DATABASE_URL` auf PostgreSQL

Dazu ein Hinweis im Ablauf für den Tag, an dem PostGIS dazukommt: `test:db:reset` räumt mit `schema:drop --full-database` die ganze Datenbank ab — unter PostGIS gehörte `spatial_ref_sys` mit dazu, und die Extension wäre danach kaputt. Solange die CI auf reinem PostgreSQL läuft, ist es unbedenklich.

## Test Plan

Der Lauf dieses PRs **ist** der Test: Er zeigt, ob die volle Suite in der CI gegen PostgreSQL durchläuft. Lokal tut sie es (1512 Tests gegen PostgreSQL 17 und dieselben gegen MariaDB 10.9).

## Nicht enthalten

Eine Matrix über beide Plattformen. Die Anwendung ist portabel geblieben und besteht die Suite auf MySQL wie auf PostgreSQL — aber die doppelte Laufzeit lohnt nur, wenn MySQL weiter unterstützt werden soll. Das ist eine eigene Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR