### PR TITLE
Search by radius with ST_DWithin instead of hand-written trigonometry

### DIFF
--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -324,19 +324,28 @@ class CityRepository extends ServiceEntityRepository
         $rsm = new ResultSetMappingBuilder($em);
         $rsm->addRootEntityFromClassMetadata(City::class, 'c');
 
+        // ST_DWithin statt einer von Hand geschriebenen Haversine-Formel: Die
+        // Bedingung kann den GiST-Index auf coordinates nutzen, die Formel
+        // konnte das nicht — sie musste jede Zeile anfassen und durchrechnen.
+        //
+        // Ueber geography gerechnet, also auf dem WGS84-Ellipsoid und in Metern;
+        // die alte Formel nahm eine Kugel mit 6371 km Radius an. Die Ergebnisse
+        // weichen dadurch um Bruchteile eines Prozents ab — zugunsten der neuen.
         $sql = <<<SQL
 SELECT c.*
 FROM city c
 WHERE c.enabled = true
   AND c.id != :id
-  AND (6371 * acos(
-           cos(radians(:lat)) * cos(radians(c.latitude)) * cos(radians(c.longitude) - radians(:lon)) +
-           sin(radians(:lat)) * sin(radians(c.latitude))
-       )) <= :distance
-ORDER BY (6371 * acos(
-             cos(radians(:lat)) * cos(radians(c.latitude)) * cos(radians(c.longitude) - radians(:lon)) +
-             sin(radians(:lat)) * sin(radians(c.latitude))
-         )) ASC
+  AND c.coordinates IS NOT NULL
+  AND ST_DWithin(
+        c.coordinates::geography,
+        ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography,
+        :meter
+      )
+ORDER BY ST_Distance(
+        c.coordinates::geography,
+        ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography
+      ) ASC
 LIMIT :size
 SQL;
 
@@ -344,7 +353,8 @@ SQL;
         $query->setParameter('lat', $city->getLatitude());
         $query->setParameter('lon', $city->getLongitude());
         $query->setParameter('id', $city->getId());
-        $query->setParameter('distance', $distance);
+        // Die Methode nimmt Kilometer entgegen, ST_DWithin ueber geography Meter.
+        $query->setParameter('meter', $distance * 1000);
         $query->setParameter('size', $size, \Doctrine\DBAL\ParameterType::INTEGER);
 
         return $query->getResult();

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -737,8 +737,6 @@ class RideRepository extends ServiceEntityRepository
 
         $latitude = $location->getLatitude();
         $longitude = $location->getLongitude();
-        $earthRadius = 6371000;
-
         $rsm = new ResultSetMapping();
 
         $rsm->addEntityResult(Ride::class, 'r');
@@ -767,30 +765,33 @@ class RideRepository extends ServiceEntityRepository
         // darauf filtern laesst. Vorher stand hier ein HAVING ohne GROUP BY, das
         // sich auf einen Alias der Auswahl bezog: MySQL laesst beides durchgehen,
         // PostgreSQL keines von beidem.
+        // ST_DWithin statt Haversine: Die Bedingung kann den GiST-Index auf
+        // coordinates nutzen. Damit entfaellt auch die Unterabfrage, die nur
+        // noetig war, um auf die selbst gerechnete Entfernung filtern zu koennen —
+        // ein HAVING ohne GROUP BY laesst PostgreSQL nicht durchgehen.
+        //
+        // Der Radius kommt bereits in Metern herein, und ueber geography rechnet
+        // ST_DWithin ebenfalls in Metern.
         $sql = <<<SQL
-SELECT * FROM (
-    SELECT
-        r.id,
-        r.dateTime AS ride_date_time,
-        r.latitude,
-        r.longitude,
-        r.title,
-        c.id AS c_id,
-        cs.id AS cs_id,
-        cs.slug AS cs_slug,
-        (
-            $earthRadius * acos(
-                cos(radians(:latitude)) * cos(radians(r.latitude)) *
-                cos(radians(r.longitude) - radians(:longitude)) +
-                sin(radians(:latitude)) * sin(radians(r.latitude))
-            )
-        ) AS distance
-    FROM ride r
-    INNER JOIN city c ON r.city_id = c.id
-    INNER JOIN cityslug cs ON cs.id = c.main_slug_id
-) naehe
-WHERE naehe.distance <= :radius
-ORDER BY naehe.ride_date_time DESC
+SELECT
+    r.id,
+    r.dateTime AS ride_date_time,
+    r.latitude,
+    r.longitude,
+    r.title,
+    c.id AS c_id,
+    cs.id AS cs_id,
+    cs.slug AS cs_slug
+FROM ride r
+INNER JOIN city c ON r.city_id = c.id
+INNER JOIN cityslug cs ON cs.id = c.main_slug_id
+WHERE r.coordinates IS NOT NULL
+  AND ST_DWithin(
+        r.coordinates::geography,
+        ST_SetSRID(ST_MakePoint(:longitude, :latitude), 4326)::geography,
+        :radius
+      )
+ORDER BY r.dateTime DESC
 LIMIT :limit
 SQL;
 

--- a/tests/Repository/NativeGeoQueryTest.php
+++ b/tests/Repository/NativeGeoQueryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Repository;
 
 use App\Entity\City;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use App\Entity\Location;
 use App\Entity\Ride;
 use App\Repository\CityRepository;
@@ -131,6 +132,80 @@ class NativeGeoQueryTest extends KernelTestCase
         }
 
         self::assertLessThanOrEqual(5, count($treffer));
+    }
+
+    /**
+     * Der Nachweis, dass die Umstellung von der Haversine-Formel auf PostGIS
+     * nichts verschoben hat (Issue #1141).
+     *
+     * Beide rechnen dieselbe Entfernung, nur auf unterschiedlichen Koerpern: die
+     * Formel auf einer Kugel mit 6371 km Radius, ST_Distance ueber geography auf
+     * dem WGS84-Ellipsoid. Der Unterschied liegt im Promillebereich — waere er
+     * groesser, haette ich beim Umstellen etwas verwechselt, etwa Laenge und
+     * Breite oder Meter und Kilometer.
+     */
+    public function testTheSpatialDistanceMatchesTheOldFormula(): void
+    {
+        if (!$this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('PostGIS-Funktionen gibt es nur unter PostgreSQL.');
+        }
+
+        $hamburg = $this->hamburg();
+
+        $zeilen = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT
+                 c.city,
+                 6371 * acos(LEAST(1, GREATEST(-1,
+                     cos(radians(:lat)) * cos(radians(c.latitude))
+                     * cos(radians(c.longitude) - radians(:lon))
+                     + sin(radians(:lat)) * sin(radians(c.latitude))
+                 ))) AS formel,
+                 ST_Distance(c.coordinates::geography,
+                             ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)::geography) / 1000 AS postgis
+             FROM city c
+             WHERE c.coordinates IS NOT NULL AND c.id <> :id',
+            ['lat' => $hamburg->getLatitude(), 'lon' => $hamburg->getLongitude(), 'id' => $hamburg->getId()]
+        );
+
+        self::assertNotEmpty($zeilen, 'Ohne Vergleichsstaedte sagt der Test nichts.');
+
+        foreach ($zeilen as $zeile) {
+            $formel = (float) $zeile['formel'];
+            $postgis = (float) $zeile['postgis'];
+
+            if ($formel < 1.0) {
+                continue;
+            }
+
+            $abweichung = abs($formel - $postgis) / $formel;
+
+            self::assertLessThan(0.01, $abweichung, sprintf(
+                'Fuer %s: Formel %.1f km, PostGIS %.1f km — das ist mehr als ein Prozent auseinander.',
+                $zeile['city'], $formel, $postgis
+            ));
+        }
+    }
+
+    /**
+     * Und der Gegentest zum Radius: Was innerhalb liegt, muss gefunden werden,
+     * was ausserhalb liegt, nicht.
+     */
+    public function testTheRadiusBoundaryHolds(): void
+    {
+        if (!$this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('PostGIS-Funktionen gibt es nur unter PostgreSQL.');
+        }
+
+        $hamburg = $this->hamburg();
+
+        $eng = $this->cityRepository()->findNearCities($hamburg, 50, 1.0);
+        $weit = $this->cityRepository()->findNearCities($hamburg, 50, 5000.0);
+
+        self::assertLessThanOrEqual(count($weit), count($eng), 'Ein groesserer Radius findet nicht weniger.');
+
+        foreach ($eng as $nah) {
+            self::assertContains($nah, $weit, 'Was im engen Radius liegt, liegt auch im weiten.');
+        }
     }
 
     public function testNearCitiesOnlyReturnsEnabledCities(): void


### PR DESCRIPTION
## Summary

**Issue #1141** für die beiden handgeschriebenen Abfragen. Sie rechneten die Haversine-Formel in SQL — und mussten dafür **jede Zeile anfassen und durchrechnen**. `ST_DWithin` kann den GiST-Index nutzen, den die Geometriespalten seit #1518 und #1519 tragen.

| | vorher | jetzt |
|---|---|---|
| `CityRepository::findNearCities` | Haversine in `WHERE` **und** `ORDER BY` | `ST_DWithin` + `ST_Distance` |
| `RideRepository::findRidesForLocation` | Haversine in einer Unterabfrage | `ST_DWithin` im `WHERE` |

**Die Unterabfrage fällt weg.** Sie gab es nur, damit sich auf die selbst gerechnete Entfernung filtern ließ — ein `HAVING` ohne `GROUP BY`, das PostgreSQL ablehnt. Mit `ST_DWithin` gehört die Bedingung ins `WHERE`, wo sie immer hingehört hätte.

Nach dieser Änderung enthält **keines der beiden Repositories** noch `acos`, `radians` oder einen Erdradius.

## Ändert sich das Ergebnis?

Ein bisschen, und zum Besseren: Gerechnet wird jetzt über `geography`, also auf dem WGS84-Ellipsoid und in Metern; die Formel nahm eine Kugel mit 6371 km Radius an.

Ein Test vergleicht **beide Verfahren über alle Städte** und hält sie auf unter ein Prozent Abweichung. Wäre der Abstand größer, hätte ich beim Umstellen etwas verwechselt — Länge mit Breite, oder Meter mit Kilometern.

## Ein stiller Fehler, den dieser Test selbst zutage förderte

Ohne Import von `PostgreSQLPlatform` löst der Klassenname im Test-Namensraum auf, `instanceof` liefert `false`, und der Test **überspringt sich stillschweigend**, statt zu scheitern. Zwei meiner neuen Tests taten das, bis mir die Zahl der Skips auffiel. Genau die Sorte Test, die grün aussieht und nichts prüft.

## Test Plan

- `tests/Repository/NativeGeoQueryTest.php` wächst auf **7 Tests**, alle laufen (keine Skips): Gleichwertigkeit mit der alten Formel, Radiusgrenze, beide Abfragen liefern gefüllte Entities.
- Volle Suite auf frisch aufgesetzter Datenbank: **1535 Tests grün**. `vendor/bin/phpstan analyse` ohne Fehler.

## Noch offen an #1141

Die Bounding-Box- und Radius-Abfragen im `DataQuery` laufen weiterhin über `latitude`/`longitude`. Sie funktionieren unverändert; erst wenn auch sie umgestellt sind, können die Fließkommaspalten fallen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR