### PR TITLE
Give rides and city cycles their location as a point geometry

### DIFF
--- a/migrations/Version20260906030000.php
+++ b/migrations/Version20260906030000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Gibt Fahrten und Tourenmustern ihre Lage als Geometrie (Issues #1137, #1142).
+ *
+ * Gleiches Vorgehen wie bei den Staedten in Version20260906020000: Die Spalte
+ * wird aus latitude und longitude gefuellt und danach von den Settern
+ * nachgefuehrt; die beiden Fliesskommaspalten bleiben vorerst die fuehrenden
+ * Werte, weil API-Ausgabe und Abfragen an ihnen haengen.
+ *
+ * Der Punkt 0,0 im Golf von Guinea dient im Bestand als Platzhalter fuer
+ * "keine Koordinaten" — solche Zeilen bleiben ohne Geometrie.
+ */
+final class Version20260906030000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add point geometries to ride and city_cycle';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            'Geometriespalten gibt es nur mit PostGIS.'
+        );
+
+        foreach (['ride', 'city_cycle'] as $tabelle) {
+            $this->addSql(sprintf('ALTER TABLE %s ADD coordinates geometry(POINT, 4326) DEFAULT NULL', $tabelle));
+
+            // In WKT steht die Laenge vor der Breite.
+            $this->addSql(sprintf('
+                UPDATE %s
+                SET coordinates = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+                WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+                  AND latitude <> 0 AND longitude <> 0
+            ', $tabelle));
+
+            $this->addSql(sprintf(
+                'CREATE INDEX %s_coordinates_gist ON %s USING gist(coordinates)', $tabelle, $tabelle
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (['ride', 'city_cycle'] as $tabelle) {
+            $this->addSql(sprintf('DROP INDEX IF EXISTS %s_coordinates_gist', $tabelle));
+            $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN coordinates', $tabelle));
+        }
+    }
+}

--- a/src/Entity/CityCycle.php
+++ b/src/Entity/CityCycle.php
@@ -7,11 +7,13 @@ use App\EntityInterface\RouteableInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Jsor\Doctrine\PostGIS\Types\PostGISType;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Table(name: 'city_cycle')]
+#[ORM\Index(fields: ['coordinates'], name: 'city_cycle_coordinates_gist', flags: ['spatial'])]
 #[ORM\Entity(repositoryClass: 'App\Repository\CityCycleRepository')]
 class CityCycle implements RouteableInterface
 {
@@ -79,6 +81,18 @@ class CityCycle implements RouteableInterface
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['ride-list', 'api-write'])]
     protected ?float $longitude = null;
+    /**
+     * Dieselbe Stelle noch einmal, diesmal als Geometrie.
+     *
+     * Gefuehrt wird sie aus latitude und longitude, nicht umgekehrt: Die beiden
+     * Spalten haengen an der API-Ausgabe und an Abfragen, die erst mit #1141 auf
+     * PostGIS umgestellt werden. Der Gewinn liegt schon jetzt beim raeumlichen
+     * Index.
+     */
+    #[ORM\Column(type: PostGISType::GEOMETRY, nullable: true, options: ['geometry_type' => 'POINT', 'srid' => 4326])]
+    #[Ignore]
+    protected ?string $coordinates = null;
+
 
     #[ORM\Column(type: 'datetime', nullable: false)]
     #[Groups(['ride-list'])]
@@ -149,6 +163,7 @@ class CityCycle implements RouteableInterface
     public function setLatitude(?float $latitude = null): CityCycle
     {
         $this->latitude = $latitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -161,6 +176,7 @@ class CityCycle implements RouteableInterface
     public function setLongitude(?float $longitude = null): CityCycle
     {
         $this->longitude = $longitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -168,6 +184,32 @@ class CityCycle implements RouteableInterface
     public function getLongitude(): ?float
     {
         return $this->longitude;
+    }
+
+    public function getCoordinates(): ?string
+    {
+        return $this->coordinates;
+    }
+
+    /**
+     * Haelt die Geometrie an den beiden Fliesskommaspalten nach.
+     *
+     * In WKT steht die Laenge vor der Breite — anders herum als in jeder
+     * Beschriftung dieser Anwendung, und eine beliebte Fehlerquelle.
+     *
+     * Null und exakt 0 gelten als "keine Angabe": Der Punkt 0,0 liegt im Golf
+     * von Guinea, und der Bestand nutzt ihn seit jeher als Platzhalter.
+     */
+    private function punktNachfuehren(): void
+    {
+        if (null === $this->latitude || null === $this->longitude
+            || 0.0 === $this->latitude || 0.0 === $this->longitude) {
+            $this->coordinates = null;
+
+            return;
+        }
+
+        $this->coordinates = sprintf('SRID=4326;POINT(%.8F %.8F)', $this->longitude, $this->latitude);
     }
 
     public function setDayOfWeek(int $dayOfWeek): CityCycle

--- a/src/Entity/Ride.php
+++ b/src/Entity/Ride.php
@@ -20,6 +20,7 @@ use App\Validator\Constraint as CriticalAssert;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Jsor\Doctrine\PostGIS\Types\PostGISType;
 use MalteHuebner\DataQueryBundle\Attribute\EntityAttribute as DataQuery;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -35,6 +36,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 #[ORM\Index(fields: ['dateTime'], name: 'ride_date_time_index')]
 #[ORM\Index(fields: ['createdAt'], name: 'ride_created_at_index')]
 #[ORM\Index(fields: ['updatedAt'], name: 'ride_updated_at_index')]
+#[ORM\Index(fields: ['coordinates'], name: 'ride_coordinates_gist', flags: ['spatial'])]
 class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterface, AuditableInterface, PostableInterface, SocialNetworkProfileAble, OrderedEntityInterface, CoordinateInterface
 {
     #[DataQuery\Sortable]
@@ -119,6 +121,18 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['ride-list', 'ride-details', 'api-write'])]
     protected ?float $longitude = 0.0;
+    /**
+     * Dieselbe Stelle noch einmal, diesmal als Geometrie.
+     *
+     * Gefuehrt wird sie aus latitude und longitude, nicht umgekehrt: Die beiden
+     * Spalten haengen an der API-Ausgabe und an Abfragen, die erst mit #1141 auf
+     * PostGIS umgestellt werden. Der Gewinn liegt schon jetzt beim raeumlichen
+     * Index.
+     */
+    #[ORM\Column(type: PostGISType::GEOMETRY, nullable: true, options: ['geometry_type' => 'POINT', 'srid' => 4326])]
+    #[Ignore]
+    protected ?string $coordinates = null;
+
 
     #[DataQuery\Sortable]
     #[DataQuery\Queryable]
@@ -315,6 +329,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     public function setLatitude(?float $latitude = null): CoordinateInterface
     {
         $this->latitude = $latitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -327,6 +342,7 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     public function setLongitude(?float $longitude = null): CoordinateInterface
     {
         $this->longitude = $longitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -334,6 +350,32 @@ class Ride implements ParticipateableInterface, PhotoInterface, RouteableInterfa
     public function getLongitude(): ?float
     {
         return $this->longitude;
+    }
+
+    public function getCoordinates(): ?string
+    {
+        return $this->coordinates;
+    }
+
+    /**
+     * Haelt die Geometrie an den beiden Fliesskommaspalten nach.
+     *
+     * In WKT steht die Laenge vor der Breite — anders herum als in jeder
+     * Beschriftung dieser Anwendung, und eine beliebte Fehlerquelle.
+     *
+     * Null und exakt 0 gelten als "keine Angabe": Der Punkt 0,0 liegt im Golf
+     * von Guinea, und der Bestand nutzt ihn seit jeher als Platzhalter.
+     */
+    private function punktNachfuehren(): void
+    {
+        if (null === $this->latitude || null === $this->longitude
+            || 0.0 === $this->latitude || 0.0 === $this->longitude) {
+            $this->coordinates = null;
+
+            return;
+        }
+
+        $this->coordinates = sprintf('SRID=4326;POINT(%.8F %.8F)', $this->longitude, $this->latitude);
     }
 
     public function setCoord(Coord $coord): Ride

--- a/tests/Entity/RideAndCycleCoordinatesTest.php
+++ b/tests/Entity/RideAndCycleCoordinatesTest.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\CityCycle;
+use App\Entity\Ride;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Die Lage von Fahrten und Tourenmustern als Geometrie (Issues #1137, #1142).
+ *
+ * Dieselben zwei Fallen wie bei den Staedten, und sie sind hier nicht weniger
+ * still: In WKT steht die Laenge vor der Breite, und 0,0 ist im Bestand ein
+ * Platzhalter, kein Ort im Golf von Guinea.
+ */
+class RideAndCycleCoordinatesTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    /**
+     * @return array<string, array{0: class-string}>
+     */
+    public static function entities(): array
+    {
+        return [
+            'Fahrt' => [Ride::class],
+            'Tourenmuster' => [CityCycle::class],
+        ];
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testTheSettersKeepTheGeometryInStep(string $klasse): void
+    {
+        $entity = new $klasse();
+        self::assertNull($entity->getCoordinates(), 'Ohne Koordinaten keine Geometrie.');
+
+        $entity->setLatitude(53.55);
+        self::assertNull($entity->getCoordinates(), 'Eine Breite allein ergibt noch keinen Punkt.');
+
+        $entity->setLongitude(9.99);
+        self::assertSame('SRID=4326;POINT(9.99000000 53.55000000)', $entity->getCoordinates());
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testLongitudeComesFirst(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(53.55);
+        $entity->setLongitude(9.99);
+
+        self::assertStringStartsWith('SRID=4326;POINT(9.99', (string) $entity->getCoordinates());
+        self::assertStringNotContainsString('POINT(53.55', (string) $entity->getCoordinates());
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testThePlaceholderZeroDoesNotBecomeAPoint(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(0.0);
+        $entity->setLongitude(0.0);
+
+        self::assertNull($entity->getCoordinates(), 'Null Grad, null Grad heisst hier: keine Angabe.');
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testClearingACoordinateClearsTheGeometry(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(53.55);
+        $entity->setLongitude(9.99);
+        self::assertNotNull($entity->getCoordinates());
+
+        $entity->setLongitude(null);
+        self::assertNull($entity->getCoordinates());
+    }
+
+    public function testTheRidesFromTheFixturesCarryTheirGeometry(): void
+    {
+        if (!$this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('Geometriespalten gibt es nur mit PostGIS.');
+        }
+
+        $mitKoordinaten = (int) $this->entityManager->getConnection()->fetchOne(
+            'SELECT count(*) FROM ride WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+             AND latitude <> 0 AND longitude <> 0'
+        );
+        $mitGeometrie = (int) $this->entityManager->getConnection()->fetchOne(
+            'SELECT count(*) FROM ride WHERE coordinates IS NOT NULL'
+        );
+
+        self::assertSame($mitKoordinaten, $mitGeometrie, 'Jede Fahrt mit Koordinaten hat auch eine Geometrie.');
+    }
+
+    #[DataProvider('tabellen')]
+    public function testTheSpatialIndexIsAGist(string $tabelle): void
+    {
+        if (!$this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('Geometriespalten gibt es nur mit PostGIS.');
+        }
+
+        $art = $this->entityManager->getConnection()->fetchOne(
+            'SELECT am.amname FROM pg_index i
+             JOIN pg_class c ON c.oid = i.indexrelid
+             JOIN pg_am am ON am.oid = c.relam
+             WHERE c.relname = :name',
+            ['name' => $tabelle . '_coordinates_gist']
+        );
+
+        self::assertSame('gist', $art, sprintf('%s traegt einen GiST-Index.', $tabelle));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function tabellen(): array
+    {
+        return ['ride' => ['ride'], 'city_cycle' => ['city_cycle']];
+    }
+}


### PR DESCRIPTION
## Summary

**Issues #1137 und #1142**, nach der Vorlage, die #1518 für die Städte gesetzt hat: Die Spalte wird aus `latitude` und `longitude` gefüllt, von den Settern nachgeführt und trägt einen **GiST-Index**.

Zwei Entities in einem PR, weil sie mechanisch identisch sind — dieselbe Spalte, derselbe Setter-Haken, derselbe Index, eine gemeinsame Migration.

Die Fließkommaspalten bleiben auch hier führend: Sie hängen an der API-Ausgabe und an den Abfragen, die **#1141** auf PostGIS umstellt. Erst danach können sie fallen.

## Test Plan

- Neue `tests/Entity/RideAndCycleCoordinatesTest.php`, 11 Tests über beide Entities: Setter führen nach, Länge steht vorn, Platzhalter 0,0 bleibt leer, Löschen einer Koordinate löscht den Punkt, jede Fahrt der Fixtures mit Koordinaten hat auch eine Geometrie, und beide Indizes sind wirklich GiST.
- Migration gegen PostGIS 3.5 / PostgreSQL 17, danach `schema:update --dump-sql` ohne Befund.
- Volle Suite auf **frisch aufgesetzter** Datenbank: **1533 Tests grün**. `vendor/bin/phpstan analyse` ohne Fehler.

Diesmal hängt der Commit am Ergebnis der Suite — beim letzten Mal hatte ich gepusht, während sie rot war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR