### PR TITLE
Let our own background jobs through the API rate limit

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,6 +4,11 @@ APP_SECRET=change-me
 MAILER_DSN=null://null
 MAILER_SENDER=noreply@criticalmass.in
 
+# Womit sich die eigenen Hintergrundlaeufe an der /api-Firewall ausweisen und
+# ihr weites Schreibkontingent bekommen. Leer lassen heisst: niemand ist
+# vertrauenswuerdig.
+CRITICALMASS_API_TOKEN=
+
 FB_ID=
 FB_SECRET=
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ public/users/
 /.env
 /.env.test
 /.env.local
+/.env.test.local
 /public/bundles/
 /var/
 /vendor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,21 @@ composer test:run          # Just run PHPUnit (no DB reset)
 composer test:api          # Only API test suite
 vendor/bin/phpunit tests/Path/To/TestFile.php              # Single test file
 vendor/bin/phpunit --filter testMethodName                  # Single test method
+# **Ein Suite-Lauf ist nur reproduzierbar, wenn vorher DREI Dinge weg sind.**
+# Sonst misst man die Vorgeschichte statt den Code — zwei Vergleiche zwischen
+# main und einem Branch lieferten so 341 Fehler gegen 35, obwohl beide Staende
+# vollstaendig gruen sind:
+#   1. die Testdatenbank (composer test:db:reset) — die Suite ueberschreibt
+#      ihren eigenen Bestand,
+#   2. var/cache/test — dort liegt der Zustand des API-Ratenbegrenzers. Die
+#      Suite schreibt mehr als 120 API-Anfragen je 15 Minuten und wirft sich
+#      beim zweiten Lauf selbst mit 429ern zurueck,
+#   3. der FilesystemAdapter von CachedTimeline in sys_get_temp_dir():
+#        find "$(php -r 'echo sys_get_temp_dir();')/symfony-cache" -maxdepth 1 \
+#          -name '*criticalmass-timeline*' -exec rm -rf {} +
+#      Er wird an der Cache-Konfiguration vorbei gebaut, ueberdauert Laeufe und
+#      laesst Startseiten-Tests gruen aussehen, ohne etwas zu pruefen.
+#      (In zsh scheitert das Glob-Muster ohne Treffer — deshalb `find`.)
 # Controller/DB tests brauchen eine laufende Datenbank; reine Unit-Tests laufen ohne.
 # Die CI faehrt PostgreSQL 17, wie die Produktion. Der Code ist portabel geblieben
 # und besteht die Suite auch gegen MariaDB — das ist aber nicht mehr die Zielplattform.

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -24,3 +24,13 @@ framework:
             policy: sliding_window
             limit: 120
             interval: '15 minutes'
+
+        # Fuer die eigenen Hintergrundlaeufe, die sich mit dem vereinbarten
+        # Token ausweisen. Der Aktivitaetslauf schreibt einmal je Stadt, also
+        # ueber 700 Anfragen am Stueck; der Eimer fasst das und fuellt sich mit
+        # 200 je Minute nach. Eine ausser Kontrolle geratene Schleife bremst er
+        # weiterhin.
+        api_write_trusted:
+            policy: token_bucket
+            limit: 1000
+            rate: { interval: '1 minute', amount: 200 }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,10 @@ parameters:
     # to outlive a couple of missed cron runs, otherwise a visitor pays for the
     # API call the cron was supposed to have made.
     feeds.cache_ttl: 5400
+    # Womit sich die eigenen Hintergrundlaeufe (Aktivitaet, Wetter, Feeds) an
+    # der /api-Firewall als solche zu erkennen geben. Leer gelassen heisst:
+    # niemand ist vertrauenswuerdig, alle teilen sich das enge Kontingent.
+    api.own_service_token: '%env(string:default::CRITICALMASS_API_TOKEN)%'
     notification.mail.sender_address: '%env(MAILER_SENDER)%'
     request_listener.http_port: 80
     request_listener.https_port: 443
@@ -51,6 +55,7 @@ services:
             $rootDirectory: '%kernel.project_dir%'
             $webRootDir: '%kernel.project_dir%/../public'
             $gapWidth: '%track.gap_width%'
+            $eigenerDienstToken: '%api.own_service_token%'
             $facebookAppId: '%facebook.app_id%'
             $facebookAppSecret: '%facebook.app_secret%'
             $facebookDefaultToken: '%facebook.default_token%'

--- a/src/EventSubscriber/ApiRateLimitSubscriber.php
+++ b/src/EventSubscriber/ApiRateLimitSubscriber.php
@@ -3,6 +3,7 @@
 namespace App\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -10,14 +11,29 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 /**
  * Drosselt schreibende Zugriffe (POST/PUT/PATCH/DELETE) auf die anonyme
- * /api-Firewall pro Client-IP (#1392). Die echte IP setzt trusted_proxies voraus.
+ * /api-Firewall (#1392). Die echte IP setzt trusted_proxies voraus.
+ *
+ * Wer sich mit dem vereinbarten Token ausweist, bekommt ein eigenes, weites
+ * Kontingent. Das ist kein Nachlass, sondern eine Berichtigung: Der naechtliche
+ * Aktivitaetslauf schickt **eine Anfrage je Stadt** an
+ * POST /api/city/{slug}/activity, bei ueber 700 Staedten gegen ein Kontingent
+ * von 120 je 15 Minuten. Er wiederholt bei 429, wodurch sich der Lauf auf
+ * anderthalb Stunden streckte, rund 50 Staedte je Nacht ausfielen und seit dem
+ * 25. Juli 17.159 Fehlermeldungen aufliefen — etwa 730 pro Nacht.
+ *
+ * Die Bremse fuer alle anderen bleibt unveraendert; sie ist das Einzige, was
+ * vor dieser Firewall steht.
  */
 final class ApiRateLimitSubscriber implements EventSubscriberInterface
 {
     private const WRITE_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
 
+    public const TOKEN_HEADER = 'X-Criticalmass-Token';
+
     public function __construct(
         private readonly RateLimiterFactory $apiWriteLimiter,
+        private readonly RateLimiterFactory $apiWriteTrustedLimiter,
+        private readonly string $eigenerDienstToken = '',
     ) {
     }
 
@@ -44,7 +60,9 @@ final class ApiRateLimitSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $limit = $this->apiWriteLimiter->create($request->getClientIp())->consume();
+        $limit = $this->istEigenerDienst($request)
+            ? $this->apiWriteTrustedLimiter->create('eigener-dienst')->consume()
+            : $this->apiWriteLimiter->create($request->getClientIp())->consume();
 
         if (false === $limit->isAccepted()) {
             throw new TooManyRequestsHttpException(
@@ -52,5 +70,25 @@ final class ApiRateLimitSubscriber implements EventSubscriberInterface
                 'API rate limit exceeded.',
             );
         }
+    }
+
+    /**
+     * Ein leer gelassenes Token gilt nie als Uebereinstimmung — sonst wuerde
+     * eine vergessene Konfiguration jeden Absender ohne Kopfzeile
+     * durchwinken.
+     */
+    private function istEigenerDienst(Request $request): bool
+    {
+        if ('' === $this->eigenerDienstToken) {
+            return false;
+        }
+
+        $mitgeschickt = $request->headers->get(self::TOKEN_HEADER, '');
+
+        if ('' === $mitgeschickt) {
+            return false;
+        }
+
+        return hash_equals($this->eigenerDienstToken, $mitgeschickt);
     }
 }

--- a/tests/EventSubscriber/ApiRateLimitSubscriberTest.php
+++ b/tests/EventSubscriber/ApiRateLimitSubscriberTest.php
@@ -37,6 +37,18 @@ final class ApiRateLimitSubscriberTest extends TestCase
         );
     }
 
+    private function eventMitToken(string $method, string $path, string $token): RequestEvent
+    {
+        $request = Request::create($path, $method);
+        $request->headers->set(ApiRateLimitSubscriber::TOKEN_HEADER, $token);
+
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+
     public function testThrottlesApiWriteWhenLimitExceeded(): void
     {
         $factory = $this->factory();
@@ -44,12 +56,12 @@ final class ApiRateLimitSubscriberTest extends TestCase
         $factory->create(self::CLIENT_IP)->consume();
 
         $this->expectException(TooManyRequestsHttpException::class);
-        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('POST', '/api/estimate'));
+        (new ApiRateLimitSubscriber($factory, $this->factory()))->onKernelRequest($this->event('POST', '/api/estimate'));
     }
 
     public function testAllowsApiWriteWithinLimit(): void
     {
-        (new ApiRateLimitSubscriber($this->factory()))->onKernelRequest($this->event('POST', '/api/estimate'));
+        (new ApiRateLimitSubscriber($this->factory(), $this->factory()))->onKernelRequest($this->event('POST', '/api/estimate'));
         $this->addToAssertionCount(1);
     }
 
@@ -59,7 +71,7 @@ final class ApiRateLimitSubscriberTest extends TestCase
         $factory->create(self::CLIENT_IP)->consume();
 
         // Bucket ist erschöpft — würde der Subscriber Reads verarbeiten, gäbe es 429.
-        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('GET', '/api/ride'));
+        (new ApiRateLimitSubscriber($factory, $this->factory()))->onKernelRequest($this->event('GET', '/api/ride'));
         $this->addToAssertionCount(1);
     }
 
@@ -68,7 +80,76 @@ final class ApiRateLimitSubscriberTest extends TestCase
         $factory = $this->factory();
         $factory->create(self::CLIENT_IP)->consume();
 
-        (new ApiRateLimitSubscriber($factory))->onKernelRequest($this->event('POST', '/login'));
+        (new ApiRateLimitSubscriber($factory, $this->factory()))->onKernelRequest($this->event('POST', '/login'));
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Der Kern der Sache: Wer sich ausweist, faellt nicht unter die Bremse
+     * fuer alle anderen — auch dann nicht, wenn deren Eimer laengst leer ist.
+     */
+    public function testOurOwnServiceGetsItsOwnAllowance(): void
+    {
+        $fuerAlle = $this->factory();
+        $fuerUns = $this->factory();
+        $fuerAlle->create(self::CLIENT_IP)->consume();
+
+        $subscriber = new ApiRateLimitSubscriber($fuerAlle, $fuerUns, 'geheim');
+        $subscriber->onKernelRequest($this->eventMitToken('POST', '/api/estimate', 'geheim'));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAWrongTokenFallsBackToTheOrdinaryLimit(): void
+    {
+        $fuerAlle = $this->factory();
+        $fuerAlle->create(self::CLIENT_IP)->consume();
+
+        $subscriber = new ApiRateLimitSubscriber($fuerAlle, $this->factory(), 'geheim');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $subscriber->onKernelRequest($this->eventMitToken('POST', '/api/estimate', 'falsch'));
+    }
+
+    /**
+     * Ohne konfiguriertes Token ist niemand vertrauenswuerdig. Sonst wuerde
+     * eine vergessene Konfiguration jeden Absender durchwinken, der die
+     * Kopfzeile weglaesst.
+     */
+    public function testWithoutAConfiguredTokenNobodyIsTrusted(): void
+    {
+        $fuerAlle = $this->factory();
+        $fuerAlle->create(self::CLIENT_IP)->consume();
+
+        $subscriber = new ApiRateLimitSubscriber($fuerAlle, $this->factory(), '');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $subscriber->onKernelRequest($this->event('POST', '/api/estimate'));
+    }
+
+    public function testAnEmptyHeaderIsNoMatchEither(): void
+    {
+        $fuerAlle = $this->factory();
+        $fuerAlle->create(self::CLIENT_IP)->consume();
+
+        $subscriber = new ApiRateLimitSubscriber($fuerAlle, $this->factory(), 'geheim');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $subscriber->onKernelRequest($this->eventMitToken('POST', '/api/estimate', ''));
+    }
+
+    /**
+     * Und das weite Kontingent ist keine Freikarte: Ist auch dieser Eimer
+     * leer, greift die Bremse ebenfalls.
+     */
+    public function testEvenOurOwnServiceIsStoppedWhenItRunsAway(): void
+    {
+        $fuerUns = $this->factory();
+        $fuerUns->create('eigener-dienst')->consume();
+
+        $subscriber = new ApiRateLimitSubscriber($this->factory(), $fuerUns, 'geheim');
+
+        $this->expectException(TooManyRequestsHttpException::class);
+        $subscriber->onKernelRequest($this->eventMitToken('POST', '/api/estimate', 'geheim'));
     }
 }


### PR DESCRIPTION
## Der Fehler

Der Ratenbegrenzer bremste **uns selbst**. Der nächtliche Aktivitätslauf schickt **einen POST je Stadt** an `POST /api/city/{slug}/activity` — über 700 — verteilt über die rund 85 Minuten, die er dauert. Das Kontingent von 120 je 15 Minuten erlaubt davon etwa 680.

| | |
|---|---|
| Fehlermeldungen seit 25. Juli | **17.159** — mit Abstand der häufigste Fehler der Anwendung |
| pro Nacht | ~730 |
| Städte, die jede Nacht ihren Wert verlieren | ~50 (665–672 von 722 kommen an) |

Die Abweisungen häuften sich zwischen 02 und 03:30 Uhr **UTC** — was mich zunächst in die Irre führte, denn das Zugriffsprotokoll schreibt Ortszeit, und dort ist das 04:00 Uhr: der Aktivitäts-Cronjob.

Und der Lauf sah dabei erfolgreich aus: Ein fehlgeschlagener Push bricht ihn nicht ab.

## Die Lösung

Wer sich mit dem vereinbarten Token in `X-Criticalmass-Token` ausweist, bekommt ein eigenes Kontingent: ein Eimer von 1000, der sich mit 200 je Minute füllt. Das trägt einen vollen Lauf und bremst eine außer Kontrolle geratene Schleife weiterhin.

**Für alle anderen ändert sich nichts** — 120 Schreibzugriffe je 15 Minuten und IP, wie bisher.

Ein **leer gelassenes** Token gilt nie als Übereinstimmung. Sonst würde eine vergessene Konfiguration jeden Absender durchwinken, der die Kopfzeile einfach weglässt.

## Reihenfolge beim Ausrollen

1. **activity zuerst** (criticalmass-one/activity#6) — ohne gesetztes Token schickt sie keine Kopfzeile, es ändert sich nichts.
2. **Dann dieser PR.**
3. **Dann `CRITICALMASS_API_TOKEN` auf beiden Seiten** in die jeweilige `.env.local` bzw. `.env.prod.local` setzen.

Umgekehrt geht es auch, nur bleibt die Drosselung dann bis Schritt 3 bestehen.

## Was dabei auffiel und **nicht** Teil dieses PRs ist

> Die `api`-Firewall hat `security: false`. **`POST /api/city/{slug}/activity` ist völlig ungeschützt** — jeder im Netz kann jeder Stadt einen Aktivitätswert schreiben, und dieser Wert entscheidet mit, ob eine Stadt auf der Startseite erscheint (unter 0,01 wird sie ausgeblendet).

Der Ratenbegrenzer ist dort das Einzige, was steht — deshalb habe ich ihn für Fremde bewusst nicht angefasst. Mit diesem Token existiert nun aber das Stück, das zum Schließen der Lücke fehlte: Den Endpunkt das Token *verlangen* zu lassen wäre eine kleine Änderung. Das ist allerdings eine Verhaltensänderung an einer öffentlichen API und gehört entschieden, nicht nebenbei gemacht — sag Bescheid, dann mache ich es als eigenen PR.

## Test Plan

`tests/EventSubscriber/ApiRateLimitSubscriberTest.php` wächst von 4 auf **9 Tests**: richtiges Token bekommt sein eigenes Kontingent, obwohl der Eimer der IP längst leer ist; falsches Token fällt zurück; ohne konfiguriertes Token ist niemand vertrauenswürdig; eine leere Kopfzeile ist keine Übereinstimmung; und auch das weite Kontingent ist keine Freikarte.

**Volle Suite:** 1538 Tests, alles grün. `vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

Nebenbei: `.gitignore` kennt jetzt auch `.env.test.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR