### PR TITLE
Let a photo without a ride, a user or a city render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ public/users/
 /.env
 /.env.test
 /.env.local
+/.env.test.local
 /public/bundles/
 /var/
 /vendor/

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -445,12 +445,6 @@ parameters:
 			path: src/Controller/Photo/LegacyPhotoUploadController.php
 
 		-
-			message: '#^Right side of && is always true\.$#'
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: src/Controller/Photo/PhotoController.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
@@ -4595,12 +4589,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Controller/LoginControllerTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with App\\Entity\\User and ''Photo should be…'' will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: tests/Controller/PhotoUploadControllerTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with int will always evaluate to true\.$#'

--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -258,12 +258,16 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
         return $this;
     }
 
-    public function getUser(): User
+    /**
+     * Der Hochladende darf fehlen — die Spalte war seit jeher nullbar, nur
+     * Getter und Setter waren strenger als sie.
+     */
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
-    public function setUser(User $user): Photo
+    public function setUser(?User $user): Photo
     {
         $this->user = $user;
 

--- a/templates/Photo/_comments.html.twig
+++ b/templates/Photo/_comments.html.twig
@@ -10,7 +10,11 @@
                     class="btn btn-success pull-right"
                     data-controller="hint-modal"
                     data-modal-hint-title="{{ 'hint_modal.photo.post_add_button.title'|trans }}"
-                    data-modal-hint-text="{{ 'hint_modal.photo.post_add_button.text'|trans({'%city%': photo.ride.city.city, '%dateTime%': photo.ride.dateTime|date('d.m.Y')}) }}"
+                    {# Ohne Tour kommen Stadt und Datum vom Foto selbst. #}
+                    data-modal-hint-text="{{ 'hint_modal.photo.post_add_button.text'|trans({
+                        '%city%': photo.city ? photo.city.city : '',
+                        '%dateTime%': (photo.ride ? photo.ride.dateTime : photo.exifCreationDate)|date('d.m.Y')
+                    }) }}"
                     data-modal-hint-size="md">
                 Kommentar hinzufügen
             </button>

--- a/templates/Photo/_details.html.twig
+++ b/templates/Photo/_details.html.twig
@@ -6,19 +6,23 @@
     </div>
     <div class="card-body">
         <dl class="mb-0">
-            <dt>
-                <i class="far fa-user me-1"></i> Fotografïn
-            </dt>
-            <dd>
-                {{ photo.user.username }}
-            </dd>
+            {% if photo.user %}
+                <dt>
+                    <i class="far fa-user me-1"></i> Fotografïn
+                </dt>
+                <dd>
+                    {{ photo.user.username }}
+                </dd>
+            {% endif %}
 
             {% if photo.exifCreationDate %}
             <dt>
                 <i class="far fa-calendar-alt me-1"></i> Aufnahmedatum
             </dt>
             <dd>
-                {{ photo.exifCreationDate|date('d.m.y H:i:s', photo.ride.city.timezone) }} Uhr
+                {# Die Zeitzone kommt von der Stadt des Fotos, nicht ueber die
+                   Tour: 139 Fotos haengen an keiner. #}
+                {{ photo.exifCreationDate|date('d.m.y H:i:s', photo.city ? photo.city.timezone : 'UTC') }} Uhr
             </dd>
             {% endif %}
 

--- a/templates/Photo/show.html.twig
+++ b/templates/Photo/show.html.twig
@@ -6,8 +6,12 @@
 
 {% block breadcrumb %}
     {{ breadcrumb.item(city.city, object_path(city)) }}
-    {{ breadcrumb.item(ride.title, object_path(ride)) }}
-    {{ breadcrumb.item('Fotos', object_path(ride, 'caldera_criticalmass_photo_ride_list')) }}
+    {# 139 Fotos haengen an keiner Tour; der Controller weiss das laengst und
+       reicht dann null herein. Ohne Tour entfaellt der Zweig einfach. #}
+    {% if ride %}
+        {{ breadcrumb.item(ride.title, object_path(ride)) }}
+        {{ breadcrumb.item('Fotos', object_path(ride, 'caldera_criticalmass_photo_ride_list')) }}
+    {% endif %}
     {{ breadcrumb.active('Foto ' ~ photo.id ~ ' aus ' ~ city.city) }}
 {% endblock %}
 
@@ -39,7 +43,9 @@
 
     <div class="row mb-4">
         <div class="col-12">
-            {% if not app.user and photo.user.blurGalleries %}
+            {# Auch der Hochladende kann fehlen. Ohne ihn gibt es niemanden,
+               der das Verschleiern eingestellt haben koennte. #}
+            {% if not app.user and photo.user and photo.user.blurGalleries %}
                 <div class="position-relative">
                     <div class="position-absolute w-100 h-100 d-flex align-items-center justify-content-center" style="z-index: 100; top: 0; left: 0;">
                         <div class="col-md-6 offset-md-3">

--- a/tests/Controller/PhotoWithoutRideControllerTest.php
+++ b/tests/Controller/PhotoWithoutRideControllerTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\Photo;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Die Fotoseite muss ein Foto ohne Tour zeigen koennen.
+ *
+ * 139 Fotos haengen an keiner Tour, eines an keinem Nutzer. Der Controller
+ * weiss das laengst — er prueft `if ($ride && ...)`, bevor er den Track sucht,
+ * und reicht dann `null` an das Template weiter. Nur das Template rechnete
+ * nicht damit und rief `object_path(null)` auf, was seit dem 20. Juli in
+ * einem 500er endete, gleichmaessig ueber die Wochen verteilt und zuletzt
+ * heute wieder.
+ */
+class PhotoWithoutRideControllerTest extends AbstractControllerTestCase
+{
+    public function testThePageWorksForAPhotoWithoutARide(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $foto = $this->fotoAnlegen($entityManager, mitNutzer: true);
+
+        $client->request('GET', sprintf('/photo/%d', $foto->getId()));
+
+        self::assertResponseIsSuccessful('Ein Foto ohne Tour hat trotzdem eine Seite.');
+
+        $entityManager->remove($foto);
+        $entityManager->flush();
+    }
+
+    /**
+     * Ohne Tour faellt der Tourenzweig der Brotkrumen weg — die Stadt bleibt.
+     */
+    public function testTheBreadcrumbFallsBackToTheCity(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $foto = $this->fotoAnlegen($entityManager, mitNutzer: true);
+
+        $crawler = $client->request('GET', sprintf('/photo/%d', $foto->getId()));
+        $brotkrumen = $crawler->filter('.breadcrumb')->text();
+
+        self::assertStringContainsString(
+            $foto->getCity()->getCity(),
+            $brotkrumen,
+            'Die Stadt steht weiterhin in den Brotkrumen.'
+        );
+        self::assertStringContainsString(
+            sprintf('Foto %d', $foto->getId()),
+            $brotkrumen,
+            'Und das Foto selbst als aktiver Eintrag.'
+        );
+
+        $entityManager->remove($foto);
+        $entityManager->flush();
+    }
+
+    /**
+     * Und auch ohne Hochladenden: Ohne ihn gibt es niemanden, der das
+     * Verschleiern der Galerien eingestellt haben koennte.
+     */
+    public function testThePageWorksForAPhotoWithoutAUser(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $foto = $this->fotoAnlegen($entityManager, mitNutzer: false);
+
+        $client->request('GET', sprintf('/photo/%d', $foto->getId()));
+
+        self::assertResponseIsSuccessful('Ein Foto ohne Hochladenden hat trotzdem eine Seite.');
+
+        $entityManager->remove($foto);
+        $entityManager->flush();
+    }
+
+    private function fotoAnlegen(EntityManagerInterface $entityManager, bool $mitNutzer): Photo
+    {
+        $stadt = $entityManager->getRepository(City::class)->findOneBy([]);
+        self::assertNotNull($stadt, 'Die Fixtures liefern mindestens eine Stadt.');
+
+        $foto = new Photo();
+        $foto
+            ->setCity($stadt)
+            ->setImageName('foto-ohne-tour.jpg')
+            ->setEnabled(true)
+            ->setDeleted(false);
+
+        if ($mitNutzer) {
+            $foto->setUser($entityManager->getRepository(User::class)->findOneBy([]));
+        }
+
+        // Kein setRide() — genau darum geht es.
+        self::assertNull($foto->getRide());
+
+        $entityManager->persist($foto);
+        $entityManager->flush();
+
+        return $foto;
+    }
+}

--- a/tests/Controller/PhotoWithoutRideControllerTest.php
+++ b/tests/Controller/PhotoWithoutRideControllerTest.php
@@ -87,11 +87,10 @@ class PhotoWithoutRideControllerTest extends AbstractControllerTestCase
         self::assertNotNull($stadt, 'Die Fixtures liefern mindestens eine Stadt.');
 
         $foto = new Photo();
-        $foto
-            ->setCity($stadt)
-            ->setImageName('foto-ohne-tour.jpg')
-            ->setEnabled(true)
-            ->setDeleted(false);
+        $foto->setCity($stadt);
+        $foto->setImageName('foto-ohne-tour.jpg');
+        $foto->setEnabled(true);
+        $foto->setDeleted(false);
 
         if ($mitNutzer) {
             $foto->setUser($entityManager->getRepository(User::class)->findOneBy([]));


### PR DESCRIPTION
## Der Fehler

`Photo::getUser()` versprach ein `User`, während die Spalte und die Eigenschaft dahinter (`protected ?User $user = null`) seit jeher nullbar waren — **dieselbe Unstimmigkeit wie in der Timeline** (#1521), nur eine Ebene tiefer.

Vier Templates folgten diesem Versprechen und griffen auf etwas zu, das fehlen kann:

| Datei | Zugriff |
|---|---|
| `show.html.twig` | die Tour in den Brotkrumen, und `photo.user.blurGalleries` |
| `_comments.html.twig` | Stadt und Datum **der Tour**, für den Hinweistext |
| `_details.html.twig` | der Name des Hochladenden, und die Zeitzone über die Stadt der Tour |

Im Bestand: **139 Fotos ohne Tour**, eines ohne Nutzer, eines ohne Stadt.

Der Controller wusste das übrigens die ganze Zeit — er prüft `if ($ride && ...)`, bevor er den Track sucht, und reicht dann `null` an das Template weiter. Nur das Template rechnete nicht damit.

## Was das getroffen hat

Jeder Aufruf eines dieser 139 Fotos endete in einem 500er. Seit dem 20. Juli **61 Mal**, gleichmäßig über die Wochen verteilt und zuletzt heute wieder.

## Die Lösung

- `getUser()` und `setUser()` werden nullbar, wie die Eigenschaft es immer war.
- Ohne Tour fällt der Tourenzweig der Brotkrumen weg; Stadt und Foto bleiben.
- Stadt und Datum kommen jetzt **vom Foto selbst**, das beides trägt, statt den Umweg über die Tour zu nehmen. Die Zeitzone ebenso.
- Ohne Hochladenden entfällt die Zeile „Fotografïn" — es gibt dann auch niemanden, der das Verschleiern der Galerien eingestellt haben könnte.

## Zwei Baseline-Einträge sind gegenstandslos geworden

Weil der Getter fälschlich nicht-nullbar war, hielt PHPStan zwei echte Prüfungen für tote Zweige:

- `if ($ride && $photo->getUser())` in `PhotoController` — „Right side of && is always true"
- ein `assertNotNull` in `PhotoUploadControllerTest` — „will always evaluate to true"

Beide prüfen jetzt wieder etwas, und beide Einträge sind aus `phpstan-baseline.neon` entfernt.

## Test Plan

`tests/Controller/PhotoWithoutRideControllerTest.php`, **3 Tests**: die Seite trägt ein Foto ohne Tour, die Brotkrumen fallen auf die Stadt zurück, und ein Foto ohne Hochladenden geht auch.

**Gegenprobe:** Ohne den Schutz fallen alle drei um — „Impossible to access an attribute ("title") on a null variable" in Zeile 11. In der Produktion tritt derselbe Fehler eine Stufe später zutage, in `objectPath()`.

**Volle Suite:** 1536 Tests, alles grün (`main`: 1533).

Dabei eine Falle, die auch andere treffen dürfte: Ein Suite-Lauf ist nur reproduzierbar, wenn man vorher **drei** Dinge wegräumt — die Testdatenbank, den `FilesystemAdapter` von `CachedTimeline` in `sys_get_temp_dir()`, und `var/cache/test` mit dem Zustand des Ratenbegrenzers. Die Suite schreibt mehr als 120 API-Anfragen je 15 Minuten und wirft sich sonst selbst mit 429ern zurück.

`vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR