### PR TITLE
Übergroße Bilder: 404 statt 500 bei der Vorschau

### DIFF
--- a/src/EventSubscriber/ThumbnailForOversizedImageSubscriber.php
+++ b/src/EventSubscriber/ThumbnailForOversizedImageSubscriber.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Beantwortet die Vorschau eines Bildes, das ImageMagick nicht oeffnen darf,
+ * mit 404 statt 500.
+ *
+ * Drei Panoramen im Bestand sind **16382 Pixel breit** -- gestitchte
+ * Rundumbilder derselben Kamera. ImageMagicks policy.xml deckelt Breite und
+ * Hoehe bei 16KP, also 16000:
+ *
+ *     <policy domain="resource" name="width" value="16KP"/>
+ *
+ * Damit scheitert schon das Oeffnen der Datei, lange vor dem Verkleinern:
+ * "width or height exceeds limit" @ error/cache.c/OpenPixelCache. Jeder
+ * Aufruf der zugehoerigen Galerie warf einen 500er, zuletzt am 05.09. und am
+ * 11.09.2026.
+ *
+ * **Das laesst sich in der Anwendung nicht abstellen.** Die Grenzen aus
+ * policy.xml sind eine Decke, keine Vorgabe: Imagick::setResourceLimit() darf
+ * sie senken, nicht heben -- ein Versuch bleibt wirkungslos, ohne Fehler. Wer
+ * Vorschauen fuer diese drei Bilder will, muss entweder die Richtlinie des
+ * Servers anfassen (die gilt fuer alle Anwendungen darauf) oder die Dateien
+ * verkleinern.
+ *
+ * Was diese Klasse leistet, ist deshalb bescheidener und trotzdem das
+ * Wichtigste: Sie macht aus dem Serverfehler eine ehrliche Auskunft. Es
+ * *gibt* unter dieser Richtlinie keine Vorschau dieser Datei -- 404 sagt das,
+ * 500 behauptet faelschlich, der Server sei kaputt. Der Schwesterfall steht in
+ * {@see ThumbnailForNonImageSubscriber}, der dasselbe fuer Videos tut.
+ *
+ * Damit der Vorgang nicht stillschweigend verschwindet, geht eine Warnung ins
+ * Protokoll: Ein neues uebergrosses Bild soll auffallen, nur eben nicht als
+ * Stoerung.
+ *
+ * Bewusst eng gefasst: nur auf den beiden Liip-Routen, und nur, wenn in der
+ * Kette tatsaechlich eine ImagickException steht. Ein Filter, der aus einem
+ * anderen Grund scheitert, soll weiterhin als Fehler auffallen.
+ */
+#[AsEventListener(event: KernelEvents::EXCEPTION)]
+final class ThumbnailForOversizedImageSubscriber
+{
+    private const LIIP_ROUTEN = ['liip_imagine_filter', 'liip_imagine_filter_runtime'];
+
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(ExceptionEvent $event): void
+    {
+        $route = $event->getRequest()->attributes->get('_route');
+
+        if (!\in_array($route, self::LIIP_ROUTEN, true)) {
+            return;
+        }
+
+        $imagick = $this->imagickAusDerKette($event->getThrowable());
+
+        if (null === $imagick) {
+            return;
+        }
+
+        $this->logger->warning('Keine Vorschau moeglich: ImageMagick lehnt die Datei ab.', [
+            'pfad' => $event->getRequest()->attributes->get('path'),
+            'filter' => $event->getRequest()->attributes->get('filter'),
+            // ImageMagicks eigene Meldung nennt den Grund und die Datei; die
+            // geltenden Grenzen stehen in policy.xml und damit im Kopf dieser
+            // Klasse -- sie aendern sich nicht von Anfrage zu Anfrage.
+            'grund' => $imagick->getMessage(),
+        ]);
+
+        $event->setThrowable(new NotFoundHttpException(
+            'Von dieser Datei gibt es keine Vorschau.',
+            $event->getThrowable()
+        ));
+    }
+
+    /**
+     * Liip verpackt den Fehler zweimal: eine RuntimeException des Controllers
+     * um eine des Imagine-Adapters um die eigentliche ImagickException. Die
+     * Tiefe ist nichts, worauf man sich festlegen sollte -- also die Kette
+     * entlanggehen.
+     */
+    private function imagickAusDerKette(\Throwable $throwable): ?\Throwable
+    {
+        if (!class_exists(\ImagickException::class)) {
+            return null;
+        }
+
+        for ($aktuell = $throwable; null !== $aktuell; $aktuell = $aktuell->getPrevious()) {
+            if ($aktuell instanceof \ImagickException) {
+                return $aktuell;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/EventSubscriber/ThumbnailForOversizedImageSubscriberTest.php
+++ b/tests/EventSubscriber/ThumbnailForOversizedImageSubscriberTest.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types=1);
+
+namespace Tests\EventSubscriber;
+
+use App\EventSubscriber\ThumbnailForOversizedImageSubscriber;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+// Imagick ist weder lokal noch in der CI installiert -- nur auf dem Server.
+require_once __DIR__ . '/../Stub/imagick_exception.php';
+
+/**
+ * Ein Bild, das ImageMagick nicht oeffnen darf, ergibt 404 statt 500.
+ *
+ * Drei Panoramen im Bestand sind 16382 Pixel breit; policy.xml deckelt Breite
+ * und Hoehe bei 16000. Jeder Aufruf der Galerie warf dadurch einen 500er.
+ * Heben laesst sich die Grenze aus der Anwendung heraus nicht -- also bleibt,
+ * ehrlich zu antworten: Unter dieser Richtlinie *gibt* es keine Vorschau.
+ */
+final class ThumbnailForOversizedImageSubscriberTest extends TestCase
+{
+    private function ereignis(\Throwable $fehler, ?string $route): ExceptionEvent
+    {
+        $request = Request::create('/media/cache/resolve/gallery_photo_thumb/panorama.jpg');
+
+        if (null !== $route) {
+            $request->attributes->set('_route', $route);
+            $request->attributes->set('path', 'panorama.jpg');
+            $request->attributes->set('filter', 'gallery_photo_thumb');
+        }
+
+        return new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            $fehler,
+        );
+    }
+
+    private function subscriber(?LoggerInterface $logger = null): ThumbnailForOversizedImageSubscriber
+    {
+        return new ThumbnailForOversizedImageSubscriber($logger ?? new NullLogger());
+    }
+
+    /**
+     * Genau die Kette, die Liip erzeugt: Controller-RuntimeException um die des
+     * Imagine-Adapters um die ImagickException.
+     */
+    private function echteKette(): \Throwable
+    {
+        $imagick = new \ImagickException('width or height exceeds limit `panorama.jpg\'', 465);
+        $imagine = new \RuntimeException('Could not load image from string', 0, $imagick);
+
+        return new \RuntimeException(
+            'Unable to create image for path "panorama.jpg" and filter "gallery_photo_thumb".',
+            0,
+            $imagine
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function liipRouten(): array
+    {
+        return [
+            'Filter' => ['liip_imagine_filter'],
+            'Filter zur Laufzeit' => ['liip_imagine_filter_runtime'],
+        ];
+    }
+
+    #[DataProvider('liipRouten')]
+    public function testAnImageMagickRefusalBecomesANotFound(string $route): void
+    {
+        $ereignis = $this->ereignis($this->echteKette(), $route);
+
+        ($this->subscriber())($ereignis);
+
+        self::assertInstanceOf(NotFoundHttpException::class, $ereignis->getThrowable());
+    }
+
+    /**
+     * Auch wenn die ImagickException ganz oben steht -- auf die Tiefe der
+     * Verpackung soll sich niemand verlassen muessen.
+     */
+    public function testTheDepthOfTheWrappingDoesNotMatter(): void
+    {
+        $ereignis = $this->ereignis(
+            new \ImagickException('width or height exceeds limit', 465),
+            'liip_imagine_filter'
+        );
+
+        ($this->subscriber())($ereignis);
+
+        self::assertInstanceOf(NotFoundHttpException::class, $ereignis->getThrowable());
+    }
+
+    /**
+     * Der urspruengliche Fehler bleibt als Ursache erhalten -- sonst waere im
+     * Protokoll nicht mehr zu sehen, worum es ging.
+     */
+    public function testTheOriginalFailureIsKeptAsTheCause(): void
+    {
+        $ursprung = $this->echteKette();
+        $ereignis = $this->ereignis($ursprung, 'liip_imagine_filter');
+
+        ($this->subscriber())($ereignis);
+
+        self::assertSame($ursprung, $ereignis->getThrowable()->getPrevious());
+    }
+
+    /**
+     * Und er verschwindet nicht stillschweigend: Ein neues uebergrosses Bild
+     * soll auffallen, nur eben nicht als Stoerung.
+     */
+    public function testTheRefusalIsWrittenToTheLog(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('Keine Vorschau'),
+                self::callback(static fn (array $zusatz): bool => 'panorama.jpg' === $zusatz['pfad']
+                    && 'gallery_photo_thumb' === $zusatz['filter']
+                    && str_contains($zusatz['grund'], 'exceeds limit'))
+            );
+
+        ($this->subscriber($logger))($this->ereignis($this->echteKette(), 'liip_imagine_filter'));
+    }
+
+    /**
+     * Ausserhalb der Liip-Routen wird nichts angefasst. Dieselbe Ausnahme aus
+     * einem Bildbearbeitungsschritt anderswo soll weiterhin als Fehler
+     * auffallen.
+     */
+    public function testOtherRoutesAreLeftAlone(): void
+    {
+        foreach (['criticalmass_photo_show', null] as $route) {
+            $ursprung = $this->echteKette();
+            $ereignis = $this->ereignis($ursprung, $route);
+
+            ($this->subscriber())($ereignis);
+
+            self::assertSame($ursprung, $ereignis->getThrowable(), sprintf('Route %s', $route ?? '(keine)'));
+        }
+    }
+
+    /**
+     * Und ein Filter, der aus einem anderen Grund scheitert -- ein fehlendes
+     * Wasserzeichen etwa -- bleibt ein Fehler.
+     */
+    public function testAFailureWithoutImageMagickStaysAnError(): void
+    {
+        $ursprung = new \RuntimeException(
+            'Unable to create image for path "foto.jpg" and filter "gallery_photo_standard".',
+            0,
+            new \RuntimeException('Watermark image not found')
+        );
+
+        $ereignis = $this->ereignis($ursprung, 'liip_imagine_filter');
+
+        ($this->subscriber())($ereignis);
+
+        self::assertSame($ursprung, $ereignis->getThrowable());
+    }
+}

--- a/tests/Stub/imagick_exception.php
+++ b/tests/Stub/imagick_exception.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * Ein Platzhalter fuer ImagickException.
+ *
+ * Die Erweiterung ist in der Produktion installiert -- liip_imagine faehrt auf
+ * `driver: imagick` --, lokal und in der CI aber nicht: Die CI laedt nur intl
+ * und pdo_pgsql. Ohne diesen Platzhalter liesse sich die Behandlung eines
+ * Imagick-Fehlers nirgends pruefen ausser auf dem Server selbst.
+ *
+ * Die echte Klasse erbt ebenfalls von Exception; mehr braucht der
+ * Subscriber nicht von ihr, er prueft nur den Typ.
+ */
+if (!class_exists('ImagickException', false)) {
+    class ImagickException extends \Exception
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Drei Panoramen im Bestand sind **16382 Pixel breit** — gestitchte Rundumbilder derselben Kamera. ImageMagicks `policy.xml` auf server2 deckelt Breite und Höhe bei `16KP`, also 16000:

```xml
<policy domain="resource" name="width" value="16KP"/>
<policy domain="resource" name="height" value="16KP"/>
```

Damit scheitert schon das **Öffnen** der Datei, lange vor dem Verkleinern:

```
ImagickException(465): width or height exceeds limit @ error/cache.c/OpenPixelCache/3909
```

Jeder Aufruf der zugehörigen Galerie warf einen 500er — zuletzt am 05.09. und am 11.09.2026.

| Datei | Abmessungen |
|---|---|
| `62a1c356d591f932196594.jpg` | 16382 × 3842 |
| `631274b96afda992551661.jpeg` | 16382 × 3848 |
| `631274b6b4e1b789674346.jpeg` | 16382 × 3804 |

Ein Durchlauf über **alle 40.935 Dateien** in `public/photos` fand genau diese drei über der Grenze. (Die 19 weiteren nicht lesbaren sind Videos und HEIC — das ist der Fall von #1519 und bereits erledigt.)

## Warum der Fix nicht mehr kann

**Die Grenzen aus `policy.xml` sind eine Decke, keine Vorgabe.** `Imagick::setResourceLimit()` darf sie senken, nicht heben — ein Versuch bleibt wirkungslos, und zwar *ohne Fehler*: Auf dem Server gemessen steht die Breite nach `setResourceLimit(…, 32768)` unverändert auf 16000.

Wer Vorschauen für diese drei Bilder will, hat zwei Wege — beides Entscheidungen, die nicht im Quelltext fallen:

1. **`policy.xml` auf server2 anheben** (z. B. auf `20KP`). Gilt für alle sechs Anwendungen auf dem Server. Das Risiko ist gering: Die eigentlichen Schranken gegen Dekompressionsbomben sind `area` (128 MP) und `memory` (256 MiB), und die bleiben — ein 20000 × 20000 großes Bild wäre mit 400 MP weiterhin abgewiesen.
2. **Die drei Dateien verkleinern** (16382 → z. B. 15000 breit). Verändert hochgeladene Originale.

## Was dieser PR tut

Aus dem Serverfehler eine ehrliche Auskunft machen. Es *gibt* unter dieser Richtlinie keine Vorschau dieser Datei — 404 sagt das, 500 behauptet fälschlich, der Server sei kaputt. Genauso verfährt seit #1519 `ThumbnailForNonImageSubscriber` mit Videos; dieser hier ist sein Schwesterfall.

Damit nichts stillschweigend verschwindet, geht eine **Warnung** ins Protokoll: Ein neues übergroßes Bild soll auffallen, nur eben nicht als Störung.

Eng gefasst: nur auf den beiden Liip-Routen, und nur, wenn in der Ausnahmekette tatsächlich eine `ImagickException` steht. Ein Filter, der aus einem anderen Grund scheitert (fehlendes Wasserzeichen etwa), bleibt ein Fehler — dafür gibt es einen Test.

## Test plan

- `tests/EventSubscriber/ThumbnailForOversizedImageSubscriberTest.php`, 7 Fälle: beide Liip-Routen, die echte dreifach verschachtelte Kette, die ImagickException ganz oben, Ursache bleibt erhalten, Protokolleintrag, andere Routen unangetastet, Fehler ohne Imagick bleibt Fehler.
- `vendor/bin/phpunit tests/EventSubscriber/` → 27/27 grün (inkl. der Nachbartests).
- `vendor/bin/phpstan analyse` über den **gesamten** Quelltext → keine Fehler, Baseline unverändert.

**Zum Platzhalter in `tests/Stub/`:** Imagick ist weder lokal noch in der CI installiert (`.github/workflows/ci.yml` lädt nur `intl, pdo_pgsql`), nur in der Produktion. Ohne ihn ließe sich die Behandlung eines Imagick-Fehlers nirgends prüfen außer auf dem Server. Ein PHPStan-`scanFiles`-Stub kam **nicht** in Frage: Er verdeckt die echte Klasse für den ganzen Quelltext und erzeugte prompt 13 neue Fehler (`Call to an undefined method Imagick::stripImage()` und so weiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)