### PR TITLE
Teilnahmefilter: boolesche Spalten gegen Wahrheitswerte vergleichen

### DIFF
--- a/src/Repository/ParticipationRepository.php
+++ b/src/Repository/ParticipationRepository.php
@@ -105,16 +105,29 @@ class ParticipationRepository extends ServiceEntityRepository
             ->setParameter('user', $user)
             ->orderBy('r.dateTime', 'DESC');
 
+        // Der zweite Wert von expr()->eq() ist ein DQL-Bruchstueck, kein Wert:
+        // ein PHP-true wurde dabei zur Zeichenkette "1", und die Abfrage fragte
+        // "goingYes = 1". MySQL nahm das hin, PostgreSQL nicht --
+        // SQLSTATE[42883], "operator does not exist: boolean = integer". Seit
+        // dem Umzug am 05.09.2026 endete /profile/participation/list damit im
+        // 500er. Ein benannter Parameter traegt den Typ mit, so wie es die
+        // uebrigen Methoden dieser Klasse ohnehin halten.
         if ($yes) {
-            $builder->andWhere($builder->expr()->eq('p.goingYes', true));
+            $builder
+                ->andWhere($builder->expr()->eq('p.goingYes', ':goingYes'))
+                ->setParameter('goingYes', true);
         }
 
         if ($maybe) {
-            $builder->andWhere($builder->expr()->eq('p.goingMaybe', true));
+            $builder
+                ->andWhere($builder->expr()->eq('p.goingMaybe', ':goingMaybe'))
+                ->setParameter('goingMaybe', true);
         }
 
         if ($no) {
-            $builder->andWhere($builder->expr()->eq('p.goingNo', true));
+            $builder
+                ->andWhere($builder->expr()->eq('p.goingNo', ':goingNo'))
+                ->setParameter('goingNo', true);
         }
 
         $query = $builder->getQuery();

--- a/tests/Repository/ParticipationBooleanPortabilityTest.php
+++ b/tests/Repository/ParticipationBooleanPortabilityTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Repository;
+
+use App\Entity\Participation;
+use App\Entity\User;
+use App\Repository\ParticipationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Boolesche Spalten muessen gegen einen Wahrheitswert verglichen werden.
+ *
+ * `$builder->expr()->eq('p.goingYes', true)` sieht aus wie ein Vergleich mit
+ * einem Wert, ist aber keiner: Das zweite Argument ist ein DQL-Bruchstueck.
+ * Aus dem PHP-true wurde die Zeichenkette "1", und die Abfrage lautete
+ * "goingYes = 1".
+ *
+ * MySQL nahm das hin. PostgreSQL nicht:
+ *
+ *     SQLSTATE[42883]: Undefined function: operator does not exist:
+ *     boolean = integer
+ *
+ * Seit dem Umzug am 05.09.2026 endete /profile/participation/list damit im
+ * 500er -- eine Seite hinter der Anmeldung, weshalb es fuenf Tage dauerte, bis
+ * es jemandem auffiel. Die Testsuite lief die ganze Zeit gruen, weil kein Test
+ * diese drei Zweige je betrat.
+ *
+ * Die Tests hier rufen jede Kombination auf. Sie pruefen bewusst kein
+ * Ergebnis: Was zurueckkommt, haengt an den Fixtures. Es geht darum, dass die
+ * Datenbank die Abfrage ueberhaupt annimmt.
+ */
+class ParticipationBooleanPortabilityTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+    }
+
+    private function repository(): ParticipationRepository
+    {
+        $repository = static::getContainer()->get(ParticipationRepository::class);
+        self::assertInstanceOf(ParticipationRepository::class, $repository);
+
+        return $repository;
+    }
+
+    /**
+     * Irgendein Konto, das ueberhaupt schon einmal teilgenommen hat -- an einem
+     * Konto ohne Teilnahmen liefe die Abfrage zwar auch, aber der Vergleich
+     * stuende dann in einem Zweig, den die Datenbank womoeglich wegoptimiert.
+     */
+    private function teilnehmendesKonto(): User
+    {
+        $teilnahme = $this->entityManager->getRepository(Participation::class)->findOneBy([]);
+        self::assertInstanceOf(Participation::class, $teilnahme, 'Die Fixtures kennen keine Teilnahme.');
+
+        $konto = $teilnahme->getUser();
+        self::assertInstanceOf(User::class, $konto);
+
+        return $konto;
+    }
+
+    public function testFilteringByYesIsAcceptedByTheDatabase(): void
+    {
+        $ergebnis = $this->repository()->findByUser($this->teilnehmendesKonto(), true);
+
+        self::assertContainsOnlyInstancesOf(Participation::class, $ergebnis);
+    }
+
+    public function testFilteringByMaybeIsAcceptedByTheDatabase(): void
+    {
+        $ergebnis = $this->repository()->findByUser($this->teilnehmendesKonto(), false, true);
+
+        self::assertContainsOnlyInstancesOf(Participation::class, $ergebnis);
+    }
+
+    public function testFilteringByNoIsAcceptedByTheDatabase(): void
+    {
+        $ergebnis = $this->repository()->findByUser($this->teilnehmendesKonto(), false, false, true);
+
+        self::assertContainsOnlyInstancesOf(Participation::class, $ergebnis);
+    }
+
+    /**
+     * Die Profilseite fragt alle drei nacheinander ab, auf demselben Builder-
+     * Muster. Der Reihe nach, damit auch die Kombination durchlaeuft.
+     */
+    public function testTheProfilePageAsksForAllThreeInARow(): void
+    {
+        $konto = $this->teilnehmendesKonto();
+        $repository = $this->repository();
+
+        self::assertContainsOnlyInstancesOf(Participation::class, $repository->findByUser($konto, true));
+        self::assertContainsOnlyInstancesOf(Participation::class, $repository->findByUser($konto, false, true));
+        self::assertContainsOnlyInstancesOf(Participation::class, $repository->findByUser($konto, false, false, true));
+    }
+
+    /**
+     * Und ohne jeden Filter -- der Zweig, der schon vorher lief.
+     */
+    public function testFilteringByNothingStillWorks(): void
+    {
+        self::assertContainsOnlyInstancesOf(Participation::class, $this->repository()->findByUser($this->teilnehmendesKonto()));
+    }
+}


### PR DESCRIPTION
## Summary

`/profile/participation/list` endet seit dem PostgreSQL-Umzug am 05.09.2026 im **500er**. Heute früh kamen die ersten beiden Aufrufe seither, deshalb fiel es erst jetzt auf — die Seite liegt hinter der Anmeldung.

```
SQLSTATE[42883]: Undefined function: operator does not exist: boolean = integer
LINE 1: ... WHERE p0_.user_id = $1 AND p0_.goingYes = 1 ORDER ...
```

Die Ursache steht in `ParticipationRepository::findByUser()`:

```php
$builder->andWhere($builder->expr()->eq('p.goingYes', true));
```

Das sieht aus wie ein Vergleich mit einem Wert, ist aber keiner: Das zweite Argument von `expr()->eq()` ist ein **DQL-Bruchstück**. Aus dem PHP-`true` wurde die Zeichenkette `"1"`, die Abfrage lautete `goingYes = 1`. MySQL nahm das hin, PostgreSQL lehnt es ab.

Benannte Parameter tragen den Typ mit — so, wie es die übrigen Methoden derselben Klasse (`countParticipationsForRide`, `findParticipationsForRide`) ohnehin schon halten.

Betroffen waren alle drei Zweige (`yes`, `maybe`, `no`). Die Suche nach demselben Muster (`expr()->eq(…, true|false)` und boolesche Literale in DQL-Strings) fand im ganzen Quelltext sonst **nichts**.

## Warum die Suite das nicht gemerkt hat

Kein Test hat diese drei Zweige je betreten — `findByUser()` wurde nur ohne Filter aufgerufen, und genau dieser Aufruf funktionierte. Der neue Test betritt sie einzeln und in der Reihe, in der die Profilseite sie abfragt.

## Test plan

- `tests/Repository/ParticipationBooleanPortabilityTest.php`, 5 Fälle.
- Gegen den **alten** Stand gefahren: 4 Fehler, genau der `42883` aus dem Protokoll. Der fünfte Fall (ohne Filter) blieb grün — der lief ja auch vorher.
- Gegen den neuen Stand: 5/5 grün.
- Lokale Testdatenbank ist PostgreSQL 17.11, also dieselbe Plattform wie Produktion und CI.
- PHPStan level 6 über beide Dateien → keine Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)