### PR TITLE
Give locations and photos their place as a geometry

### DIFF
--- a/migrations/Version20260907120000.php
+++ b/migrations/Version20260907120000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Gibt Orten und Fotos ihre Lage als Geometrie (Issues #1138, #1139).
+ *
+ * Gleiches Vorgehen wie bei Stadt, Fahrt und Tourenmuster: Die Spalte wird aus
+ * latitude und longitude gefuellt und danach von den Settern nachgefuehrt; die
+ * beiden Fliesskommaspalten bleiben vorerst die fuehrenden Werte, weil
+ * API-Ausgabe, Formulare und die DataQuery-Attribute an ihnen haengen.
+ *
+ * Bestand zum Zeitpunkt dieser Migration: 23 Orte, alle mit Koordinaten, und
+ * 45.499 Fotos, davon 26.024 mit echten GPS-Daten aus den EXIF-Angaben. Der
+ * Punkt 0,0 im Golf von Guinea dient als Platzhalter fuer "keine Angabe" und
+ * bekommt keine Geometrie — bei den Fotos betrifft das 18 Zeilen.
+ */
+final class Version20260907120000 extends AbstractMigration
+{
+    private const TABELLEN = ['location', 'photo'];
+
+    public function getDescription(): string
+    {
+        return 'Add point geometries to location and photo';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform,
+            'Geometriespalten gibt es nur mit PostGIS.'
+        );
+
+        foreach (self::TABELLEN as $tabelle) {
+            $this->addSql(sprintf('ALTER TABLE %s ADD coordinates geometry(POINT, 4326) DEFAULT NULL', $tabelle));
+
+            // In WKT steht die Laenge vor der Breite.
+            $this->addSql(sprintf('
+                UPDATE %s
+                SET coordinates = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+                WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+                  AND latitude <> 0 AND longitude <> 0
+            ', $tabelle));
+
+            $this->addSql(sprintf(
+                'CREATE INDEX %s_coordinates_gist ON %s USING gist(coordinates)', $tabelle, $tabelle
+            ));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::TABELLEN as $tabelle) {
+            $this->addSql(sprintf('DROP INDEX IF EXISTS %s_coordinates_gist', $tabelle));
+            $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN coordinates', $tabelle));
+        }
+    }
+}

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -7,11 +7,13 @@ use App\Criticalmass\Router\Attribute\RouteParameter;
 use App\EntityInterface\AuditableInterface;
 use App\EntityInterface\RouteableInterface;
 use Doctrine\ORM\Mapping as ORM;
+use Jsor\Doctrine\PostGIS\Types\PostGISType;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 
 #[Routing\DefaultRoute(name: 'caldera_criticalmass_location_show')]
 #[ORM\Table(name: 'location')]
+#[ORM\Index(fields: ['coordinates'], name: 'location_coordinates_gist', flags: ['spatial'])]
 #[ORM\Entity(repositoryClass: 'App\Repository\LocationRepository')]
 class Location implements RouteableInterface, AuditableInterface
 {
@@ -39,6 +41,18 @@ class Location implements RouteableInterface, AuditableInterface
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['location'])]
     protected ?float $longitude = null;
+    /**
+     * Dieselbe Stelle noch einmal, diesmal als Geometrie.
+     *
+     * Gefuehrt wird sie aus latitude und longitude, nicht umgekehrt: Die beiden
+     * Spalten haengen an der API-Ausgabe und an den Formularen. Der Gewinn
+     * liegt beim raeumlichen Index — eine Umkreissuche ueber ST_DWithin kann
+     * ihn nutzen, die Haversine-Formel ueber zwei Fliesskommaspalten nicht.
+     */
+    #[ORM\Column(type: PostGISType::GEOMETRY, nullable: true, options: ['geometry_type' => 'POINT', 'srid' => 4326])]
+    #[Ignore]
+    protected ?string $coordinates = null;
+
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     #[Groups(['location'])]
@@ -56,6 +70,7 @@ class Location implements RouteableInterface, AuditableInterface
     public function setLatitude(?float $latitude = null): Location
     {
         $this->latitude = $latitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -68,6 +83,7 @@ class Location implements RouteableInterface, AuditableInterface
     public function setLongitude(?float $longitude = null): Location
     {
         $this->longitude = $longitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -75,6 +91,33 @@ class Location implements RouteableInterface, AuditableInterface
     public function getLongitude(): ?float
     {
         return $this->longitude;
+    }
+
+    public function getCoordinates(): ?string
+    {
+        return $this->coordinates;
+    }
+
+    /**
+     * Haelt die Geometrie an den beiden Fliesskommaspalten nach.
+     *
+     * In WKT steht die Laenge vor der Breite — anders herum als in jeder
+     * Beschriftung dieser Anwendung, und eine beliebte Fehlerquelle.
+     *
+     * Null und exakt 0 gelten als "keine Angabe": Der Punkt 0,0 liegt im Golf
+     * von Guinea, und der Bestand nutzt ihn seit jeher als Platzhalter — bei
+     * den Fotos betrifft das 18 Zeilen.
+     */
+    private function punktNachfuehren(): void
+    {
+        if (null === $this->latitude || null === $this->longitude
+            || 0.0 === $this->latitude || 0.0 === $this->longitude) {
+            $this->coordinates = null;
+
+            return;
+        }
+
+        $this->coordinates = sprintf('SRID=4326;POINT(%.8F %.8F)', $this->longitude, $this->latitude);
     }
 
     public function setDescription(?string $description = null): Location

--- a/src/Entity/Photo.php
+++ b/src/Entity/Photo.php
@@ -16,6 +16,7 @@ use MalteHuebner\OrderedEntitiesBundle\OrderedEntityInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Jsor\Doctrine\PostGIS\Types\PostGISType;
 use MalteHuebner\DataQueryBundle\Attribute\EntityAttribute as DataQuery;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -28,6 +29,7 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 #[ORM\Table(name: 'photo')]
 #[ORM\Entity(repositoryClass: 'App\Repository\PhotoRepository')]
 #[ORM\Index(fields: ['exifCreationDate'], name: 'photo_exif_creation_date_index')]
+#[ORM\Index(fields: ['coordinates'], name: 'photo_coordinates_gist', flags: ['spatial'])]
 class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableInterface, PostableInterface, OrderedEntityInterface, CoordinateInterface
 {
     #[Routing\RouteParameter(name: 'id')]
@@ -69,6 +71,18 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     #[ORM\Column(type: 'float', nullable: true)]
     #[Groups(['ride-details', 'photo-details'])]
     protected ?float $longitude = null;
+    /**
+     * Dieselbe Stelle noch einmal, diesmal als Geometrie.
+     *
+     * Gefuehrt wird sie aus latitude und longitude, nicht umgekehrt: Die beiden
+     * Spalten haengen an der API-Ausgabe und an den Formularen. Der Gewinn
+     * liegt beim raeumlichen Index — eine Umkreissuche ueber ST_DWithin kann
+     * ihn nutzen, die Haversine-Formel ueber zwei Fliesskommaspalten nicht.
+     */
+    #[ORM\Column(type: PostGISType::GEOMETRY, nullable: true, options: ['geometry_type' => 'POINT', 'srid' => 4326])]
+    #[Ignore]
+    protected ?string $coordinates = null;
+
 
     #[DataQuery\Sortable]
     #[ORM\Column(type: 'text', nullable: true)]
@@ -230,6 +244,7 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
     public function setLatitude(?float $latitude = null): CoordinateInterface
     {
         $this->latitude = $latitude;
+        $this->punktNachfuehren();
 
         return $this;
     }
@@ -239,9 +254,37 @@ class Photo implements FakeUploadable, ManipulateablePhotoInterface, RouteableIn
         return $this->longitude;
     }
 
+    public function getCoordinates(): ?string
+    {
+        return $this->coordinates;
+    }
+
+    /**
+     * Haelt die Geometrie an den beiden Fliesskommaspalten nach.
+     *
+     * In WKT steht die Laenge vor der Breite — anders herum als in jeder
+     * Beschriftung dieser Anwendung, und eine beliebte Fehlerquelle.
+     *
+     * Null und exakt 0 gelten als "keine Angabe": Der Punkt 0,0 liegt im Golf
+     * von Guinea, und der Bestand nutzt ihn seit jeher als Platzhalter — bei
+     * den Fotos betrifft das 18 Zeilen.
+     */
+    private function punktNachfuehren(): void
+    {
+        if (null === $this->latitude || null === $this->longitude
+            || 0.0 === $this->latitude || 0.0 === $this->longitude) {
+            $this->coordinates = null;
+
+            return;
+        }
+
+        $this->coordinates = sprintf('SRID=4326;POINT(%.8F %.8F)', $this->longitude, $this->latitude);
+    }
+
     public function setLongitude(?float $longitude = null): CoordinateInterface
     {
         $this->longitude = $longitude;
+        $this->punktNachfuehren();
 
         return $this;
     }

--- a/tests/Entity/LocationAndPhotoCoordinatesTest.php
+++ b/tests/Entity/LocationAndPhotoCoordinatesTest.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\Location;
+use App\Entity\Photo;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Die Lage von Orten und Fotos als Geometrie (Issues #1138, #1139).
+ *
+ * Dieselben zwei Fallen wie bei Stadt, Fahrt und Tourenmuster, und sie sind
+ * hier nicht weniger still: In WKT steht die Laenge vor der Breite, und 0,0
+ * ist im Bestand ein Platzhalter, kein Ort im Golf von Guinea. Bei den Fotos
+ * betrifft das 18 Zeilen.
+ */
+class LocationAndPhotoCoordinatesTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    /**
+     * @return array<string, array{0: class-string}>
+     */
+    public static function entities(): array
+    {
+        return [
+            'Ort' => [Location::class],
+            'Foto' => [Photo::class],
+        ];
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function tabellen(): array
+    {
+        return ['location' => ['location'], 'photo' => ['photo']];
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testTheSettersKeepTheGeometryInStep(string $klasse): void
+    {
+        $entity = new $klasse();
+        self::assertNull($entity->getCoordinates(), 'Ohne Koordinaten keine Geometrie.');
+
+        $entity->setLatitude(53.55);
+        self::assertNull($entity->getCoordinates(), 'Eine Breite allein ergibt noch keinen Punkt.');
+
+        $entity->setLongitude(9.99);
+        self::assertSame('SRID=4326;POINT(9.99000000 53.55000000)', $entity->getCoordinates());
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testLongitudeComesFirst(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(53.55);
+        $entity->setLongitude(9.99);
+
+        self::assertStringStartsWith('SRID=4326;POINT(9.99', (string) $entity->getCoordinates());
+        self::assertStringNotContainsString('POINT(53.55', (string) $entity->getCoordinates());
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testThePlaceholderZeroDoesNotBecomeAPoint(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(0.0);
+        $entity->setLongitude(0.0);
+
+        self::assertNull($entity->getCoordinates(), 'Null Grad, null Grad heisst hier: keine Angabe.');
+    }
+
+    /**
+     * @param class-string $klasse
+     */
+    #[DataProvider('entities')]
+    public function testClearingACoordinateClearsTheGeometry(string $klasse): void
+    {
+        $entity = new $klasse();
+        $entity->setLatitude(53.55);
+        $entity->setLongitude(9.99);
+        self::assertNotNull($entity->getCoordinates());
+
+        $entity->setLongitude(null);
+        self::assertNull($entity->getCoordinates());
+    }
+
+    #[DataProvider('tabellen')]
+    public function testEveryRowWithCoordinatesCarriesItsGeometry(string $tabelle): void
+    {
+        $this->nurMitPostGIS();
+
+        $mitKoordinaten = (int) $this->entityManager->getConnection()->fetchOne(sprintf(
+            'SELECT count(*) FROM %s WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+             AND latitude <> 0 AND longitude <> 0', $tabelle
+        ));
+        $mitGeometrie = (int) $this->entityManager->getConnection()->fetchOne(sprintf(
+            'SELECT count(*) FROM %s WHERE coordinates IS NOT NULL', $tabelle
+        ));
+
+        self::assertSame($mitKoordinaten, $mitGeometrie,
+            sprintf('Jede Zeile in %s mit Koordinaten hat auch eine Geometrie.', $tabelle));
+    }
+
+    #[DataProvider('tabellen')]
+    public function testTheSpatialIndexIsAGist(string $tabelle): void
+    {
+        $this->nurMitPostGIS();
+
+        $art = $this->entityManager->getConnection()->fetchOne(
+            'SELECT am.amname FROM pg_index i
+             JOIN pg_class c ON c.oid = i.indexrelid
+             JOIN pg_am am ON am.oid = c.relam
+             WHERE c.relname = :name',
+            ['name' => $tabelle . '_coordinates_gist']
+        );
+
+        self::assertSame('gist', $art, sprintf('%s traegt einen GiST-Index.', $tabelle));
+    }
+
+    /**
+     * Und die Geometrie steht auch da, wo sie hingehoert: Die zurueckgelesene
+     * Lage muss der gespeicherten entsprechen. Ein vertauschtes Paar faellt
+     * hier auf, wo es in den reinen Zeichenkettenpruefungen oben nur beim
+     * Format auffiele.
+     */
+    public function testTheStoredPointMatchesTheFloatColumns(): void
+    {
+        $this->nurMitPostGIS();
+
+        $zeile = $this->entityManager->getConnection()->fetchAssociative(
+            'SELECT latitude, longitude,
+                    ST_Y(coordinates) AS geo_breite, ST_X(coordinates) AS geo_laenge
+             FROM photo WHERE coordinates IS NOT NULL LIMIT 1'
+        );
+
+        if (false === $zeile) {
+            self::markTestSkipped('Keine Fotos mit Koordinaten in den Fixtures.');
+        }
+
+        self::assertEqualsWithDelta((float) $zeile['latitude'], (float) $zeile['geo_breite'], 0.0000001,
+            'ST_Y liefert die Breite.');
+        self::assertEqualsWithDelta((float) $zeile['longitude'], (float) $zeile['geo_laenge'], 0.0000001,
+            'ST_X liefert die Laenge.');
+    }
+
+    private function nurMitPostGIS(): void
+    {
+        if (!$this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('Geometriespalten gibt es nur mit PostGIS.');
+        }
+    }
+}


### PR DESCRIPTION
Schließt **#1138** (Location) und **#1139** (Photo). Gleiches Muster wie #1136, #1137 und #1142 — deshalb in einem PR.

## Was passiert

`location` und `photo` bekommen eine `geometry(POINT, 4326)`-Spalte, gefüllt aus `latitude`/`longitude` und danach von den Settern nachgeführt. Dazu je ein GiST-Index.

| Tabelle | Zeilen | davon mit Koordinaten |
|---|---|---|
| `location` | 23 | 23 |
| `photo` | 45.499 | 26.024 (aus den EXIF-Angaben) |

**Die Fließkommaspalten bleiben die führenden Werte.** Sie hängen an der API-Ausgabe, an den Formularen und an den `DataQuery`-Attributen; fallen können sie erst, wenn auch die Bounding-Box-Abfragen umgestellt sind (Rest von #1141).

Der Punkt 0,0 liegt im Golf von Guinea und dient im Bestand als Platzhalter für „keine Angabe" — solche Zeilen bekommen **keine** Geometrie, die eine Ortsangabe vortäuschen würde. Bei den Fotos sind das 18 Zeilen.

## Test Plan

`tests/Entity/LocationAndPhotoCoordinatesTest.php`, **13 Tests**, keiner übersprungen:

- die Setter halten die Geometrie nach, auch beim Leeren einer Koordinate
- **die Länge steht vor der Breite** — in WKT anders herum als in jeder Beschriftung dieser Anwendung, und die Falle, die mich bei den Städten schon beschäftigt hat
- 0,0 wird kein Punkt
- jede Zeile mit Koordinaten trägt eine Geometrie, und beide Indexe sind GiST
- und einer, der über `ST_Y`/`ST_X` zurückliest und mit den Fließkommaspalten vergleicht: **Ein vertauschtes Paar fällt dort auf**, wo die reinen Zeichenkettenprüfungen nur das Format sehen würden

**Die Migration gegen eine echte Datenbank geprüft**, in beide Richtungen: `up` legt Spalten an, füllt sie vollständig (7 von 7 bzw. 6 von 6 in den Fixtures) und erzeugt beide Indexe; `down` räumt Spalten und Indexe restlos ab.

**Volle Suite:** 1595 Tests, alles grün. `phpstan analyse --memory-limit=1G` ohne Fehler. `schema:update --dump-sql` meldet „Nothing to update" — Schema und Entity-Modell decken sich.

## Danach offen

Von der Geometrie-Reihe bleiben **#1140** (Track als LineString, der Brocken) und der Rest von **#1141** (Bounding-Box und Umkreis im `DataQuery`). Erst wenn #1141 ganz durch ist, können `latitude`/`longitude` überhaupt fallen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR