### PR TITLE
Fill the geometry of tracks that carry no trim range

### DIFF
--- a/src/Command/Track/TracksLineStringCommand.php
+++ b/src/Command/Track/TracksLineStringCommand.php
@@ -142,6 +142,30 @@ class TracksLineStringCommand extends Command
     }
 
     /**
+     * Die Punkte einer Fahrt — mit Zuschnitt, wo einer gesetzt ist.
+     *
+     * 36 der 2.186 Tracks haben `endPoint = 0`, was "kein Zuschnitt" heisst
+     * und nicht "bis zum ersten Punkt". `getPointsInRange()` rechnet daraus
+     * aber `array_slice($punkte, 0, 0 - 0 + 1)` — **genau einen Punkt**, und
+     * damit keine Strecke. Diese Tracks blieben beim ersten Lauf allesamt
+     * liegen, und der Befehl meldete sie als "ohne genug Punkte", was formal
+     * stimmte und in die Irre fuehrte.
+     *
+     * @return array<int, \phpGPX\Models\Point>
+     */
+    private function punkte(Track $track): array
+    {
+        $von = (int) $track->getStartPoint();
+        $bis = (int) $track->getEndPoint();
+
+        if ($bis > $von) {
+            return $this->gpxService->getPointsInRange($track);
+        }
+
+        return $this->gpxService->getPoints($track);
+    }
+
+    /**
      * Baut das WKT aus den Punkten der GPX-Datei.
      *
      * In WKT steht die Laenge vor der Breite — anders herum als in jeder
@@ -150,7 +174,7 @@ class TracksLineStringCommand extends Command
      */
     private function wktAusGpx(Track $track): ?string
     {
-        $punkte = $this->gpxService->getPointsInRange($track);
+        $punkte = $this->punkte($track);
 
         $paare = [];
 

--- a/src/Criticalmass/Geo/Entity/Track.php
+++ b/src/Criticalmass/Geo/Entity/Track.php
@@ -167,9 +167,17 @@ class Track
         return $this;
     }
 
+    /**
+     * Der erste Punkt des Zuschnitts, oder 0.
+     *
+     * Die Spalte ist nullbar, der Rueckgabetyp war es nicht — bei einem Track
+     * ohne gesetzten Zuschnitt **warf** dieser Aufruf einen TypeError, statt
+     * "kein Zuschnitt" zu sagen. Getroffen hat das jeden Weg ueber
+     * GpxService::getPointsInRange().
+     */
     public function getStartPoint(): int
     {
-        return $this->startPoint;
+        return $this->startPoint ?? 0;
     }
 
     public function setEndPoint(int $endPoint): Track
@@ -179,9 +187,12 @@ class Track
         return $this;
     }
 
+    /**
+     * Der letzte Punkt des Zuschnitts, oder 0 fuer "keiner gesetzt".
+     */
     public function getEndPoint(): int
     {
-        return $this->endPoint;
+        return $this->endPoint ?? 0;
     }
 
     public function setUpdatedAt(\DateTime $updatedAt): Track

--- a/tests/Command/TracksLineStringCommandTest.php
+++ b/tests/Command/TracksLineStringCommandTest.php
@@ -28,6 +28,12 @@ class TracksLineStringCommandTest extends KernelTestCase
     {
         self::bootKernel();
         $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        // Jeder Test faengt bei null an. Ohne das bauen sie aufeinander auf:
+        // Der erste schreibt Geometrien, der zweite findet weniger offene
+        // Tracks vor als er erwartet, und welcher Test scheitert, haengt
+        // davon ab, in welcher Reihenfolge sie liefen.
+        $this->entityManager->createQuery('UPDATE App\Entity\Track t SET t.lineString = NULL')->execute();
     }
 
     /**
@@ -44,8 +50,12 @@ class TracksLineStringCommandTest extends KernelTestCase
             $punkte[] = $punkt;
         }
 
+        // Beide Wege bestuecken: Wo kein Zuschnitt gesetzt ist — und bei den
+        // Fixtures ist keiner gesetzt —, greift der Befehl auf getPoints()
+        // zurueck statt auf getPointsInRange().
         $stellvertreter = $this->createMock(GpxServiceInterface::class);
         $stellvertreter->method('getPointsInRange')->willReturn($punkte);
+        $stellvertreter->method('getPoints')->willReturn($punkte);
 
         static::getContainer()->set(GpxServiceInterface::class, $stellvertreter);
     }


### PR DESCRIPTION
Nachtrag zu #1529, gefunden beim ersten Lauf auf der Produktion.

## Was passierte

Der Befehl übersprang **alle** Tracks, die er ansah:

```
[OK] 0 Geometrien waeren geschrieben worden, 20 ohne genug Punkte uebersprungen, 0 gescheitert.
```

## Warum

**36 der 2.186 Tracks haben `endPoint = 0`** — das heißt „kein Zuschnitt gesetzt", nicht „bis zum ersten Punkt". `getPointsInRange()` rechnet daraus aber

```php
array_slice($punkte, 0, 0 - 0 + 1)   // genau ein Punkt
```

und ein Punkt ist keine Strecke. Die Meldung „ohne genug Punkte" stimmte formal und sagte niemandem etwas.

Dass ausgerechnet **alle** übersprungen wurden, lag am `--limit=20`: Die Tracks werden nach `id` sortiert, und die kaputten liegen am Anfang. Mit `--limit=80` schrieb er 45 und übersprang 35 — die Rechnung geht auf.

## Und ein zweiter Fehler darunter

`getStartPoint()` und `getEndPoint()` deklarieren `int`, ihre Spalten sind aber **nullbar**. Bei einem Track ohne Zuschnitt **warf** der Aufruf einen TypeError, statt „keiner" zu sagen:

```
App\Criticalmass\Geo\Entity\Track::getStartPoint(): Return value must be of type int, null returned
```

Das trifft **jeden** Weg über `GpxService::getPointsInRange()`, nicht nur diesen Befehl. In der Produktion steht dort meist 0 statt NULL, deshalb ist es bisher nicht aufgefallen — in den Fixtures ist es NULL, und dort fiel es sofort auf. Beide Zugriffsmethoden antworten jetzt mit 0.

## Test Plan

Die fünf Tests aus #1529 laufen weiter, mit zwei Korrekturen an ihnen selbst:

- Das Testdoppel bestückt **beide** Wege durch den Dienst (`getPointsInRange` **und** `getPoints`) — vorher konnte es den Rückfall gar nicht abbilden.
- `setUp` setzt die Geometrien zurück. Ohne das bauten die Tests aufeinander auf, und **welcher scheiterte, hing von der Reihenfolge ab** — zweimal hintereinander gelaufen, zweimal ein anderes Bild.

**Volle Suite:** 1643 Tests grün, `phpstan analyse --memory-limit=1G` ohne Fehler.

Nach dem Ausrollen läuft `criticalmass:tracks:linestring` über alle 2.186 Tracks; die 35 ohne Dateinamen bleiben liegen und werden als gescheitert gemeldet, statt still zu verschwinden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaHeHKrGZdx2sj6ckx6LLR