### PR TITLE
Require a number where a number is expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ public/users/
 /.env
 /.env.test
 /.env.local
+/.env.test.local
 /public/bundles/
 /var/
 /vendor/

--- a/src/Controller/Api/PhotoController.php
+++ b/src/Controller/Api/PhotoController.php
@@ -121,7 +121,7 @@ class PhotoController extends BaseController
     /**
      * Retrieve details of a single photo by its id.
      */
-    #[Route(path: '/api/photo/{id}', name: 'caldera_criticalmass_rest_photo_show', methods: ['GET'], priority: 200)]
+    #[Route(path: '/api/photo/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_rest_photo_show', methods: ['GET'], priority: 200)]
     #[OA\Tag(name: 'Photo')]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the photo', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 200, description: 'Returns photo details or 404 if not found')]

--- a/src/Controller/Api/SocialNetworkProfileController.php
+++ b/src/Controller/Api/SocialNetworkProfileController.php
@@ -65,7 +65,7 @@ class SocialNetworkProfileController extends BaseController
     /**
      * Update properties of a social network profile.
      */
-    #[Route(path: '/api/{citySlug}/socialnetwork-profiles/{id}', name: 'caldera_criticalmass_rest_socialnetwork_profiles_update', methods: ['POST'], priority: 190)]
+    #[Route(path: '/api/{citySlug}/socialnetwork-profiles/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_rest_socialnetwork_profiles_update', methods: ['POST'], priority: 190)]
     #[OA\Tag(name: 'Social Network Profile')]
     #[OA\Parameter(name: 'citySlug', in: 'path', description: 'Slug of the city', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the social network profile to update', required: true, schema: new OA\Schema(type: 'integer'))]

--- a/src/Controller/Api/TrackController.php
+++ b/src/Controller/Api/TrackController.php
@@ -37,7 +37,7 @@ class TrackController extends BaseController
     /**
      * Show details of a specified track.
      */
-    #[Route(path: '/api/track/{id}', name: 'caldera_criticalmass_rest_track_view', methods: ['GET'], priority: 200)]
+    #[Route(path: '/api/track/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_rest_track_view', methods: ['GET'], priority: 200)]
     #[OA\Tag(name: 'Track')]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the track', required: true, schema: new OA\Schema(type: 'integer'))]
     #[OA\Response(response: 200, description: 'Returned when successful')]
@@ -124,7 +124,7 @@ class TrackController extends BaseController
      *
      * Marks the track as deleted. Requires edit permissions on the track.
      */
-    #[Route('/api/track/{id}', name: 'caldera_criticalmass_rest_track_delete', methods: ['DELETE'], priority: 200)]
+    #[Route('/api/track/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_rest_track_delete', methods: ['DELETE'], priority: 200)]
     #[IsGranted('edit', 'track')]
     #[OA\Tag(name: 'Track')]
     #[OA\Parameter(name: 'id', in: 'path', description: 'Id of the track to delete', required: true, schema: new OA\Schema(type: 'integer'))]

--- a/src/Controller/CityCycle/CityCycleController.php
+++ b/src/Controller/CityCycle/CityCycleController.php
@@ -26,7 +26,7 @@ class CityCycleController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/{citySlug}/cycles/{id}/list', name: 'caldera_criticalmass_citycycle_ride_list', priority: 80)]
+    #[Route('/{citySlug}/cycles/{id}/list', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_citycycle_ride_list', priority: 80)]
     public function listRidesAction(
         CityCycle $cityCycle,
         ManagerRegistry $registry

--- a/src/Controller/CityCycle/CityCycleExecuteController.php
+++ b/src/Controller/CityCycle/CityCycleExecuteController.php
@@ -32,7 +32,7 @@ class CityCycleExecuteController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/{citySlug}/cycles/{id}/execute', name: 'caldera_criticalmass_citycycle_execute', priority: 80)]
+    #[Route('/{citySlug}/cycles/{id}/execute', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_citycycle_execute', priority: 80)]
     public function executeAction(
         Request $request,
         CityCycle $cityCycle,
@@ -71,7 +71,7 @@ class CityCycleExecuteController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/{citySlug}/cycles/{id}/execute-persist', name: 'caldera_criticalmass_citycycle_execute_persist', priority: 80)]
+    #[Route('/{citySlug}/cycles/{id}/execute-persist', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_citycycle_execute_persist', priority: 80)]
     public function executePersistAction(
         Request $request,
         CityCycle $cityCycle,

--- a/src/Controller/CityCycle/CityCycleManagementController.php
+++ b/src/Controller/CityCycle/CityCycleManagementController.php
@@ -70,7 +70,7 @@ class CityCycleManagementController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/{citySlug}/cycles/{id}/edit', name: 'caldera_criticalmass_citycycle_edit', priority: 80)]
+    #[Route('/{citySlug}/cycles/{id}/edit', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_citycycle_edit', priority: 80)]
     public function editAction(
         Request $request,
         CityCycle $cityCycle,
@@ -125,7 +125,7 @@ class CityCycleManagementController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/{citySlug}/cycles/{id}/disable', name: 'caldera_criticalmass_citycycle_disable', methods: ['POST'], priority: 80)]
+    #[Route('/{citySlug}/cycles/{id}/disable', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_citycycle_disable', methods: ['POST'], priority: 80)]
     public function disableAction(
         Request $request,
         CityCycle $cityCycle,

--- a/src/Controller/ForumSubscriptionController.php
+++ b/src/Controller/ForumSubscriptionController.php
@@ -95,7 +95,7 @@ class ForumSubscriptionController extends AbstractController
         ]);
     }
 
-    #[Route('/forum/subscriptions/{id}/remove', name: 'caldera_criticalmass_forum_unsubscribe', methods: ['POST'], priority: 240)]
+    #[Route('/forum/subscriptions/{id}/remove', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_forum_unsubscribe', methods: ['POST'], priority: 240)]
     public function removeAction(Request $request, ForumSubscription $subscription): Response
     {
         $this->denyInvalidToken($request, 'forum-subscribe');

--- a/src/Controller/Photo/PhotoController.php
+++ b/src/Controller/Photo/PhotoController.php
@@ -17,8 +17,8 @@ use Symfony\Component\Routing\Attribute\Route;
 #[Feature('photos')]
 class PhotoController extends AbstractController
 {
-    #[Route('/{citySlug}/{rideIdentifier}/photo/{id}', name: 'caldera_criticalmass_photo_show_ride', priority: 170)]
-    #[Route('/photo/{id}', name: 'caldera_criticalmass_photo_show', options: ['expose' => true], priority: 170)]
+    #[Route('/{citySlug}/{rideIdentifier}/photo/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_show_ride', priority: 170)]
+    #[Route('/photo/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_show', options: ['expose' => true], priority: 170)]
     public function showAction(
         SeoPageInterface $seoPage,
         TrackRepository $trackRepository,

--- a/src/Controller/Photo/PhotoDownloadController.php
+++ b/src/Controller/Photo/PhotoDownloadController.php
@@ -14,7 +14,7 @@ use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 #[Feature('photos')]
 class PhotoDownloadController extends AbstractController
 {
-    #[Route('/photo/{id}/download', name: 'caldera_criticalmass_photo_download', priority: 180)]
+    #[Route('/photo/{id}/download', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_download', priority: 180)]
     #[IsGranted('ROLE_PHOTO_DOWNLOAD')]
     public function downloadAction(
         UploaderHelper $uploaderHelper,

--- a/src/Controller/Photo/PhotoManagementController.php
+++ b/src/Controller/Photo/PhotoManagementController.php
@@ -54,7 +54,7 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/managephotos/{id}/delete', name: 'caldera_criticalmass_photo_delete', priority: 170)]
+    #[Route('/managephotos/{id}/delete', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_delete', priority: 170)]
     public function deleteAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
@@ -89,7 +89,7 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/photo/{id}/toggle', name: 'caldera_criticalmass_photo_toggle', priority: 170)]
+    #[Route('/photo/{id}/toggle', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_toggle', priority: 170)]
     public function toggleAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
@@ -102,7 +102,7 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/photo/{id}/featured', name: 'caldera_criticalmass_photo_featured', priority: 170)]
+    #[Route('/photo/{id}/featured', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_featured', priority: 170)]
     public function featuredPhotoAction(Request $request, Photo $photo, ManagerRegistry $registry): Response
     {
         $this->saveReferer($request);
@@ -115,7 +115,7 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/photo/{id}/place', name: 'caldera_criticalmass_photo_place_single', priority: 170)]
+    #[Route('/photo/{id}/place', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_place_single', priority: 170)]
     public function placeSingleAction(
         Request $request,
         Photo $photo,
@@ -186,7 +186,7 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/photo/{id}/rotate', name: 'caldera_criticalmass_photo_rotate', priority: 170)]
+    #[Route('/photo/{id}/rotate', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_rotate', priority: 170)]
     public function rotateAction(Request $request, Photo $photo, PhotoManipulatorInterface $photoManipulator): Response
     {
         $this->saveReferer($request);
@@ -204,8 +204,8 @@ class PhotoManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'photo')]
-    #[Route('/photo/{id}/censor', name: 'caldera_criticalmass_photo_censor', priority: 170)]
-    #[Route('/photo/{id}/censor', name: 'caldera_criticalmass_photo_censor_short', options: ['expose' => true], priority: 170)]
+    #[Route('/photo/{id}/censor', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_censor', priority: 170)]
+    #[Route('/photo/{id}/censor', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_photo_censor_short', options: ['expose' => true], priority: 170)]
     public function censorAction(
         Request $request,
         Photo $photo,

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -55,21 +55,21 @@ class PostController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/post/write/city/{id}', name: 'caldera_criticalmass_timeline_post_write_city', priority: 120)]
+    #[Route('/post/write/city/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_timeline_post_write_city', priority: 120)]
     public function writeCityAction(Request $request, City $city, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $city, $objectRouter);
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/post/write/ride/{id}', name: 'caldera_criticalmass_timeline_post_write_ride', priority: 120)]
+    #[Route('/post/write/ride/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_timeline_post_write_ride', priority: 120)]
     public function writeRideAction(Request $request, Ride $ride, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $ride, $objectRouter);
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/post/write/photo/{id}', name: 'caldera_criticalmass_timeline_post_write_photo', priority: 120)]
+    #[Route('/post/write/photo/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_timeline_post_write_photo', priority: 120)]
     public function writePhotoAction(Request $request, Photo $photo, ObjectRouterInterface $objectRouter): Response
     {
         return $this->writeAction($request, $photo, $objectRouter);
@@ -178,7 +178,7 @@ class PostController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/post/edit/{postId}', name: 'caldera_criticalmass_post_edit', priority: 120)]
+    #[Route('/post/edit/{postId}', requirements: ['postId' => '\d+'], name: 'caldera_criticalmass_post_edit', priority: 120)]
     public function editAction(
         Request $request,
         ObjectRouterInterface $objectRouter,
@@ -212,7 +212,7 @@ class PostController extends AbstractController
     }
 
     #[IsGranted('ROLE_USER')]
-    #[Route('/post/disable/{postId}', name: 'caldera_criticalmass_post_disable', methods: ['POST'], priority: 120)]
+    #[Route('/post/disable/{postId}', requirements: ['postId' => '\d+'], name: 'caldera_criticalmass_post_disable', methods: ['POST'], priority: 120)]
     public function disableAction(
         Request $request,
         ObjectRouterInterface $objectRouter,

--- a/src/Controller/Profile/ParticipationController.php
+++ b/src/Controller/Profile/ParticipationController.php
@@ -60,6 +60,7 @@ class ParticipationController extends AbstractController
     #[IsGranted('cancel', 'participation')]
     #[Route(
         '/profile/participation/{id}/update',
+        requirements: ['id' => '\d+'],
         name: 'criticalmass_user_participation_update',
         priority: 180
     )]
@@ -86,6 +87,7 @@ class ParticipationController extends AbstractController
     #[IsGranted('delete', 'participation')]
     #[Route(
         '/profile/participation/{id}/delete',
+        requirements: ['id' => '\d+'],
         name: 'criticalmass_user_participation_delete',
         priority: 180
     )]

--- a/src/Controller/RedirectingController.php
+++ b/src/Controller/RedirectingController.php
@@ -2,12 +2,23 @@
 
 namespace App\Controller;
 
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingException;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RouterInterface;
 
 class RedirectingController extends AbstractController
 {
+    public function __construct(
+        ManagerRegistry $managerRegistry,
+        private readonly RouterInterface $router,
+    ) {
+        parent::__construct($managerRegistry);
+    }
+
     #[Route(
         '/{url}',
         name: 'remove_trailing_slash',
@@ -26,6 +37,39 @@ class RedirectingController extends AbstractController
             $url = '/';
         }
 
+        $this->sackgasseAusschliessen(rtrim($pathInfo, ' /'));
+
         return $this->redirect($url, RedirectResponse::HTTP_MOVED_PERMANENTLY);
+    }
+
+    /**
+     * Bricht ab, wenn hinter dem Ziel gar nichts liegt.
+     *
+     * Diese Route passt auf jeden Pfad, der auf einen Schraegstrich endet —
+     * und genau daraus schliesst Symfony fuer *jeden* unbekannten Pfad, dass
+     * es ihn mit angehaengtem Schraegstrich gaebe. Es leitet also /gibt/es/nicht
+     * auf /gibt/es/nicht/ um, worauf diese Methode den Schraegstrich wieder
+     * abschneidet: eine Schleife, die keinen Fehler wirft und nie endet.
+     *
+     * Sichtbar wurde sie erst, als die Zahlbedingungen an den Routen dafuer
+     * sorgten, dass ein /photo/foo nicht mehr in einem 500er endet, sondern
+     * ueberhaupt keine Route mehr trifft.
+     */
+    private function sackgasseAusschliessen(string $ziel): void
+    {
+        if ('' === $ziel) {
+            return;
+        }
+
+        // Bewusst ein schlichter UrlMatcher und nicht der Router: Dessen
+        // Matcher leitet selbst um und meldet deshalb fuer jeden Pfad einen
+        // Treffer — er wuerde die Schleife bestaetigen statt sie zu erkennen.
+        $matcher = new UrlMatcher($this->router->getRouteCollection(), $this->router->getContext());
+
+        try {
+            $matcher->match($ziel);
+        } catch (RoutingException) {
+            throw $this->createNotFoundException(sprintf('Nothing behind %s', $ziel));
+        }
     }
 }

--- a/src/Controller/Ride/SubrideController.php
+++ b/src/Controller/Ride/SubrideController.php
@@ -84,6 +84,7 @@ class SubrideController extends AbstractController
     #[IsGranted('ROLE_USER')]
     #[Route(
         '/{citySlug}/{rideIdentifier}/editsubride/{id}',
+        requirements: ['id' => '\d+'],
         name: 'caldera_criticalmass_subride_edit',
         priority: 20
     )]

--- a/src/Controller/Ride/TimelapseController.php
+++ b/src/Controller/Ride/TimelapseController.php
@@ -31,6 +31,7 @@ class TimelapseController extends AbstractController
 
     #[Route(
         '/{citySlug}/{rideIdentifier}/timelapse/load/{id}',
+        requirements: ['id' => '\d+'],
         name: 'caldera_criticalmass_timelapse_load',
         options: ['expose' => true],
         priority: 135

--- a/src/Controller/SocialNetwork/SocialNetworkManagementController.php
+++ b/src/Controller/SocialNetwork/SocialNetworkManagementController.php
@@ -22,6 +22,7 @@ class SocialNetworkManagementController extends AbstractController
 {
     #[Route(
         '/socialnetwork/{id}/edit',
+        requirements: ['id' => '\d+'],
         name: 'criticalmass_socialnetwork_edit',
         priority: 80
     )]
@@ -87,6 +88,7 @@ class SocialNetworkManagementController extends AbstractController
     #[IsGranted('ROLE_USER')]
     #[Route(
         '/socialnetwork/{id}/disable',
+        requirements: ['id' => '\d+'],
         name: 'criticalmass_socialnetwork_disable',
         methods: ['POST'],
         priority: 80

--- a/src/Controller/Statistic/MonthlyStatsController.php
+++ b/src/Controller/Statistic/MonthlyStatsController.php
@@ -11,6 +11,7 @@ class MonthlyStatsController extends AbstractController
 {
     #[Route(
         '/statistic/{year}/{month}',
+        requirements: ['month' => '\d{1,2}', 'year' => '\d{4}'],
         name: 'caldera_criticalmass_statistic_ride_month',
         priority: 140
     )]

--- a/src/Controller/Track/TrackController.php
+++ b/src/Controller/Track/TrackController.php
@@ -14,6 +14,7 @@ class TrackController extends AbstractController
     #[IsGranted('view', 'track')]
     #[Route(
         '/track/view/{id}',
+        requirements: ['id' => '\d+'],
         name: 'caldera_criticalmass_track_view',
         priority: 150
     )]
@@ -27,6 +28,7 @@ class TrackController extends AbstractController
     #[IsGranted('approve', 'track')]
     #[Route(
         '/track/{id}/approve',
+        requirements: ['id' => '\d+'],
         name: 'caldera_criticalmass_track_approve',
         priority: 150
     )]

--- a/src/Controller/Track/TrackDownloadController.php
+++ b/src/Controller/Track/TrackDownloadController.php
@@ -13,7 +13,7 @@ use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 class TrackDownloadController extends AbstractController
 {
     #[IsGranted('edit', 'track')]
-    #[Route('/track/download/{id}', name: 'caldera_criticalmass_track_download', priority: 270)]
+    #[Route('/track/download/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_track_download', priority: 270)]
     public function downloadAction(Track $track, UploaderHelper $uploaderHelper): Response
     {
         /** @var Filesystem $filesystem */

--- a/src/Controller/Track/TrackManagementController.php
+++ b/src/Controller/Track/TrackManagementController.php
@@ -41,7 +41,7 @@ class TrackManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'track')]
-    #[Route('/{id}/toggle', name: 'toggle', methods: ['POST'], priority: 150)]
+    #[Route('/{id}/toggle', requirements: ['id' => '\d+'], name: 'toggle', methods: ['POST'], priority: 150)]
     public function toggleAction(Request $request, EventDispatcherInterface $eventDispatcher, Track $track): Response
     {
         if (!$this->isCsrfTokenValid('track_toggle_' . $track->getId(), $request->request->get('_token'))) {
@@ -62,7 +62,7 @@ class TrackManagementController extends AbstractController
     }
 
     #[IsGranted('edit', 'track')]
-    #[Route('/{id}/delete', name: 'delete', methods: ['POST'], priority: 150)]
+    #[Route('/{id}/delete', requirements: ['id' => '\d+'], name: 'delete', methods: ['POST'], priority: 150)]
     public function deleteAction(Request $request, Track $track, EventDispatcherInterface $eventDispatcher): Response
     {
         if (!$this->isCsrfTokenValid('track_delete_' . $track->getId(), $request->request->get('_token'))) {

--- a/src/Controller/Track/TrackRangeController.php
+++ b/src/Controller/Track/TrackRangeController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class TrackRangeController extends AbstractController
 {
     #[IsGranted('edit', 'track')]
-    #[Route('/track/range/{id}', name: 'caldera_criticalmass_track_range', priority: 270)]
+    #[Route('/track/range/{id}', requirements: ['id' => '\d+'], name: 'caldera_criticalmass_track_range', priority: 270)]
     public function rangeAction(
         Request $request,
         Track $track,

--- a/src/Controller/Track/TrackTimeController.php
+++ b/src/Controller/Track/TrackTimeController.php
@@ -21,6 +21,7 @@ class TrackTimeController extends AbstractController
     #[IsGranted('edit', 'track')]
     #[Route(
         '/track/time/{id}',
+        requirements: ['id' => '\d+'],
         name: 'caldera_criticalmass_track_time',
         priority: 270
     )]

--- a/tests/Controller/NumericRouteParametersTest.php
+++ b/tests/Controller/NumericRouteParametersTest.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * Ein Pfadteil, der eine Zahl sein soll, muss auch eine verlangen.
+ *
+ * Ohne Bedingung nimmt {id} alles entgegen, und der Wert landet unveraendert
+ * in einer Abfrage gegen eine Integer-Spalte. Unter MySQL lieferte
+ * `WHERE id = 'foo'` stillschweigend nichts und damit einen 404. **Unter
+ * PostgreSQL wirft es** (SQLSTATE 22P02, „invalid input syntax for type
+ * integer") und die Seite antwortet mit einem 500er.
+ *
+ * Aufgefallen ist es am 06.09.2026, einen Tag nach dem Umzug, an einer
+ * einzelnen Anfrage des Yandex-Bots: `GET /norderstedt/2020-01-03/photo/foo`.
+ *
+ * Dieselbe Luecke, nur mit anderem Ausgang, hatte `/statistic/{year}/{month}`:
+ * Dort kam die Zeichenkette bis in die Signatur
+ * `listRidesAction(int $year, int $month)` und erzeugte einen TypeError —
+ * 255 Mal.
+ *
+ * Und weil solche Adressen nun gar keine Route mehr treffen, kam eine zweite
+ * Schwaeche ans Licht, die es laengst gab: die Schleife um
+ * `remove_trailing_slash`, siehe testAnUnknownPathDoesNotLoop().
+ */
+class NumericRouteParametersTest extends AbstractControllerTestCase
+{
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function unsinnigeAdressen(): array
+    {
+        return [
+            'die Anfrage des Bots' => ['/norderstedt/2020-01-03/photo/foo'],
+            'Foto ohne Nummer' => ['/photo/foo'],
+            'Foto halb Nummer' => ['/photo/12abc'],
+            'Download ohne Nummer' => ['/photo/foo/download'],
+            'Track ohne Nummer' => ['/track/download/foo'],
+            'Statistik ohne Jahr' => ['/statistic/foo/bar'],
+            'Statistik zu kurzes Jahr' => ['/statistic/20/9'],
+            'Beitrag ohne Nummer' => ['/post/edit/foo'],
+        ];
+    }
+
+    /**
+     * Der Kern: keine dieser Adressen darf die Anwendung umwerfen, und keine
+     * darf im Kreis laufen.
+     */
+    #[DataProvider('unsinnigeAdressen')]
+    public function testSuchAnAddressNeitherBreaksNorLoops(string $adresse): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(false);
+
+        [$status, $sprünge] = $this->verfolgen($client, $adresse);
+
+        self::assertNotSame(500, $status, sprintf('%s wirft die Anwendung um.', $adresse));
+        self::assertLessThan(5, $sprünge, sprintf('%s laeuft im Kreis.', $adresse));
+    }
+
+    /**
+     * Und die Anfrage des Bots endet, wo sie hingehoert: im 404.
+     */
+    public function testTheBotsRequestEndsInANotFound(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(false);
+
+        [$status] = $this->verfolgen($client, '/norderstedt/2020-01-03/photo/foo');
+
+        self::assertSame(404, $status);
+    }
+
+    /**
+     * Die Schleife, die durch die Zahlbedingungen sichtbar wurde: Die Route
+     * remove_trailing_slash passt auf jeden Pfad mit Schraegstrich am Ende,
+     * weshalb Symfony fuer *jeden* unbekannten Pfad annahm, es gebe ihn mit
+     * angehaengtem Schraegstrich — und der Controller schnitt ihn wieder ab.
+     */
+    public function testAnUnknownPathDoesNotLoop(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(false);
+
+        [$status, $sprünge] = $this->verfolgen($client, '/gibt/es/nicht');
+
+        self::assertSame(404, $status, 'Was es nicht gibt, endet im 404.');
+        self::assertLessThan(5, $sprünge, 'Und nicht in einer Schleife.');
+    }
+
+    /**
+     * Der gute Fall bleibt unberuehrt: Eine echte Adresse mit Schraegstrich am
+     * Ende wird weiterhin auf die saubere Form umgeleitet.
+     */
+    public function testARealAddressStillLosesItsTrailingSlash(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects(false);
+        $client->request('GET', '/hamburg/');
+
+        self::assertResponseRedirects();
+        self::assertStringEndsWith(
+            '/hamburg',
+            (string) $client->getResponse()->headers->get('Location')
+        );
+    }
+
+    /**
+     * Und eine gueltige Zahl kommt weiterhin durch.
+     */
+    public function testANumericParameterStillReachesTheController(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/statistic/2026/9');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @return array{0: int, 1: int} Endstatus und Zahl der Spruenge
+     */
+    private function verfolgen(KernelBrowser $client, string $adresse): array
+    {
+        $client->request('GET', $adresse);
+        $sprünge = 0;
+
+        while ($client->getResponse()->isRedirection() && $sprünge < 10) {
+            ++$sprünge;
+            $client->followRedirect();
+        }
+
+        return [$client->getResponse()->getStatusCode(), $sprünge];
+    }
+}


### PR DESCRIPTION
## Der Fehler

**40 Routen** nahmen ein `{id}`, `{postId}` oder `{year}` entgegen, ohne Ziffern zu verlangen. Was ein Aufrufer schickte, ging unverändert in eine Abfrage gegen eine Integer-Spalte.

Unter MySQL traf `WHERE id = 'foo'` stillschweigend nichts und der Besucher bekam einen 404. **Unter PostgreSQL wirft es** — `SQLSTATE[22P02]: invalid input syntax for type integer: "foo"` — und die Seite antwortet mit einem 500er.

Gefunden hat es **eine einzelne Anfrage des Yandex-Bots**, einen Tag nach dem Umzug:

```
GET /norderstedt/2020-01-03/photo/foo   →   500
```

Dieselbe Lücke mit anderem Ausgang saß auf `/statistic/{year}/{month}`: Dort kam die Zeichenkette bis in die Signatur `listRidesAction(int $year, int $month)` und erzeugte einen **TypeError — bisher 255 Mal**. Eine Änderung, zwei Fehlerklassen.

Die Konvention gab es schon: `BulkTrackReviewController` schreibt `requirements: ['id' => '\d+']` aus. Diese 40 Routen hatten sie nur nie bekommen.

## Und was dabei ans Licht kam: eine Umleitungsschleife

Sobald `/photo/foo` **keine** Route mehr trifft, greift `remove_trailing_slash` — deren Muster `/{url}` mit `.*/$` passt auf jeden Pfad mit Schrägstrich am Ende. Symfony schließt daraus für **jeden** unbekannten Pfad, es gäbe ihn mit angehängtem Schrägstrich:

```
/gibt/es/nicht  →301→  /gibt/es/nicht/  →301→  /gibt/es/nicht  →301→  …
```

**Die gab es schon vorher** — auf `main` läuft `/gibt/es/nicht` genauso im Kreis, ganz ohne meine Änderung. Sie wäre nur der neue Ausgang für alles gewesen, was ich gerade vom 500er befreit habe, und ein 500er gegen eine Endlosschleife zu tauschen wäre kein Fortschritt.

Der Controller prüft jetzt vor dem Umleiten, ob hinter dem Ziel überhaupt etwas liegt, und antwortet sonst mit 404. Dafür baut er bewusst einen schlichten `UrlMatcher`, statt den Router zu fragen: **Dessen Matcher leitet selbst um und meldet für jeden Pfad einen Treffer** — er würde die Schleife bestätigen statt sie zu erkennen. Das hat mich beim ersten Anlauf eine Runde gekostet.

Echte Adressen verlieren ihren Schrägstrich weiterhin: `/hamburg/` → `/hamburg`.

## Test Plan

`tests/Controller/NumericRouteParametersTest.php`, **12 Tests**: acht unsinnige Adressen werfen die Anwendung nicht um und laufen nicht im Kreis; die Anfrage des Bots endet im 404; ein unbekannter Pfad ebenso; `/hamburg/` wird weiterhin sauber umgeleitet; `/statistic/2026/9` kommt durch.

**Gegenproben, beide Hälften einzeln:**

| zurückgedreht | Ergebnis |
|---|---|
| Zahlbedingung der Fotoroute | 2 Tests fallen um |
| Schleifenriegel | 4 Tests melden „läuft im Kreis" |

**Nachweis der Vollständigkeit:** `debug:router --format=json` gegen dieselbe Prüfung, die die 40 Fundstellen ermittelt hat — **0 ungeschützte Zahlparameter** verbleiben.

**Volle Suite:** 1545 Tests, alles grün. `vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

## Nachbemerkung

Der erste Sprung (`/x` → `/x/`) findet weiterhin statt, bevor überhaupt ein Controller läuft — das entscheidet Symfonys `RedirectableUrlMatcher` im Router. Ein Crawler bekommt also 301 und dann 404. Das terminiert und ist ehrlich; ihn ganz abzustellen hieße, an der Matcher-Klasse zu drehen, und das gehört nicht in diesen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR