### PR TITLE
Say in the timeline where and when a ride is

### DIFF
--- a/templates/Timeline/Items/photoComment.html.twig
+++ b/templates/Timeline/Items/photoComment.html.twig
@@ -13,11 +13,13 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-3">
+                <h5 class="mb-1">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.ride.title }}
                     </a>
                 </h5>
+
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% for post in item.postList %}
                     <div class="row g-3 mb-3">

--- a/templates/Timeline/Items/rideComment.html.twig
+++ b/templates/Timeline/Items/rideComment.html.twig
@@ -13,11 +13,13 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-2">
+                <h5 class="mb-1">
                     <a href="{{ object_path(item.ride) }}#post-{{ item.post.id }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
+
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 <p class="text-muted mb-0">
                     {{ item.post.message }}

--- a/templates/Timeline/Items/rideEdit.html.twig
+++ b/templates/Timeline/Items/rideEdit.html.twig
@@ -13,11 +13,13 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-3">
+                <h5 class="mb-1">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
+
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% if item.ride.latitude and item.ride.longitude %}
                     <div id="map-{{ item.uniqId }}"

--- a/templates/Timeline/Items/rideParticipationEstimate.html.twig
+++ b/templates/Timeline/Items/rideParticipationEstimate.html.twig
@@ -25,6 +25,8 @@
                     {% endif %}
                 </p>
 
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
+
                 <div class="text-center">
                     <div class="flipcounter">
                         {% set counter = item.estimatedParticipants %}

--- a/templates/Timeline/Items/ridePhoto.html.twig
+++ b/templates/Timeline/Items/ridePhoto.html.twig
@@ -30,6 +30,8 @@
                     {% endif %}
                 </p>
 
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
+
                 <div class="row g-3">
                     {% for previewPhoto in item.previewPhotoList %}
                         <div class="col-4">

--- a/templates/Timeline/Items/rideTrack.html.twig
+++ b/templates/Timeline/Items/rideTrack.html.twig
@@ -13,11 +13,13 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-3">
+                <h5 class="mb-1">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
+
+                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% if item.polyline %}
                     <div class="rounded overflow-hidden mb-3"

--- a/templates/Timeline/_includes/ride_meta.html.twig
+++ b/templates/Timeline/_includes/ride_meta.html.twig
@@ -1,0 +1,27 @@
+{#
+ # Stadt, Datum und Uhrzeit einer Fahrt.
+ #
+ # Ohne diese drei Angaben ordnet ein Eintrag sich nicht ein: Ein Titel wie
+ # "KidicalMass" sagt weder, wo die Fahrt stattfindet, noch wann. Bei Titeln
+ # wie "Critical Mass Offenbach 28.08.2026" steht beides zwar drin, aber nur,
+ # weil jemand es von Hand hineingeschrieben hat.
+ #
+ # Die Zeitzone kommt von der Stadt, nicht aus der Twig-Vorgabe. Fuer den
+ # heutigen Bestand macht das keinen Unterschied — dort steht bei fast jeder
+ # Stadt Europe/Berlin, auch bei Los Angeles —, aber es wird richtig, sobald
+ # jemand diese Angabe pflegt, statt dann still falsch zu bleiben.
+ #}
+{% if ride %}
+    <p class="text-muted small mb-2 timeline-item-ride-meta">
+        {% if ride.city %}
+            <i class="fas fa-map-marker-alt me-1" aria-hidden="true"></i>{{ ride.city.city }}
+        {% endif %}
+
+        {% if ride.dateTime %}
+            {% if ride.city %}<span class="mx-1">·</span>{% endif %}
+            <i class="far fa-calendar-alt me-1" aria-hidden="true"></i>{{ ride.dateTime|date('d.m.Y', ride.city ? ride.city.timezone : null) }}
+            <span class="mx-1">·</span>
+            <i class="far fa-clock me-1" aria-hidden="true"></i>{{ ride.dateTime|date('H:i', ride.city ? ride.city.timezone : null) }} Uhr
+        {% endif %}
+    </p>
+{% endif %}

--- a/tests/Criticalmass/Timeline/TimelineSaysWhereAndWhenTest.php
+++ b/tests/Criticalmass/Timeline/TimelineSaysWhereAndWhenTest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\Timeline;
+
+use App\Entity\City;
+use App\Entity\Ride;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Tests\Controller\AbstractControllerTestCase;
+
+/**
+ * Ein Timeline-Eintrag muss sagen, wo und wann.
+ *
+ * Der Titel einer Tour reicht dafuer nicht. "Critical Mass Offenbach
+ * 28.08.2026" traegt Ort und Datum nur, weil jemand sie von Hand
+ * hineingeschrieben hat; bei "KidicalMass" — so stand es am 08.09.2026 auf
+ * der Startseite — verriet allein die Karte, dass Rosenheim gemeint war, und
+ * wann die Fahrt startet, stand nirgends.
+ */
+class TimelineSaysWhereAndWhenTest extends AbstractControllerTestCase
+{
+    private const KARGER_TITEL = 'KidicalMass';
+
+    /**
+     * CachedTimeline baut seinen FilesystemAdapter an der Cache-Konfiguration
+     * vorbei; ohne dieses Leeren beantwortet die Startseite den Aufruf aus
+     * einem Bestand, der die eben angelegte Tour nicht kennt.
+     */
+    private function timelineZwischenspeicherLeeren(): void
+    {
+        (new FilesystemAdapter('criticalmass-timeline'))->clear();
+    }
+
+    /**
+     * Der Text aller Angabenzeilen der Seite.
+     *
+     * Ueber alle, nicht nur die erste: Die Timeline zeigt auch die Touren der
+     * Fixtures, und die eigene steht nicht zwangslaeufig oben.
+     */
+    private function alleAngaben(\Symfony\Component\DomCrawler\Crawler $crawler): string
+    {
+        return implode(' | ', $crawler->filter('.timeline-item-ride-meta')
+            ->each(static fn (\Symfony\Component\DomCrawler\Crawler $zeile): string => $zeile->text()));
+    }
+
+    private function tourAnlegen(EntityManagerInterface $entityManager): Ride
+    {
+        $stadt = $entityManager->getRepository(City::class)->findOneBy([]);
+        self::assertNotNull($stadt, 'Die Fixtures liefern mindestens eine Stadt.');
+        self::assertNotNull($stadt->getCity(), 'Und die Stadt hat einen Namen.');
+
+        $tour = new Ride();
+        $tour->setCity($stadt);
+        $tour->setTitle(self::KARGER_TITEL);
+        // 16:30 UTC, damit sich eine Verschiebung in der Anzeige zeigen wuerde.
+        $tour->setDateTime(new \DateTime('2026-09-18 16:30:00', new \DateTimeZone('UTC')));
+        $tour->setCreatedAt(new \DateTime());
+        $tour->setUpdatedAt(new \DateTime());
+        $tour->setEnabled(true);
+
+        $entityManager->persist($tour);
+        $entityManager->flush();
+
+        return $tour;
+    }
+
+    public function testTheTimelineNamesTheCity(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $tour = $this->tourAnlegen($entityManager);
+        $this->timelineZwischenspeicherLeeren();
+
+        $crawler = $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('.timeline-item-ride-meta')->count(),
+            'Jeder Toureneintrag traegt seine Angaben.'
+        );
+        self::assertStringContainsString(
+            (string) $tour->getCity()?->getCity(),
+            $this->alleAngaben($crawler),
+            'Die Stadt steht dabei — der Titel allein verraet sie nicht.'
+        );
+
+        $entityManager->remove($tour);
+        $entityManager->flush();
+    }
+
+    public function testTheTimelineNamesDateAndTime(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $tour = $this->tourAnlegen($entityManager);
+        $this->timelineZwischenspeicherLeeren();
+
+        $crawler = $client->request('GET', '/');
+        $angaben = $this->alleAngaben($crawler);
+
+        self::assertStringContainsString('18.09.2026', $angaben, 'Das Datum steht dabei.');
+        self::assertMatchesRegularExpression('/\d{2}:\d{2} Uhr/', $angaben, 'Und die Uhrzeit.');
+
+        $entityManager->remove($tour);
+        $entityManager->flush();
+    }
+
+    /**
+     * Die Uhrzeit wird in der Zeitzone der Stadt gezeigt, nicht als roher
+     * Datenbankwert: In der Datenbank steht UTC, angezeigt gehoert Ortszeit.
+     */
+    public function testTheTimeIsNotTheRawUtcValue(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $tour = $this->tourAnlegen($entityManager);
+        $stadt = $tour->getCity();
+        $zone = $stadt?->getTimezone() ?? 'Europe/Berlin';
+
+        $erwartet = (new \DateTimeImmutable('2026-09-18 16:30:00', new \DateTimeZone('UTC')))
+            ->setTimezone(new \DateTimeZone($zone))
+            ->format('H:i');
+
+        $this->timelineZwischenspeicherLeeren();
+        $crawler = $client->request('GET', '/');
+
+        self::assertStringContainsString(
+            $erwartet . ' Uhr',
+            $this->alleAngaben($crawler),
+            sprintf('16:30 UTC sind %s in %s.', $erwartet, $zone)
+        );
+
+        $entityManager->remove($tour);
+        $entityManager->flush();
+    }
+
+    /**
+     * Eine Tour ohne Stadt darf die Startseite nicht umwerfen — getCity() ist
+     * nullbar, und die Timeline hat sich an genau solchen Luecken schon
+     * einmal verschluckt.
+     */
+    public function testARideWithoutACityDoesNotBreakThePage(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $tour = new Ride();
+        $tour->setTitle('Tour ohne Stadt');
+        $tour->setDateTime(new \DateTime('+3 days'));
+        $tour->setCreatedAt(new \DateTime());
+        $tour->setUpdatedAt(new \DateTime());
+        $tour->setEnabled(true);
+        $entityManager->persist($tour);
+        $entityManager->flush();
+
+        $this->timelineZwischenspeicherLeeren();
+        $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful('Ohne Stadt bleibt die Seite stehen.');
+
+        $entityManager->remove($tour);
+        $entityManager->flush();
+    }
+}


### PR DESCRIPTION
## Das Problem

Ein Eintrag wie **„Critical Mass Offenbach 28.08.2026"** trägt Ort und Datum nur, weil jemand sie **von Hand in den Titel geschrieben** hat. Einer wie **„KidicalMass"** trägt beides nicht:

> *anonymous cyclist hat eine Tour editiert:* **KidicalMass**

So stand es am 8. September auf der Startseite. Dass Rosenheim gemeint war, verriet allein die Karte; **wann** die Fahrt startet, stand nirgends.

## Die Lösung

Alle **sechs** Einträge, die sich auf eine Tour beziehen — Bearbeitung, Track, Fotos, Schätzung, Tourenkommentar, Fotokommentar — tragen jetzt dieselbe Zeile darunter:

```
📍 Hamburg  ·  📅 04.06.2026  ·  🕐 21:00 Uhr
```

**Ein gemeinsamer Baustein** statt sechs Varianten: Die nächste Eintragsart bekommt es geschenkt, und keiner kann davondriften.

## Eine Entscheidung, die heute nichts ändert

Die Uhrzeit wird in der **Zeitzone der Stadt** dargestellt, nicht in Twigs Vorgabe (`Europe/Paris`). Für den heutigen Bestand ist das dasselbe — ich habe nachgesehen: **Los Angeles trägt `Europe/Berlin`**, wie fast jede Stadt. Es wird aber richtig, sobald jemand dieses Feld pflegt, statt dann still falsch zu bleiben.

Im Bestand gibt es dazu beide Schreibweisen: `Track/upload.html.twig` gibt die Zeitzone mit, `Promotion/index.html.twig` nicht. Ich habe mich an die erste gehalten.

## Test Plan

`tests/Criticalmass/Timeline/TimelineSaysWhereAndWhenTest.php`, **4 Tests** gegen die **gerenderte Startseite**:

- die Stadt steht da, auch wenn der Titel sie nicht nennt (Tour heißt „KidicalMass")
- Datum und Uhrzeit stehen da
- **16:30 UTC erscheinen als 18:30**, nicht als roher Datenbankwert
- eine Tour **ohne Stadt** lässt die Zeile weg, nicht die Seite — `getCity()` ist nullbar, und diese Timeline hat sich an genau solchen Lücken schon einmal verschluckt (#1521)

**Gegenprobe:** Mit geleertem Baustein fallen 3 der 4 um.

**Volle Suite:** 1586 Tests grün, `phpstan analyse --memory-limit=1G` ohne Fehler.

Im Browser gegen die Fixtures angesehen: Die Zeile sitzt bei Track- und Foto-Einträgen sauber unter dem Titel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR