### PR TITLE
Say so when there are no Mini-Masses to copy from

### DIFF
--- a/templates/Subride/preparecopy.html.twig
+++ b/templates/Subride/preparecopy.html.twig
@@ -12,6 +12,24 @@
             </div>
         </div>
 
+        {# Es muss keine fruehere Tour mit Mini-Masses geben — in einer Stadt,
+           in der noch nie welche eingetragen wurden, gibt es schlicht nichts
+           zu kopieren. Das Repository liefert dann null. #}
+        {% if not oldRide %}
+            <div class="row">
+                <div class="col-md-12">
+                    <div class="alert alert-info">
+                        In dieser Stadt gibt es noch keine frühere Tour mit Mini-Masses,
+                        von der sich welche kopieren ließen. Lege sie einmal von Hand an —
+                        beim nächsten Mal steht diese Tour dann hier zur Auswahl.
+                    </div>
+
+                    <a href="{{ object_path(newRide) }}" class="btn btn-secondary">
+                        Zurück zur Tour
+                    </a>
+                </div>
+            </div>
+        {% else %}
         <div class="row">
             <div class="col-md-12">
                 <p>Von der Tour <a href="{{ object_path(oldRide) }}">{{ oldRide.title }}</a>
@@ -46,5 +64,6 @@
                 </div>
             </div>
         </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/tests/Controller/SubrideCopyWithoutPreviousRideTest.php
+++ b/tests/Controller/SubrideCopyWithoutPreviousRideTest.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\Ride;
+use App\Entity\Subride;
+use App\Repository\RideRepository;
+
+/**
+ * Mini-Masses kopieren, wenn es nichts zu kopieren gibt.
+ *
+ * `RideRepository::getPreviousRideWithSubrides()` endet auf
+ * `getOneOrNullResult()` — in einer Stadt, in der noch nie Mini-Masses
+ * eingetragen wurden, gibt es keine fruehere Tour, und die Methode liefert
+ * null. Das Template rechnete nicht damit und rief `object_path(null)` auf.
+ *
+ * Getroffen hat das echte Menschen: Am 06.09.2026 um 17:20 Uhr bekam jemand
+ * aus Koeln auf `/koeln/2026-09-27/preparecopysubrides` einen 500er, direkt
+ * von der Tourenseite kommend. Ein zweiter Fall liegt am 30.08.2026.
+ *
+ * Es ist dieselbe Familie wie der Fotofehler in #1522 — ein Controller, der
+ * null durchreicht, und ein Template, das es nicht erwartet.
+ */
+class SubrideCopyWithoutPreviousRideTest extends AbstractControllerTestCase
+{
+    /**
+     * Der Fall des Koelner Nutzers: nichts zu kopieren.
+     *
+     * Die Lage wird hergestellt statt gesucht — eine Tour, vor der es in ihrer
+     * Stadt ueberhaupt keine gibt. Ein Test, der sich eine passende Tour aus
+     * den Fixtures sucht, haengt sonst davon ab, was andere Tests vorher in
+     * die Datenbank geschrieben haben; genau daran ist die erste Fassung im
+     * Suitenlauf gescheitert, waehrend sie allein gruen war.
+     */
+    public function testThePageExplainsItselfWhenThereIsNothingToCopy(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $stadt = $entityManager->getRepository(\App\Entity\City::class)->findOneBy([]);
+        self::assertNotNull($stadt, 'Die Fixtures liefern mindestens eine Stadt.');
+
+        $erste = new Ride();
+        $erste->setCity($stadt);
+        $erste->setTitle('Die allererste Tour');
+        $erste->setDateTime(new \DateTime('1990-01-01 18:00'));
+        $erste->setCreatedAt(new \DateTime());
+        $erste->setUpdatedAt(new \DateTime());
+        $erste->setEnabled(true);
+        $entityManager->persist($erste);
+        $entityManager->flush();
+
+        self::assertNull(
+            static::getContainer()->get(RideRepository::class)->getPreviousRideWithSubrides($erste),
+            'Vor der allerersten Tour kann es keinen Vorgaenger geben.'
+        );
+
+        $this->loginAs($client, $this->irgendeineEmail($entityManager));
+
+        $client->request('GET', sprintf(
+            '/%s/%s/preparecopysubrides',
+            $stadt->getMainSlugString(),
+            $erste->getDateTime()->format('Y-m-d')
+        ));
+
+        self::assertResponseIsSuccessful('Auch ohne Vorgaenger hat die Seite eine Antwort.');
+        self::assertStringContainsString(
+            'noch keine frühere Tour mit Mini-Masses',
+            (string) $client->getResponse()->getContent(),
+            'Und sagt, warum nichts zu holen ist.'
+        );
+
+        $entityManager->remove($erste);
+        $entityManager->flush();
+    }
+
+    private function irgendeineEmail(\Doctrine\ORM\EntityManagerInterface $entityManager): string
+    {
+        $nutzer = $entityManager->getRepository(\App\Entity\User::class)->findOneBy([]);
+        self::assertNotNull($nutzer, 'Die Fixtures liefern mindestens einen Nutzer.');
+
+        return (string) $nutzer->getEmail();
+    }
+
+    /**
+     * Der gute Fall bleibt: Gibt es einen Vorgaenger mit Mini-Masses, nennt
+     * die Seite ihn beim Namen.
+     *
+     * Der Test legt sich diese Lage selbst an, statt sie in den Fixtures zu
+     * suchen — sonst haette er sich uebersprungen, sobald die Fixtures sie
+     * nicht mehr hergeben, und dabei gruen ausgesehen.
+     */
+    public function testTheRideToCopyFromIsNamedWhenThereIsOne(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $stadt = $entityManager->getRepository(\App\Entity\City::class)->findOneBy([]);
+        self::assertNotNull($stadt, 'Die Fixtures liefern mindestens eine Stadt.');
+
+        $vorgaenger = new Ride();
+        $vorgaenger->setCity($stadt);
+        $vorgaenger->setTitle('Tour mit Mini-Masses');
+        $vorgaenger->setDateTime(new \DateTime('-2 months'));
+        $vorgaenger->setCreatedAt(new \DateTime());
+        $vorgaenger->setUpdatedAt(new \DateTime());
+        $vorgaenger->setEnabled(true);
+        $entityManager->persist($vorgaenger);
+
+        $minimass = new Subride();
+        $minimass->setRide($vorgaenger);
+        $minimass->setTitle('Nordroute');
+        $minimass->setDateTime(new \DateTime('-2 months'));
+        $entityManager->persist($minimass);
+
+        $spaeter = new Ride();
+        $spaeter->setCity($stadt);
+        $spaeter->setTitle('Tour ohne Mini-Masses');
+        $spaeter->setDateTime(new \DateTime('+2 months'));
+        $spaeter->setCreatedAt(new \DateTime());
+        $spaeter->setUpdatedAt(new \DateTime());
+        $spaeter->setEnabled(true);
+        $entityManager->persist($spaeter);
+
+        $entityManager->flush();
+
+        $this->loginAs($client, $this->irgendeineEmail($entityManager));
+
+        $client->request('GET', sprintf(
+            '/%s/%s/preparecopysubrides',
+            $stadt->getMainSlugString(),
+            $spaeter->getDateTime()->format('Y-m-d')
+        ));
+
+        self::assertResponseIsSuccessful();
+
+        // Welche Tour die Abfrage tatsaechlich waehlt, entscheidet sie selbst:
+        // Es ist die juengste vor dieser, und das kann auch eine aus den
+        // Fixtures sein. Geprueft wird deshalb gegen ihre Wahl, nicht gegen
+        // einen geratenen Titel.
+        $gewaehlt = static::getContainer()->get(RideRepository::class)
+            ->getPreviousRideWithSubrides($spaeter);
+        self::assertNotNull($gewaehlt, 'Jetzt gibt es einen Vorgaenger mit Mini-Masses.');
+
+        $inhalt = (string) $client->getResponse()->getContent();
+        self::assertStringContainsString('können die folgenden Mini-Masses kopiert werden', $inhalt);
+        self::assertStringContainsString((string) $gewaehlt->getTitle(), $inhalt);
+
+        $entityManager->remove($minimass);
+        $entityManager->remove($vorgaenger);
+        $entityManager->remove($spaeter);
+        $entityManager->flush();
+    }
+}


### PR DESCRIPTION
## Der Fehler

`RideRepository::getPreviousRideWithSubrides()` endet auf `getOneOrNullResult()`. In einer Stadt, in der noch nie Mini-Masses eingetragen wurden, gibt es keine frühere Tour — die Methode liefert `null`, der Controller reicht es durch, und das Template rief `object_path(null)` auf.

**Es trifft genau die Person, die als erste in ihrer Stadt welche anlegen will.** Und es hat eine echte getroffen: Am 6. September 2026 um 17:20 Uhr bekam jemand aus Köln auf `/koeln/2026-09-27/preparecopysubrides` einen 500er, direkt von der Tourenseite kommend. Ein zweiter Fall liegt am 30. August.

Gefunden hat es die Wache, die seit dem heutigen Ausrollen jeden Fehler meldet — vorher stand er im Schatten der 17.159 Ratenbegrenzer-Meldungen.

Es ist dieselbe Familie wie #1521 und #1522: ein Controller, der `null` durchreicht, und ein Template, das nicht damit rechnet.

## Die Lösung

Ohne Vorgänger sagt die Seite, dass es noch nichts zu kopieren gibt, und bietet den Weg zurück — statt abzustürzen.

## Test Plan

`tests/Controller/SubrideCopyWithoutPreviousRideTest.php`, **2 Tests**: ohne Vorgänger erklärt sich die Seite; mit Vorgänger nennt sie ihn beim Namen.

**Gegenprobe:** Ohne den Schutz fällt der erste Test mit exakt der Meldung aus der Produktion um (`objectPath(): Argument #1 must be of type RouteableInterface, null given`).

**Zwei Fassungen davor waren wertlos, und beide auf dieselbe Art:**

1. Der zweite Test *suchte* in den Fixtures nach einer Tour mit passendem Vorgänger — fand keine und **übersprang sich stillschweigend**.
2. Der erste Test suchte umgekehrt eine Tour *ohne* Vorgänger. Allein grün, im Suitenlauf rot: Andere Tests hatten die Datenbank inzwischen verändert.

Beide stellen ihre Lage jetzt selbst her. Der zweite prüft zudem gegen die Tour, die die Abfrage **tatsächlich wählt** (die jüngste vor der Zieltour), statt gegen einen geratenen Titel — sonst hätte eine Fixture-Tour dazwischengefunkt.

**Volle Suite:** 1576 Tests, alles grün, kein Übersprungener in dieser Klasse. `vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR