### PR TITLE
Answer 404, not 500, for the preview of a non-image

### DIFF
--- a/src/EventSubscriber/ThumbnailForNonImageSubscriber.php
+++ b/src/EventSubscriber/ThumbnailForNonImageSubscriber.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Liip\ImagineBundle\Exception\LogicException;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Beantwortet die Vorschau einer Datei, die kein Bild ist, mit 404 statt 500.
+ *
+ * Liips DataManager wirft eine LogicException, sobald der MIME-Typ weder
+ * `image/…` noch `application/pdf` ist. Fuer den Bestand ist das erledigt —
+ * Version20260906100000 hat die 18 Nicht-Bilder aus dem Verkehr genommen, und
+ * seither faellt statt 326 Fehlern in zwei Monaten noch einer an. Der kommt
+ * von direkten Abrufen alter Vorschau-Adressen: Liip fragt die Datenbank
+ * nicht, ein Zeiger aus einem Suchindex oder dem Verlauf trifft die Datei
+ * weiterhin.
+ *
+ * Es *gibt* keine Vorschau einer Videodatei — 404 ist die richtige Auskunft,
+ * nicht ein Serverfehler. Liips eigener Controller verfaehrt bei fehlenden
+ * Dateien genauso (NotLoadableException wird zu NotFoundHttpException).
+ *
+ * Bewusst eng gefasst: nur auf den beiden Liip-Routen. Eine LogicException aus
+ * einer fehlerhaften Filterkonfiguration soll weiterhin auffallen.
+ */
+#[AsEventListener(event: KernelEvents::EXCEPTION)]
+final class ThumbnailForNonImageSubscriber
+{
+    private const LIIP_ROUTEN = ['liip_imagine_filter', 'liip_imagine_filter_runtime'];
+
+    public function __invoke(ExceptionEvent $event): void
+    {
+        if (!$event->getThrowable() instanceof LogicException) {
+            return;
+        }
+
+        $route = $event->getRequest()->attributes->get('_route');
+
+        if (!\in_array($route, self::LIIP_ROUTEN, true)) {
+            return;
+        }
+
+        $event->setThrowable(new NotFoundHttpException(
+            'Von dieser Datei gibt es keine Vorschau.',
+            $event->getThrowable()
+        ));
+    }
+}

--- a/tests/EventSubscriber/ThumbnailForNonImageSubscriberTest.php
+++ b/tests/EventSubscriber/ThumbnailForNonImageSubscriberTest.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\ThumbnailForNonImageSubscriber;
+use Liip\ImagineBundle\Exception\LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Von einer Datei, die kein Bild ist, gibt es keine Vorschau — das ist ein
+ * 404, kein Serverfehler.
+ *
+ * Der Bestand ist erledigt (Version20260906100000), aber alte Vorschau-
+ * Adressen aus Suchindizes und Verlaeufen treffen die Dateien weiterhin
+ * direkt; Liip fragt die Datenbank nicht.
+ */
+final class ThumbnailForNonImageSubscriberTest extends TestCase
+{
+    private function ereignis(\Throwable $fehler, ?string $route): ExceptionEvent
+    {
+        $request = Request::create('/media/cache/resolve/gallery_photo_thumb/video.mov');
+
+        if (null !== $route) {
+            $request->attributes->set('_route', $route);
+        }
+
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $fehler,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function liipRouten(): array
+    {
+        return [
+            'Filter' => ['liip_imagine_filter'],
+            'Filter zur Laufzeit' => ['liip_imagine_filter_runtime'],
+        ];
+    }
+
+    #[DataProvider('liipRouten')]
+    public function testTheMimeTypeComplaintBecomesANotFound(string $route): void
+    {
+        $ereignis = $this->ereignis(
+            new LogicException('The mime type of file x.mov must be image/xxx or application/pdf, got video/quicktime.'),
+            $route
+        );
+
+        (new ThumbnailForNonImageSubscriber())($ereignis);
+
+        self::assertInstanceOf(NotFoundHttpException::class, $ereignis->getThrowable());
+    }
+
+    /**
+     * Die urspruengliche Ausnahme bleibt als Ursache erhalten — sonst waere
+     * im Protokoll nicht mehr zu sehen, worum es ging.
+     */
+    public function testTheOriginalCauseIsKept(): void
+    {
+        $urspruenglich = new LogicException('The mime type of file x.mov must be image/xxx or application/pdf.');
+        $ereignis = $this->ereignis($urspruenglich, 'liip_imagine_filter');
+
+        (new ThumbnailForNonImageSubscriber())($ereignis);
+
+        self::assertSame($urspruenglich, $ereignis->getThrowable()->getPrevious());
+    }
+
+    /**
+     * Ausserhalb der Liip-Routen wird nichts angefasst — eine LogicException
+     * aus einer fehlerhaften Filterkonfiguration soll weiterhin auffallen.
+     */
+    public function testItKeepsItsHandsOffOtherRoutes(): void
+    {
+        $urspruenglich = new LogicException('irgendetwas anderes');
+        $ereignis = $this->ereignis($urspruenglich, 'caldera_criticalmass_frontpage');
+
+        (new ThumbnailForNonImageSubscriber())($ereignis);
+
+        self::assertSame($urspruenglich, $ereignis->getThrowable());
+    }
+
+    public function testARequestWithoutARouteIsLeftAlone(): void
+    {
+        $urspruenglich = new LogicException('irgendetwas anderes');
+        $ereignis = $this->ereignis($urspruenglich, null);
+
+        (new ThumbnailForNonImageSubscriber())($ereignis);
+
+        self::assertSame($urspruenglich, $ereignis->getThrowable());
+    }
+
+    /**
+     * Und andere Fehler auf derselben Route bleiben, was sie sind.
+     */
+    public function testOtherFailuresOnTheSameRouteStayAsTheyAre(): void
+    {
+        $urspruenglich = new \RuntimeException('Festplatte voll');
+        $ereignis = $this->ereignis($urspruenglich, 'liip_imagine_filter');
+
+        (new ThumbnailForNonImageSubscriber())($ereignis);
+
+        self::assertSame($urspruenglich, $ereignis->getThrowable());
+    }
+}


### PR DESCRIPTION
## Der Rest eines behobenen Fehlers

#1523 hat die 18 Nicht-Bilder aus dem Verkehr genommen, und das hat gewirkt:

| | Meldungen |
|---|---|
| 9. Juli bis 6. September | **326** |
| seit dem Ausrollen am 6.9. | **1** |

Der Rest kommt von **direkten Abrufen alter Vorschau-Adressen**. Liip fragt die Datenbank nicht — ein Zeiger aus einem Suchindex, einem Cache oder jemandes Verlauf trifft die Datei weiterhin, ganz gleich wie die Zeile markiert ist.

Und dann wirft `DataManager`, sobald der MIME-Typ weder `image/…` noch `application/pdf` ist: ein 500er.

## Warum 404 richtig ist

Es **gibt** keine Vorschau einer Videodatei. Das ist keine Störung, sondern eine Auskunft — und genau die gibt Liips eigener Controller bereits, wenn eine Datei fehlt (`NotLoadableException` → `NotFoundHttpException`).

## Warum ein Lauscher und kein Dekorator

Der naheliegende Weg wäre, den Lader `NotLoadableException` werfen zu lassen. Diese Anwendung hat aber **fünf** benannte Lader (`photo_`, `user_photo_`, `city_image_`, `ride_image_`, `frontpage_teaser_flysystem_loader`); fünf Dekoratoren für einen Fehler am Tag stehen in keinem Verhältnis, und der sechste würde beim nächsten Lader vergessen.

Der Lauscher ist **bewusst eng gefasst**: nur `Liip\ImagineBundle\Exception\LogicException`, und nur auf den beiden Liip-Routen. Eine `LogicException` aus einer fehlerhaften Filterkonfiguration soll weiterhin auffallen. Die ursprüngliche Ausnahme bleibt als Ursache erhalten, damit im Protokoll sichtbar bleibt, worum es ging.

## Test Plan

`tests/EventSubscriber/ThumbnailForNonImageSubscriberTest.php`, **6 Tests**: beide Liip-Routen werden zu 404; die Ursache bleibt erhalten; andere Routen, Anfragen ohne Route und andere Fehlerarten auf derselben Route bleiben unangetastet.

**Gegenprobe:** Ohne die Routenprüfung fallen 2 Tests um. Zusätzlich per `debug:event-dispatcher` geprüft, dass der Lauscher tatsächlich an `kernel.exception` hängt — ein Lauscher, der nicht registriert ist, hätte grüne Unit-Tests und keine Wirkung.

**Volle Suite:** 1582 Tests, alles grün. `vendor/bin/phpstan analyse --memory-limit=1G` ohne Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR