### PR TITLE
Lay the PostGIS groundwork the geometry issues need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     # Aussage mehr ueber das, was tatsaechlich laeuft.
     services:
       postgres:
-        image: postgres:17
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_DB: criticalmass
           POSTGRES_USER: criticalmass
@@ -75,10 +75,10 @@ jobs:
 
       - run: cp .env.dist .env
 
-      # Achtung fuer den Tag, an dem PostGIS dazukommt: test:db:reset raeumt mit
-      # "schema:drop --full-database" die ganze Datenbank ab — unter PostGIS
-      # gehoerte spatial_ref_sys mit dazu, und die Extension waere danach kaputt.
-      # Solange die CI auf reinem PostgreSQL laeuft, ist es unbedenklich.
+      # test:db:reset raeumt mit "schema:drop --full-database" die ganze Datenbank
+      # ab. Dass PostGIS das ueberlebt, liegt am schema_filter in doctrine.yaml:
+      # er haelt spatial_ref_sys aus Doctrines Blickfeld heraus. Ohne ihn waere die
+      # Extension nach dem ersten Zuruecksetzen kaputt — nachgeprueft.
       - run: composer test:db:reset
         env:
           DATABASE_URL: "postgresql://criticalmass:criticalmass@127.0.0.1:5432/criticalmass?serverVersion=17&charset=utf8"

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
         "symfony/rate-limiter": "^7.4",
         "symfony/lock": "^7.4",
         "adriangibbons/php-fit-file-analysis": "^3.2",
-        "league/oauth2-server-bundle": "^1.1"
+        "league/oauth2-server-bundle": "^1.1",
+        "jsor/doctrine-postgis": "^2.4"
     },
     "require-dev": {
         "symfony/browser-kit": "^7.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "751cd8bea8a53160df0f3b170749e66d",
+    "content-hash": "6dbb5af540432e9a603095984fc40519",
     "packages": [
         {
             "name": "adriangibbons/php-fit-file-analysis",
@@ -2692,6 +2692,81 @@
                 "source": "https://github.com/schmittjoh/metadata/tree/2.9.0"
             },
             "time": "2025-11-30T20:12:26+00:00"
+        },
+        {
+            "name": "jsor/doctrine-postgis",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsor/doctrine-postgis.git",
+                "reference": "0db64e93f18b7d3347beca1f9f0d724212d4ea8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsor/doctrine-postgis/zipball/0db64e93f18b7d3347beca1f9f0d724212d4ea8a",
+                "reference": "0db64e93f18b7d3347beca1f9f0d724212d4ea8a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.7 || ^4.0",
+                "doctrine/deprecations": "^0.5.3 || ^1.0",
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/orm": "<2.18"
+            },
+            "require-dev": {
+                "doctrine/collections": "^2.0 || ^3.0",
+                "doctrine/orm": "^2.19 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "phpunit/phpunit": "^9.6",
+                "symfony/doctrine-bridge": "^6.4",
+                "symfony/doctrine-messenger": "^6.4",
+                "vimeo/psalm": "^6.13"
+            },
+            "suggest": {
+                "doctrine/orm": "For using with the Doctrine ORM"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jsor\\Doctrine\\PostGIS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com"
+                }
+            ],
+            "description": "Spatial and Geographic Data with PostGIS and Doctrine.",
+            "keywords": [
+                "database",
+                "dbal",
+                "doctrine",
+                "geo",
+                "geography",
+                "geometry",
+                "gis",
+                "orm",
+                "postgis",
+                "spatial"
+            ],
+            "support": {
+                "issues": "https://github.com/jsor/doctrine-postgis/issues",
+                "source": "https://github.com/jsor/doctrine-postgis/tree/v2.4.0"
+            },
+            "time": "2025-10-09T07:18:57+00:00"
         },
         {
             "name": "khill/php-duration",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -18,6 +18,18 @@ doctrine:
             datetime: App\DBAL\Type\UTCDateTimeType
             date: App\DBAL\Type\UTCDateType
             time: App\DBAL\Type\UTCTimeType
+            geometry: Jsor\Doctrine\PostGIS\Types\GeometryType
+            geography: Jsor\Doctrine\PostGIS\Types\GeographyType
+
+        # PostGIS legt eigene Schemas und eine Tabelle spatial_ref_sys an. Ohne
+        # diesen Filter haelt Doctrine sie fuer verwaiste Objekte und will sie
+        # loeschen — spatial_ref_sys liegt naemlich in public, mitten zwischen
+        # unseren eigenen Tabellen.
+        schema_filter: ~^(?!tiger)(?!topology)(?!spatial_ref_sys)~
+
+        # PostGIS bringt Spalten vom Typ _text mit, den Doctrine sonst nicht kennt.
+        mapping_types:
+            _text: string
 
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'

--- a/config/packages/jsor_doctrine_postgis.yaml
+++ b/config/packages/jsor_doctrine_postgis.yaml
@@ -1,0 +1,15 @@
+# Anbindung von PostGIS an Doctrine.
+#
+# Der Listener sorgt dafuer, dass Geometriespalten und raeumliche Indizes beim
+# Erzeugen des Schemas richtig herauskommen; das Middleware haengt sich in die
+# Verbindung, damit die Typen beim Auslesen des Schemas erkannt werden.
+#
+# Frueher registrierte man dafuer einen doctrine.event_subscriber — das
+# Event-System ist in DBAL 4 entfallen, deshalb der Listener.
+services:
+    Jsor\Doctrine\PostGIS\Event\ORMSchemaEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: postGenerateSchemaTable, connection: default }
+
+    Jsor\Doctrine\PostGIS\Driver\Middleware:
+        tags: [ doctrine.middleware ]

--- a/migrations/Version20260906010000.php
+++ b/migrations/Version20260906010000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Schaltet PostGIS in der Datenbank frei.
+ *
+ * Damit steht der Datentyp geometry bereit — die Voraussetzung dafuer, dass die
+ * Koordinaten von Staedten, Fahrten, Orten und Fotos als Punkte statt als zwei
+ * lose Fliesskommazahlen gespeichert werden koennen (Issues #1136 bis #1142).
+ *
+ * Die Extension legt in public zusaetzlich die Tabelle spatial_ref_sys an, in
+ * der die Koordinatensysteme stehen. Sie gehoert PostGIS, nicht uns — der
+ * schema_filter in doctrine.yaml haelt Doctrine davon ab, sie fuer verwaist zu
+ * halten und loeschen zu wollen.
+ */
+final class Version20260906010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enable the PostGIS extension';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            'PostGIS gibt es nur fuer PostgreSQL.'
+        );
+
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS postgis');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Nicht zurueckrollbar, sobald Geometriespalten daran haengen: DROP
+        // EXTENSION braeuchte CASCADE und nimmt die Spalten mit den Daten mit.
+        throw new \LogicException(
+            'PostGIS wird nicht wieder abgeschaltet — ein DROP EXTENSION CASCADE '
+            . 'nimmt jede Geometriespalte samt Inhalt mit.'
+        );
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -93,6 +93,9 @@
             "config/routes/hwi_oauth_routing.yaml"
         ]
     },
+    "jsor/doctrine-postgis": {
+        "version": "v2.4.0"
+    },
     "knplabs/knp-menu-bundle": {
         "version": "v3.2.0"
     },

--- a/tests/Doctrine/PostgisSetupTest.php
+++ b/tests/Doctrine/PostgisSetupTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Doctrine;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManagerInterface;
+use Jsor\Doctrine\PostGIS\Types\GeographyType;
+use Jsor\Doctrine\PostGIS\Types\GeometryType;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Das Fundament fuer die Geometrie-Issues #1136 bis #1142.
+ *
+ * Geprueft wird die Anbindung, nicht PostGIS selbst: dass Doctrine die
+ * Geometrietypen kennt, dass der Schema-Filter die Tabellen von PostGIS in Ruhe
+ * laesst, und dass die Extension da ist. Ohne diese drei Dinge scheitert jede
+ * Geometriespalte, die spaeter dazukommt — und zwar erst beim Anlegen des
+ * Schemas, nicht beim Lesen des Codes.
+ */
+class PostgisSetupTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function istPostgreSql(): bool
+    {
+        return $this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform;
+    }
+
+    public function testDoctrineKnowsTheGeometryTypes(): void
+    {
+        self::assertTrue(Type::hasType('geometry'), 'Der Typ geometry ist registriert.');
+        self::assertTrue(Type::hasType('geography'), 'Der Typ geography ist registriert.');
+        self::assertInstanceOf(GeometryType::class, Type::getType('geometry'));
+        self::assertInstanceOf(GeographyType::class, Type::getType('geography'));
+    }
+
+    /**
+     * Der Filter ist der Grund, warum Doctrine die Tabellen von PostGIS nicht
+     * fuer verwaist haelt. spatial_ref_sys liegt in public, mitten zwischen den
+     * eigenen Tabellen — ohne den Filter stuende sie auf der Abschussliste.
+     */
+    public function testTheSchemaFilterSparesThePostgisTables(): void
+    {
+        $filter = $this->entityManager->getConnection()->getConfiguration()->getSchemaAssetsFilter();
+
+        foreach (['spatial_ref_sys', 'tiger_data', 'topology'] as $fremd) {
+            self::assertFalse((bool) $filter($fremd), sprintf('%s bleibt aussen vor.', $fremd));
+        }
+
+        foreach (['city', 'ride', 'app_user', 'track_polyline'] as $eigen) {
+            self::assertTrue((bool) $filter($eigen), sprintf('%s wird weiterhin verwaltet.', $eigen));
+        }
+    }
+
+    public function testThePostgisExtensionIsEnabled(): void
+    {
+        if (!$this->istPostgreSql()) {
+            self::markTestSkipped('PostGIS gibt es nur fuer PostgreSQL.');
+        }
+
+        $version = $this->entityManager->getConnection()
+            ->fetchOne("SELECT extversion FROM pg_extension WHERE extname = 'postgis'");
+
+        self::assertNotFalse($version, 'Die Extension postgis ist eingeschaltet.');
+        self::assertMatchesRegularExpression('/^3\./', (string) $version, 'PostGIS 3.x');
+    }
+
+    /**
+     * Die eigentliche Probe: Eine Geometriespalte laesst sich anlegen, fuellen
+     * und raeumlich abfragen — mit Doctrines eigener Verbindung.
+     */
+    public function testAGeometryColumnCanBeCreatedFilledAndQueried(): void
+    {
+        if (!$this->istPostgreSql()) {
+            self::markTestSkipped('PostGIS gibt es nur fuer PostgreSQL.');
+        }
+
+        $verbindung = $this->entityManager->getConnection();
+        $tabelle = 'geo_probe_' . substr(md5(uniqid('', true)), 0, 8);
+
+        $verbindung->executeStatement(sprintf(
+            'CREATE TABLE %s (id serial PRIMARY KEY, punkt geometry(POINT, 4326))', $tabelle
+        ));
+
+        try {
+            $verbindung->executeStatement(sprintf(
+                'CREATE INDEX %s_gist ON %s USING gist (punkt)', $tabelle, $tabelle
+            ));
+
+            // Hamburg
+            $verbindung->executeStatement(sprintf(
+                'INSERT INTO %s (punkt) VALUES (ST_SetSRID(ST_MakePoint(9.99, 53.55), 4326))', $tabelle
+            ));
+
+            self::assertSame('POINT(9.99 53.55)', $verbindung->fetchOne(
+                sprintf('SELECT ST_AsText(punkt) FROM %s', $tabelle)
+            ));
+
+            // Entfernung nach Berlin, ueber geography also in Metern.
+            $kilometer = (int) round((float) $verbindung->fetchOne(sprintf(
+                'SELECT ST_Distance(punkt::geography, ST_SetSRID(ST_MakePoint(13.40, 52.52), 4326)::geography) / 1000
+                 FROM %s', $tabelle
+            )));
+
+            self::assertGreaterThan(240, $kilometer, 'Hamburg und Berlin liegen rund 255 km auseinander.');
+            self::assertLessThan(270, $kilometer);
+        } finally {
+            $verbindung->executeStatement(sprintf('DROP TABLE IF EXISTS %s', $tabelle));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Das Fundament für **Phase 4** — die Geometrie-Issues #1136 bis #1142. Es benutzt noch **keine** Geometriespalte; das hier ist der Boden, auf dem sie stehen.

- `jsor/doctrine-postgis` **v2.4** (verträgt DBAL 4; criticalmaps hängt noch auf v2.3 mit DBAL 3)
- Die Doctrine-Typen `geometry` und `geography`
- Eine Migration, die `CREATE EXTENSION postgis` ausführt

## Zwei Details, die nicht in der alten Anleitung stehen

**Die Registrierung geht über einen `doctrine.event_listener` plus ein Treiber-Middleware**, nicht über den `doctrine.event_subscriber`, den ältere Anleitungen und criticalmaps verwenden — **DBAL 4 hat das Event-System entfernt**.

**`doctrine.yaml` bekommt einen Schema-Filter.** PostGIS legt `spatial_ref_sys` in `public` ab, mitten zwischen unseren eigenen Tabellen; ohne den Filter hält Doctrine sie für verwaist und bietet an, sie zu löschen. Der in der Paketdoku empfohlene Filter grenzt nur die Schemas `tiger` und `topology` aus und hätte das nicht verhindert.

Damit erledigt sich zugleich die Warnung, die ich in #1515 in die CI geschrieben hatte: `test:db:reset` räumt mit `schema:drop --full-database` ab, aber **die Extension überlebt das** — der Filter hält sie aus Doctrines Blickfeld. Nachgeprüft, nicht vermutet.

## Test Plan

- Neue `tests/Doctrine/PostgisSetupTest.php`, 4 Tests: Typen registriert, Filter schont die PostGIS-Tabellen und lässt die eigenen durch, Extension eingeschaltet, und eine **echte Geometriespalte** wird angelegt, gefüllt, mit GIST indiziert und räumlich abgefragt (Hamburg–Berlin, 256 km).
- Kette von null gegen **PostGIS 3.5 / PostgreSQL 17.6**: Baseline, Umbenennung überspringt sich, Extension an, danach `schema:update --dump-sql` ohne Befund an unseren Tabellen.
- Zurücksetz-Zyklus (`schema:drop --full-database` → `schema:create` → Fixtures) durchgespielt: PostGIS lebt danach noch.
- Volle Suite: **1516 Tests grün**. `vendor/bin/phpstan analyse` ohne Fehler.

Das CI-Dienst-Image wird `postgis/postgis:17-3.5`, damit die Extension auch dort da ist.

## Nebenbefund

In der Testumgebung will `schema:update` die vier `oauth2_*`-Tabellen löschen. Das ist **vorbestehend und umgebungsabhängig**: `league_oauth2_server.yaml` schaltet unter `when@test` auf `persistence: in_memory`, wodurch die Entities dort nicht abgebildet sind. In `prod` mit Doctrine-Persistenz tritt es nicht auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR