### PR TITLE
Put the ride details below the map, and only once

### DIFF
--- a/templates/Timeline/Items/photoComment.html.twig
+++ b/templates/Timeline/Items/photoComment.html.twig
@@ -13,13 +13,11 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-1">
+                <h5 class="mb-3">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.ride.title }}
                     </a>
                 </h5>
-
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% for post in item.postList %}
                     <div class="row g-3 mb-3">
@@ -36,6 +34,10 @@
                         </div>
                     </div>
                 {% endfor %}
+
+                <div class="row g-3 mt-1">
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/Timeline/Items/rideComment.html.twig
+++ b/templates/Timeline/Items/rideComment.html.twig
@@ -13,17 +13,19 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-1">
+                <h5 class="mb-2">
                     <a href="{{ object_path(item.ride) }}#post-{{ item.post.id }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
 
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
-
                 <p class="text-muted mb-0">
                     {{ item.post.message }}
                 </p>
+
+                <div class="row g-3 mt-1">
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/Timeline/Items/rideEdit.html.twig
+++ b/templates/Timeline/Items/rideEdit.html.twig
@@ -13,13 +13,11 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-1">
+                <h5 class="mb-3">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
-
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% if item.ride.latitude and item.ride.longitude %}
                     <div id="map-{{ item.uniqId }}"
@@ -36,6 +34,10 @@
                          data-map--map-vector-value="false">
                     </div>
                 {% endif %}
+
+                <div class="row g-3 mt-1">
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
+                </div>
             </div>
         </div>
     </div>

--- a/templates/Timeline/Items/rideParticipationEstimate.html.twig
+++ b/templates/Timeline/Items/rideParticipationEstimate.html.twig
@@ -25,8 +25,6 @@
                     {% endif %}
                 </p>
 
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
-
                 <div class="text-center">
                     <div class="flipcounter">
                         {% set counter = item.estimatedParticipants %}
@@ -49,6 +47,10 @@
                         <div class="digit">{{ counter[2:1] }}</div>
                         <div class="digit">{{ counter[3:1] }}</div>
                     </div>
+                </div>
+
+                <div class="row g-3 mt-1">
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
                 </div>
             </div>
         </div>

--- a/templates/Timeline/Items/ridePhoto.html.twig
+++ b/templates/Timeline/Items/ridePhoto.html.twig
@@ -30,8 +30,6 @@
                     {% endif %}
                 </p>
 
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
-
                 <div class="row g-3">
                     {% for previewPhoto in item.previewPhotoList %}
                         <div class="col-4">
@@ -40,6 +38,10 @@
                             </a>
                         </div>
                     {% endfor %}
+                </div>
+
+                <div class="row g-3 mt-1">
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
                 </div>
             </div>
         </div>

--- a/templates/Timeline/Items/rideTrack.html.twig
+++ b/templates/Timeline/Items/rideTrack.html.twig
@@ -13,13 +13,11 @@
                     {% endif %}
                 </p>
 
-                <h5 class="mb-1">
+                <h5 class="mb-3">
                     <a href="{{ object_path(item.ride) }}" class="text-decoration-none">
                         {{ item.rideTitle }}
                     </a>
                 </h5>
-
-                {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
                 {% if item.polyline %}
                     <div class="rounded overflow-hidden mb-3"
@@ -37,20 +35,9 @@
                 {% endif %}
 
                 <div class="row g-3">
-                    <div class="col-4">
-                        <div class="d-flex align-items-center">
-                            <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
-                                 style="width: 36px; height: 36px; min-width: 36px;">
-                                <i class="far fa-calendar-alt text-primary"></i>
-                            </div>
-                            <div>
-                                <small class="text-muted d-block">Datum</small>
-                                <strong>{{ item.ride.dateTime|date('d.m.Y') }}</strong>
-                            </div>
-                        </div>
-                    </div>
+                    {{ include('Timeline/_includes/ride_meta.html.twig', {ride: item.ride}) }}
 
-                    <div class="col-4">
+                    <div class="col-6 col-md-4">
                         <div class="d-flex align-items-center">
                             <div class="bg-success bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
                                  style="width: 36px; height: 36px; min-width: 36px;">
@@ -63,7 +50,7 @@
                         </div>
                     </div>
 
-                    <div class="col-4">
+                    <div class="col-6 col-md-4">
                         <div class="d-flex align-items-center">
                             <div class="bg-info bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
                                  style="width: 36px; height: 36px; min-width: 36px;">

--- a/templates/Timeline/_includes/ride_meta.html.twig
+++ b/templates/Timeline/_includes/ride_meta.html.twig
@@ -1,27 +1,68 @@
 {#
- # Stadt, Datum und Uhrzeit einer Fahrt.
+ # Stadt, Datum und Uhrzeit einer Fahrt — als Zellen in der Bildsprache, die
+ # der Track-Eintrag schon nutzt: farbiger Kreis, Beschriftung, Wert.
  #
- # Ohne diese drei Angaben ordnet ein Eintrag sich nicht ein: Ein Titel wie
- # "KidicalMass" sagt weder, wo die Fahrt stattfindet, noch wann. Bei Titeln
- # wie "Critical Mass Offenbach 28.08.2026" steht beides zwar drin, aber nur,
- # weil jemand es von Hand hineingeschrieben hat.
+ # Ohne diese Angaben ordnet ein Eintrag sich nicht ein: Ein Titel wie
+ # "KidicalMass" sagt weder, wo die Fahrt stattfindet, noch wann. Bei
+ # "Critical Mass Offenbach 28.08.2026" steht beides zwar drin, aber nur, weil
+ # jemand es von Hand hineingeschrieben hat.
+ #
+ # Bewusst **nur die Zellen**, ohne umschliessende Zeile: Der Track-Eintrag
+ # hat bereits eine mit Distanz und Dauer, und die Angaben gehoeren dort
+ # hinein statt in eine zweite darunter. Wer den Baustein einbindet, setzt
+ # also selbst ein `<div class="row g-3">` darum.
+ #
+ # `mitDatum` laesst sich abschalten, wo das Datum schon steht.
  #
  # Die Zeitzone kommt von der Stadt, nicht aus der Twig-Vorgabe. Fuer den
  # heutigen Bestand macht das keinen Unterschied — dort steht bei fast jeder
  # Stadt Europe/Berlin, auch bei Los Angeles —, aber es wird richtig, sobald
  # jemand diese Angabe pflegt, statt dann still falsch zu bleiben.
  #}
-{% if ride %}
-    <p class="text-muted small mb-2 timeline-item-ride-meta">
-        {% if ride.city %}
-            <i class="fas fa-map-marker-alt me-1" aria-hidden="true"></i>{{ ride.city.city }}
-        {% endif %}
+{% set mitDatum = mitDatum ?? true %}
+{% set zone = ride and ride.city ? ride.city.timezone : null %}
 
-        {% if ride.dateTime %}
-            {% if ride.city %}<span class="mx-1">·</span>{% endif %}
-            <i class="far fa-calendar-alt me-1" aria-hidden="true"></i>{{ ride.dateTime|date('d.m.Y', ride.city ? ride.city.timezone : null) }}
-            <span class="mx-1">·</span>
-            <i class="far fa-clock me-1" aria-hidden="true"></i>{{ ride.dateTime|date('H:i', ride.city ? ride.city.timezone : null) }} Uhr
-        {% endif %}
-    </p>
+{% if ride and ride.city %}
+    <div class="col-6 col-md-4 timeline-item-ride-meta">
+        <div class="d-flex align-items-center">
+            <div class="bg-danger bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                 style="width: 36px; height: 36px; min-width: 36px;">
+                <i class="fas fa-map-marker-alt text-danger"></i>
+            </div>
+            <div>
+                <small class="text-muted d-block">Stadt</small>
+                <strong>{{ ride.city.city }}</strong>
+            </div>
+        </div>
+    </div>
+{% endif %}
+
+{% if ride and ride.dateTime %}
+    {% if mitDatum %}
+        <div class="col-6 col-md-4 timeline-item-ride-meta">
+            <div class="d-flex align-items-center">
+                <div class="bg-primary bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                     style="width: 36px; height: 36px; min-width: 36px;">
+                    <i class="far fa-calendar-alt text-primary"></i>
+                </div>
+                <div>
+                    <small class="text-muted d-block">Datum</small>
+                    <strong>{{ ride.dateTime|date('d.m.Y', zone) }}</strong>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
+    <div class="col-6 col-md-4 timeline-item-ride-meta">
+        <div class="d-flex align-items-center">
+            <div class="bg-warning bg-opacity-10 rounded-circle d-flex align-items-center justify-content-center me-2"
+                 style="width: 36px; height: 36px; min-width: 36px;">
+                <i class="far fa-clock text-warning"></i>
+            </div>
+            <div>
+                <small class="text-muted d-block">Uhrzeit</small>
+                <strong>{{ ride.dateTime|date('H:i', zone) }} Uhr</strong>
+            </div>
+        </div>
+    </div>
 {% endif %}


### PR DESCRIPTION
Korrigiert #1530 nach deinem Hinweis.

## Was falsch war

Ich hatte Stadt, Datum und Uhrzeit als dünne graue Zeile **zwischen Titel und Karte** gesetzt, in einer eigenen Formensprache. Zwei Dinge stimmten daran nicht:

1. Sie gehören **unter** die Karte.
2. Beim Track stand das **Datum doppelt** — einmal in meiner Zeile, einmal in der Icon-Zeile, die der Eintrag ohnehin schon hatte.

## Wie es jetzt ist

Die Angaben nutzen dieselbe Bildsprache wie der Track-Eintrag: farbiger Kreis, Beschriftung, Wert.

Der Baustein liefert **nur die Zellen**, ohne umschließende Zeile. Dadurch behält der Track seine **eine** Zeile und bekommt Stadt und Uhrzeit hinein, statt eine zweite darüber zu wachsen, die wiederholt, was schon dasteht:

```
📍 Stadt      📅 Datum        🕐 Uhrzeit
   Berlin        04.08.2026      21:00 Uhr
🚲 Distanz    🕐 Dauer
   18,00 km      3 h
```

Seine Zellen werden `col-6 col-md-4` — es sind jetzt fünf statt drei.

Die anderen fünf Einträge setzen die Zellen in eine eigene Zeile **ganz unten**: unter Karte, Fotos oder Zähler.

## Test Plan

Die vier Tests aus #1530 laufen unverändert durch — sie prüfen den **Text** der Angaben, nicht ihre Anordnung, und bleiben damit auch bei diesem Umbau gültig.

**Volle Suite:** 1586 Tests grün, `phpstan analyse --memory-limit=1G` ohne Fehler.

Im Browser gegen die Fixtures angesehen: eine Zeile unter der Karte, Datum genau einmal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR