### PR TITLE
Nur prüfbare Adressen als Verweis in sozialen Netzwerken

### DIFF
--- a/src/Entity/SocialNetworkProfile.php
+++ b/src/Entity/SocialNetworkProfile.php
@@ -167,6 +167,52 @@ class SocialNetworkProfile
         return $this;
     }
 
+    /**
+     * Die Kennung als Adresse, auf die ein Verweis zeigen darf -- oder null.
+     *
+     * Die Kennung ist ein freies Textfeld, das jedes angemeldete Konto fuellen
+     * kann, und sie landete bisher unveraendert im href. Das ging auf zwei
+     * Arten schief:
+     *
+     *   "facebook.com/Critical Mass Kaiserslautern" (ohne Schema) las der
+     *   Browser als relativen Pfad und landete auf
+     *   criticalmass.in/kaiserslautern/facebook.com/... -- ein 404 auf der
+     *   Stadt- und der Tourseite. Sechs solcher Verweise standen live.
+     *
+     *   Schwerer wiegt, was nicht drinstand: "javascript:..." haette Twig
+     *   anstandslos in den href geschrieben. Autoescaping hilft dort nicht,
+     *   weil an so einer Zeichenkette nichts zu escapen ist -- ein Klick
+     *   fuehrt Code im Namen der lesenden Person aus.
+     *
+     * Deshalb entscheidet nicht mehr das Template, sondern diese Methode: nur
+     * http und https, und nur mit einem Rechnernamen dahinter. Alles andere
+     * ergibt null, und die Vorlagen zeigen dann Text statt eines Verweises.
+     */
+    public function getSafeUrl(): ?string
+    {
+        if (null === $this->identifier) {
+            return null;
+        }
+
+        $adresse = trim($this->identifier);
+
+        if ('' === $adresse) {
+            return null;
+        }
+
+        $teile = parse_url($adresse);
+
+        if (false === $teile || !isset($teile['scheme'], $teile['host'])) {
+            return null;
+        }
+
+        if (!in_array(strtolower($teile['scheme']), ['http', 'https'], true)) {
+            return null;
+        }
+
+        return '' === $teile['host'] ? null : $adresse;
+    }
+
     public function getNetwork(): ?string
     {
         return $this->network;

--- a/templates/City/Includes/_socialMedia.html.twig
+++ b/templates/City/Includes/_socialMedia.html.twig
@@ -10,8 +10,11 @@
             {% for profile in socialNetworkProfiles %}
                 {% set network = getNetwork(profile.network) %}
 
-                {% if network %}
-                    <a href="{{ profile.identifier }}"
+                {# Nur eine echte http(s)-Adresse wird zum Verweis; alles andere
+                   waere ein relativer Pfad oder Schlimmeres. Siehe
+                   SocialNetworkProfile::getSafeUrl(). #}
+                {% if network and profile.safeUrl %}
+                    <a href="{{ profile.safeUrl }}"
                        class="btn btn-sm"
                        style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};"
                        target="_blank"

--- a/templates/Ride/Includes/_socialMedia.html.twig
+++ b/templates/Ride/Includes/_socialMedia.html.twig
@@ -3,9 +3,15 @@
     <span class="text-muted me-2"><i class="far fa-share-alt me-1"></i>Soziale Netzwerke:</span>
     {% for profile in socialNetworkProfiles %}
         {% set network = getNetwork(profile.network) %}
-        <a href="{{ profile.identifier }}" class="btn btn-sm me-1 mb-1" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};" target="_blank" rel="noopener">
-            <i class="{{ network.icon }} me-1"></i>{{ network.name }}
-        </a>
+        {# Wie auf der Stadtseite: kein Verweis ohne pruefbare Adresse, und die
+           Stadtseite prueft hier zusaetzlich auf ein bekanntes Netz -- ohne das
+           lief diese Vorlage bei einem unbekannten Netz in network.icon auf
+           null. #}
+        {% if network and profile.safeUrl %}
+            <a href="{{ profile.safeUrl }}" class="btn btn-sm me-1 mb-1" style="background-color: {{ network.backgroundColor }}; color: {{ network.textColor }};" target="_blank" rel="noopener">
+                <i class="{{ network.icon }} me-1"></i>{{ network.name }}
+            </a>
+        {% endif %}
     {% endfor %}
 </div>
 {% endif %}

--- a/templates/SocialNetwork/list.html.twig
+++ b/templates/SocialNetwork/list.html.twig
@@ -72,9 +72,20 @@
                                 {{ network ? network.name : profile.network }}
                             </td>
                             <td>
-                                <a href="{{ profile.identifier }}">
-                                    {{ profile.identifier }}
-                                </a>
+                                {# Die Verwaltungsliste zeigt die Kennung immer,
+                                   auch eine unbrauchbare -- nur wer sie sieht,
+                                   kann sie richtigstellen. Verwiesen wird aber
+                                   nur auf eine pruefbare Adresse. #}
+                                {% if profile.safeUrl %}
+                                    <a href="{{ profile.safeUrl }}" target="_blank" rel="noopener">
+                                        {{ profile.identifier }}
+                                    </a>
+                                {% else %}
+                                    <span class="text-danger" title="Keine gültige http(s)-Adresse — dieser Eintrag verweist nirgendwohin.">
+                                        {{ profile.identifier }}
+                                        <i class="far fa-triangle-exclamation ms-1"></i>
+                                    </span>
+                                {% endif %}
                             </td>
                             <td>
                                 <div class="btn-group">

--- a/tests/Entity/SocialNetworkProfileSafeUrlTest.php
+++ b/tests/Entity/SocialNetworkProfileSafeUrlTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\SocialNetworkProfile;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Was in einem href stehen darf.
+ *
+ * Die Kennung eines Profils ist ein freies Textfeld, das jedes angemeldete
+ * Konto fuellen kann, und sie ging bisher unveraendert in den Verweis. Auf der
+ * Produktion standen dadurch sechs Verweise ohne Schema -- der Browser las sie
+ * als relativen Pfad, "facebook.com/Critical Mass Kaiserslautern" wurde zu
+ * criticalmass.in/kaiserslautern/facebook.com/... und antwortete mit 404.
+ *
+ * Der ernstere Fall stand nicht drin, war aber jederzeit eintragbar:
+ * "javascript:..." haette Twig klaglos in den href geschrieben. Autoescaping
+ * greift dort nicht, weil an der Zeichenkette nichts zu escapen ist.
+ */
+class SocialNetworkProfileSafeUrlTest extends TestCase
+{
+    private function profilMit(string $kennung): SocialNetworkProfile
+    {
+        $profil = new SocialNetworkProfile();
+        $profil->setIdentifier($kennung);
+
+        return $profil;
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function gueltigeAdressen(): array
+    {
+        return [
+            'https' => ['https://www.instagram.com/critical_mass_kaiserslautern/'],
+            'http' => ['http://example.org/critical-mass'],
+            'mit Fragment' => ['https://signal.group/#CjQKIL4s1RXDzHG17zF'],
+            'mit Abfrage' => ['https://instagram.com/xyclona?igshid=YmMyMTA2M2Y='],
+            'Grossschreibung im Schema' => ['HTTPS://example.org/'],
+        ];
+    }
+
+    #[DataProvider('gueltigeAdressen')]
+    public function testARealWebAddressIsHandedThrough(string $kennung): void
+    {
+        self::assertSame($kennung, $this->profilMit($kennung)->getSafeUrl());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function untauglicheKennungen(): array
+    {
+        return [
+            // Genau die sechs Formen, die live standen oder stehen:
+            'ohne Schema' => ['www.facebook.com/groups/786611191740363'],
+            'ohne Schema, mit Leerzeichen' => ['facebook.com/Critical Mass Kaiserslautern'],
+            'gar keine Adresse' => ['FB-67278'],
+            'Mastodon-Kennung' => ['@criticalmass@karlsruhe-social.de'],
+            'Schlagwort' => ['#CriticalMassNorderstedt'],
+
+            // Und das, was nie drinstand, aber jederzeit haette drinstehen koennen:
+            'javascript' => ['javascript:alert(document.cookie)'],
+            'javascript in Grossbuchstaben' => ['JavaScript:alert(1)'],
+            'data' => ['data:text/html,<script>alert(1)</script>'],
+            'vbscript' => ['vbscript:msgbox(1)'],
+
+            // Schemata, die zwar harmlos sind, aber in diesem Feld nichts zu
+            // suchen haben -- der Verweis soll eine Webseite oeffnen.
+            'Datei' => ['file:///etc/passwd'],
+            'Post' => ['mailto:info@example.org'],
+
+            'leer' => [''],
+            'nur Leerzeichen' => ['   '],
+            'Schema ohne Rechnernamen' => ['https://'],
+        ];
+    }
+
+    #[DataProvider('untauglicheKennungen')]
+    public function testAnythingElseYieldsNoLink(string $kennung): void
+    {
+        self::assertNull(
+            $this->profilMit($kennung)->getSafeUrl(),
+            sprintf('"%s" darf nicht in einem href landen.', $kennung)
+        );
+    }
+
+    public function testAProfileWithoutAnIdentifierYieldsNoLink(): void
+    {
+        self::assertNull((new SocialNetworkProfile())->getSafeUrl());
+    }
+
+    /**
+     * Fuehrende Leerzeichen sind ein Tippfehler, kein Grund, den Verweis
+     * fallenzulassen -- aber die zurueckgegebene Adresse ist die getrimmte.
+     */
+    public function testSurroundingWhitespaceIsForgiven(): void
+    {
+        self::assertSame(
+            'https://example.org/',
+            $this->profilMit("  https://example.org/\n")->getSafeUrl()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Die Kennung eines `SocialNetworkProfile` ist ein freies Textfeld, das jedes angemeldete Konto füllen kann — und sie ging bisher unverändert in den `href`.

- **Live sichtbar war der harmlosere Teil:** sechs aktive Kennungen ohne Schema, die der Browser als *relativen Pfad* las. `facebook.com/Critical Mass Kaiserslautern` wurde auf der Stadt- und der Tourseite zu `criticalmass.in/kaiserslautern/facebook.com/…` und antwortete mit 404. (Die sechs Zeilen sind auf der Produktion bereits richtiggestellt: vier bekamen ihr `https://`, zwei waren gar keine Adresse und stehen jetzt auf `enabled = false`.)
- **Der ernstere Fall stand nicht in der Datenbank, war aber jederzeit eintragbar:** `javascript:…` hätte Twig klaglos in den `href` geschrieben. Autoescaping greift dort nicht, weil an so einer Zeichenkette nichts zu escapen ist — ein Klick führt Code im Namen der lesenden Person aus. Anlegen darf ein Profil jedes angemeldete Konto, gelesen wird es öffentlich.

Deshalb entscheidet nicht mehr die Vorlage, sondern `SocialNetworkProfile::getSafeUrl()`: nur `http` und `https`, und nur mit einem Rechnernamen dahinter. Alle drei Stellen, die einen Verweis erzeugen, gehen darüber.

Die Verwaltungsliste zeigt eine unbrauchbare Kennung **weiterhin an** — nur wer sie sieht, kann sie richtigstellen — aber ohne Verweis und mit einem Hinweis daneben.

Nebenbei: die Tourseite prüft jetzt auch, ob das Netz bekannt ist. Ohne das lief sie bei einem unbekannten Netz in `network.icon` auf `null`; die Stadtseite tat das schon.

**Bewusst nicht getan:** keine `Assert\Url` auf der Entity. Sieben (deaktivierte) Kennungen sind Mastodon-Adressen der Form `@name@instanz` oder Schlagwörter — ob die legitim sind, weiß ich nicht, und eine Ablehnung beim Speichern würde sie unreparierbar machen. Die Prüfung beim Rendern schließt die Lücke unabhängig davon, was gespeichert ist.

## Test plan

- `tests/Entity/SocialNetworkProfileSafeUrlTest.php`, 21 Fälle: die fünf Formen, die tatsächlich in der Produktion standen, dazu `javascript:` (auch gemischt geschrieben), `data:`, `vbscript:`, `file:`, `mailto:`, leer, nur Leerzeichen und `https://` ohne Rechnernamen.
- `vendor/bin/phpunit tests/Entity/SocialNetworkProfileSafeUrlTest.php` → 21/21 grün.
- `bin/console lint:twig` über die drei Vorlagen → OK.
- PHPStan level 6 über die geänderten Dateien → keine Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)