### PR TITLE
Keep out of the galleries what is not an image

### DIFF
--- a/.env.test.local
+++ b/.env.test.local
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:55432/cm?serverVersion=17&charset=utf8"
+MAILER_SENDER=test@criticalmass.in

--- a/migrations/Version20260906100000.php
+++ b/migrations/Version20260906100000.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Nimmt die Nicht-Bilder aus der Fototabelle aus dem Verkehr.
+ *
+ * 17 Zeilen tragen kein Bild: dreizehn Videos (mp4, mov, avi), die ein
+ * frueherer Upload noch durchliess, und vier leere Dateien
+ * (application/x-empty) aus einem missglueckten Upload an derselben Tour.
+ * Liip kann daraus keine Miniaturansicht bauen und wirft stattdessen — jeder
+ * Abruf einer solchen Vorschau endet in einem 500er, seit dem 9. Juli 292 Mal
+ * und weiterhin ein paar Mal am Tag.
+ *
+ * Die Menge kann nicht mehr wachsen: Der heutige Upload nimmt nur noch
+ * jpg, jpeg, png, webp, gif, heic und heif an (UploadDispatcher), und die
+ * juengste dieser Zeilen stammt vom 4. Dezember 2025.
+ *
+ * `deleted` ist die Kennzeichnung, auf die alle Galerie-Abfragen bereits
+ * hoeren — nicht ganz woertlich gemeint, denn geloescht hat sie niemand, aber
+ * anzeigbar sind sie auch nicht. Die Dateien selbst bleiben unangetastet, und
+ * down() nimmt die Kennzeichnung fuer genau diese Zeilen wieder zurueck.
+ */
+final class Version20260906100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Mark photos that are not images as deleted';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE photo
+            SET deleted = true
+            WHERE deleted = false
+              AND (imageMimeType IS NULL OR imageMimeType NOT LIKE 'image/%')
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("
+            UPDATE photo
+            SET deleted = false
+            WHERE deleted = true
+              AND (imageMimeType IS NULL OR imageMimeType NOT LIKE 'image/%')
+        ");
+    }
+}

--- a/src/Repository/PhotoRepository.php
+++ b/src/Repository/PhotoRepository.php
@@ -202,6 +202,27 @@ class PhotoRepository extends ServiceEntityRepository
         ];
     }
 
+    /**
+     * Beschraenkt eine Abfrage auf das, was sich auch anzeigen laesst.
+     *
+     * In der Fototabelle stecken 17 Zeilen, die kein Bild sind: Videos aus
+     * einem frueheren Upload und vier leere Dateien. Liip kann daraus keine
+     * Miniaturansicht bauen und wirft stattdessen, was jeden Abruf einer
+     * solchen Vorschau in einem 500er enden laesst.
+     *
+     * Version20260906100000 nimmt den Bestand aus dem Verkehr; dieser Riegel
+     * sorgt dafuer, dass so etwas gar nicht erst wieder in einer Galerie
+     * landet. Ein fehlender Typ zaehlt als Bild — er ist bei alten Zeilen
+     * schlicht nie gesetzt worden.
+     */
+    private function nurAnzeigbareBilder(QueryBuilder $builder): QueryBuilder
+    {
+        return $builder->andWhere($builder->expr()->orX(
+            $builder->expr()->isNull('p.imageMimeType'),
+            $builder->expr()->like('p.imageMimeType', $builder->expr()->literal('image/%'))
+        ));
+    }
+
     public function buildQueryPhotosByRide(Ride $ride): QueryBuilder
     {
         $builder = $this->createQueryBuilder('p');
@@ -213,7 +234,7 @@ class PhotoRepository extends ServiceEntityRepository
             ->setParameter('deleted', false)
             ->addOrderBy('p.exifCreationDate', 'ASC');
 
-        return $builder;
+        return $this->nurAnzeigbareBilder($builder);
     }
 
     public function findPhotosByRide(Ride $ride): array
@@ -254,7 +275,7 @@ class PhotoRepository extends ServiceEntityRepository
         ->setParameter('deleted', false)
         ->addOrderBy('p.exifCreationDate', 'ASC');
 
-        return $builder->getQuery();
+        return $this->nurAnzeigbareBilder($builder)->getQuery();
     }
 
     public function findPhotosByUserAndRide(User $user, Ride $ride): array
@@ -275,6 +296,8 @@ class PhotoRepository extends ServiceEntityRepository
             ->setParameter('enabled', true)
             ->andWhere($builder->expr()->eq('p.deleted', ':deleted'))
             ->setParameter('deleted', false);
+
+        $this->nurAnzeigbareBilder($builder);
 
         if ($city) {
             $builder

--- a/tests/Repository/PhotosThatAreNotImagesTest.php
+++ b/tests/Repository/PhotosThatAreNotImagesTest.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\Photo;
+use App\Entity\Ride;
+use App\Repository\PhotoRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Was kein Bild ist, gehoert in keine Galerie.
+ *
+ * 17 Zeilen der Fototabelle tragen kein Bild: dreizehn Videos, die ein
+ * frueherer Upload noch durchliess, und vier leere Dateien aus einem
+ * missglueckten Upload. Liip kann daraus keine Miniaturansicht bauen und
+ * wirft stattdessen — jeder Abruf einer solchen Vorschau endete in einem
+ * 500er, seit dem 9. Juli 292 Mal.
+ *
+ * Version20260906100000 nimmt den Bestand aus dem Verkehr. Diese Tests
+ * pruefen den Riegel davor: dass eine solche Zeile gar nicht erst in einer
+ * Galerie auftaucht, auch wenn sie neu hineingeriete.
+ */
+class PhotosThatAreNotImagesTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private PhotoRepository $photoRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->photoRepository = static::getContainer()->get(PhotoRepository::class);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function nichtBilder(): array
+    {
+        return [
+            'mp4' => ['video.mp4', 'video/mp4'],
+            'quicktime' => ['video.mov', 'video/quicktime'],
+            'avi' => ['video.avi', 'video/x-msvideo'],
+            'leere Datei' => ['leer', 'application/x-empty'],
+        ];
+    }
+
+    #[DataProvider('nichtBilder')]
+    public function testTheRideGalleryLeavesItOut(string $dateiname, string $typ): void
+    {
+        $tour = $this->irgendeineTour();
+        $vorher = count($this->photoRepository->findPhotosByRide($tour));
+
+        $foto = $this->fotoAnlegen($tour, $dateiname, $typ);
+
+        self::assertCount(
+            $vorher,
+            $this->photoRepository->findPhotosByRide($tour),
+            sprintf('%s taucht in der Galerie der Tour nicht auf.', $typ)
+        );
+
+        $this->entityManager->remove($foto);
+        $this->entityManager->flush();
+    }
+
+    public function testAnOrdinaryImageStillShows(): void
+    {
+        $tour = $this->irgendeineTour();
+        $vorher = count($this->photoRepository->findPhotosByRide($tour));
+
+        $foto = $this->fotoAnlegen($tour, 'foto.jpg', 'image/jpeg');
+
+        self::assertCount(
+            $vorher + 1,
+            $this->photoRepository->findPhotosByRide($tour),
+            'Ein echtes Bild kommt selbstverstaendlich weiterhin durch.'
+        );
+
+        $this->entityManager->remove($foto);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Alte Zeilen haben nie einen Typ bekommen. Sie gelten als Bild — sonst
+     * verschwaende dieser Riegel den halben Bestand.
+     */
+    public function testAPhotoWithoutAMimeTypeCountsAsAnImage(): void
+    {
+        $tour = $this->irgendeineTour();
+        $vorher = count($this->photoRepository->findPhotosByRide($tour));
+
+        $foto = $this->fotoAnlegen($tour, 'alt.jpg', null);
+
+        self::assertCount(
+            $vorher + 1,
+            $this->photoRepository->findPhotosByRide($tour),
+            'Ohne Typangabe bleibt es sichtbar.'
+        );
+
+        $this->entityManager->remove($foto);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Und der zufaellige Ausschnitt fuer die Startseite darf gar nichts
+     * anderes als Bilder liefern.
+     */
+    public function testTheRandomSelectionIsAllImages(): void
+    {
+        $tour = $this->irgendeineTour();
+        $foto = $this->fotoAnlegen($tour, 'video.mp4', 'video/mp4');
+
+        foreach ($this->photoRepository->findSomePhotos(100) as $treffer) {
+            $typ = $treffer->getImageMimeType();
+
+            self::assertTrue(
+                null === $typ || str_starts_with($typ, 'image/'),
+                sprintf('Der Ausschnitt enthaelt %s.', (string) $typ)
+            );
+        }
+
+        $this->entityManager->remove($foto);
+        $this->entityManager->flush();
+    }
+
+    private function irgendeineTour(): Ride
+    {
+        $tour = $this->entityManager->getRepository(Ride::class)->findOneBy([]);
+        self::assertNotNull($tour, 'Die Fixtures liefern mindestens eine Tour.');
+
+        return $tour;
+    }
+
+    private function fotoAnlegen(Ride $tour, string $dateiname, ?string $typ): Photo
+    {
+        $foto = new Photo();
+        $foto->setRide($tour);
+        $foto->setCity($tour->getCity());
+        $foto->setImageName($dateiname);
+        $foto->setImageMimeType($typ);
+        $foto->setEnabled(true);
+        $foto->setDeleted(false);
+
+        $this->entityManager->persist($foto);
+        $this->entityManager->flush();
+
+        return $foto;
+    }
+}


### PR DESCRIPTION
## Der Fehler

17 Zeilen der Fototabelle tragen kein Bild:

| Art | Anzahl |
|---|---|
| Videos (`video/mp4`, `video/quicktime`, `video/x-msvideo`) | 13 |
| leere Dateien (`application/x-empty`) | 4 |

Liip kann daraus keine Miniaturansicht bauen und wirft stattdessen. Jeder Abruf einer solchen Vorschau endete in einem 500er — **292 Mal seit dem 9. Juli**, und weiterhin ein paar Mal am Tag. Der Fehler entsteht beim Abruf des Vorschaubildes selbst (`/media/cache/…`), nicht beim Rendern der Seite; die Seite baut die URL bereitwillig, erst der Bildabruf kippt.

Die vier leeren Dateien stammen übrigens alle vom selben missglückten Upload an einer Tour.

## Warum die Menge abgeschlossen ist

Der heutige Upload nimmt nur noch `jpg, jpeg, png, webp, gif, heic, heif` an (`UploadDispatcher::IMAGE_EXTENSIONS`) — ein Video kommt gar nicht mehr herein. Die **jüngste** dieser Zeilen stammt vom **4. Dezember 2025**, also aus der Zeit davor.

## Die Lösung

**Eine Migration** nimmt den Bestand aus dem Verkehr, über `deleted` — die Kennzeichnung, auf die alle Galerie-Abfragen bereits hören. Nicht ganz wörtlich gemeint, denn gelöscht hat sie niemand, aber anzeigbar sind sie eben auch nicht. **Die Dateien selbst bleiben unangetastet**, und `down()` nimmt die Kennzeichnung wieder zurück.

**Ein Riegel** in den Galerie-Abfragen (`buildQueryPhotosByRide`, `buildQueryPhotosByUserAndRide`, `findSomePhotos`) sorgt dafür, dass so etwas gar nicht erst wieder auftaucht. Das ist der prüfbare Teil: Eine reine Datenmigration ließe sich nicht testen, weil die Fixtures keine Videos enthalten.

Ein **fehlender** Typ zählt als Bild. Alte Zeilen haben nie einen bekommen, und sie für verdächtig zu halten würde den halben Bestand verschwinden lassen.

## Warum nicht an den elf Ausgabestellen ansetzen?

Weil es elf sind — Stadtseite, Timeline, Galerien, Fotoverwaltung, Fotoseite — gespeist aus verschiedenen Abfragen. Ein Filter je Ausgabestelle wäre lückenhaft; an der Quelle und am Bestand ist es vollständig.

## Test Plan

`tests/Repository/PhotosThatAreNotImagesTest.php`, **7 Tests**: die vier Nicht-Bild-Arten bleiben aus der Tourengalerie draußen, ein echtes Bild kommt durch, eines ohne Typangabe auch, und der zufällige Ausschnitt für die Startseite enthält nichts anderes als Bilder.

**Gegenprobe:** Ohne den Riegel fallen vier davon um.

**Die Migration gegen eine echte Datenbank** in beide Richtungen geprüft: `up` setzt die Kennzeichnung, `down` nimmt sie zurück.

**Volle Suite:** 1540 Tests, alles grün. `vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

### Ein Vorbehalt zu `down()`

`down()` erkennt die Zeilen an derselben Bedingung. Es würde daher auch eine Nicht-Bild-Zeile wieder sichtbar machen, die *vorher schon* als gelöscht markiert war — heute gibt es keine solche, aber falls dieser PR lange liegen bleibt, lohnt vor dem Zurückrollen ein Blick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR