### PR TITLE
Inaktive Städte nicht mehr prominent bewerben

### DIFF
--- a/assets/scss/criticalmass/_calendar.scss
+++ b/assets/scss/criticalmass/_calendar.scss
@@ -164,6 +164,19 @@
         text-decoration: line-through;
         color: var(--bs-secondary-color, #6c757d);
     }
+
+    /* Stadt ohne Lebenszeichen: da, aber nicht beworben. */
+    &--inactive,
+    &--inactive a {
+        color: var(--bs-secondary-color, #6c757d);
+    }
+}
+
+.calendar-day__subheading {
+    font-size: .95rem;
+    font-weight: 600;
+    color: var(--bs-secondary-color, #6c757d);
+    margin: 1.5rem 0 .5rem;
 }
 
 .calendar-day__time {

--- a/src/Controller/City/CityListController.php
+++ b/src/Controller/City/CityListController.php
@@ -24,18 +24,28 @@ class CityListController extends AbstractController
 
         $now = new \DateTime();
         $cityList = [];
+        $inactiveCityList = [];
 
+        // Eingeschlafene Staedte bleiben erreichbar, stehen aber nicht mehr
+        // gleichrangig neben denen, in denen gefahren wird.
         foreach ($cityRepository->findEnabledCities() as $city) {
-            $cityList[] = new CityListModel(
+            $model = new CityListModel(
                 $city,
                 $rideRepository->findCurrentRideForCity($city),
                 $cityCycleRepository->findByCity($city, $now, $now),
                 $rideRepository->countRidesByCity($city),
             );
+
+            if ($city->isInactive()) {
+                $inactiveCityList[] = $model;
+            } else {
+                $cityList[] = $model;
+            }
         }
 
         return $this->render('CityList/list.html.twig', [
             'cityList' => $cityList,
+            'inactiveCityList' => $inactiveCityList,
         ]);
     }
 }

--- a/src/DataFixtures/CityFixtures.php
+++ b/src/DataFixtures/CityFixtures.php
@@ -98,6 +98,8 @@ class CityFixtures extends Fixture implements DependentFixtureInterface
             $manager,
             0.005
         );
+        // Aelter als die Karenzzeit, sonst gaelte sie als neu und damit als aktiv.
+        $inactiveCity->setCreatedAt(new \DateTime('-2 years'));
         $this->addReference(self::INACTIVE_CITY_REFERENCE, $inactiveCity);
 
         $manager->flush();

--- a/src/Entity/City.php
+++ b/src/Entity/City.php
@@ -12,6 +12,7 @@ use App\EntityInterface\PhotoInterface;
 use App\EntityInterface\PostableInterface;
 use App\EntityInterface\RouteableInterface;
 use App\EntityInterface\SocialNetworkProfileAble;
+use App\Repository\CityRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -886,5 +887,35 @@ class City implements BoardInterface, PhotoInterface, RouteableInterface, Audita
         $this->activityScore = $activityScore;
 
         return $this;
+    }
+
+    /**
+     * Ob die Stadt als eingeschlafen gilt und deshalb nicht mehr beworben wird.
+     *
+     * Der Score misst nur, was auf criticalmass.in ankommt — Teilnahmen, Fotos,
+     * Tracks, Feed-Eintraege der letzten sechs Monate. Eine frisch angelegte
+     * Stadt hat davon zwangslaeufig nichts: Die zehn indonesischen Staedte vom
+     * September 2026 standen zwei Tage nach dem Anlegen alle auf 0, obwohl sie
+     * nachweislich fahren. Deshalb gilt eine Stadt erst als inaktiv, wenn sie
+     * aelter ist als das Messfenster.
+     *
+     * Gleiche Regel wie CityRepository::addActiveCityCondition() — beide
+     * zusammen aendern.
+     */
+    #[Ignore]
+    public function isInactive(?\DateTimeInterface $now = null): bool
+    {
+        if (null === $this->activityScore || $this->activityScore >= CityRepository::ACTIVITY_SCORE_THRESHOLD) {
+            return false;
+        }
+
+        if (null === $this->createdAt) {
+            return true;
+        }
+
+        // time() statt new DateTime(), damit ClockMock in Tests greift.
+        $now ??= (new \DateTimeImmutable())->setTimestamp(time());
+
+        return $this->createdAt <= CityRepository::activityGraceStart($now);
     }
 }

--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -6,6 +6,7 @@ use App\Entity\City;
 use App\Entity\Region;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\ResultSetMappingBuilder;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 class CityRepository extends ServiceEntityRepository
@@ -172,6 +173,39 @@ class CityRepository extends ServiceEntityRepository
      */
     public const ACTIVITY_SCORE_THRESHOLD = 0.01;
 
+    /**
+     * So lange gilt eine neu angelegte Stadt nie als inaktiv — genau das
+     * Messfenster des Scores, siehe City::isInactive().
+     */
+    public const ACTIVITY_GRACE_PERIOD = '-6 months';
+
+    public static function activityGraceStart(\DateTimeInterface $now): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromInterface($now)->modify(self::ACTIVITY_GRACE_PERIOD);
+    }
+
+    /**
+     * Schraenkt eine Abfrage auf Staedte ein, die nicht als inaktiv gelten:
+     * Score ab dem Schwellwert, noch kein Score, oder juenger als die
+     * Karenzzeit. Gleiche Regel wie City::isInactive() — beide zusammen aendern.
+     */
+    public static function addActiveCityCondition(QueryBuilder $builder, string $alias): QueryBuilder
+    {
+        // time() statt new DateTime(), damit ClockMock in Tests greift.
+        $now = (new \DateTimeImmutable())->setTimestamp(time());
+
+        return $builder
+            ->andWhere(
+                $builder->expr()->orX(
+                    $builder->expr()->gte($alias . '.activityScore', ':activityThreshold'),
+                    $builder->expr()->isNull($alias . '.activityScore'),
+                    $builder->expr()->gt($alias . '.createdAt', ':activityGraceStart')
+                )
+            )
+            ->setParameter('activityThreshold', self::ACTIVITY_SCORE_THRESHOLD)
+            ->setParameter('activityGraceStart', \DateTime::createFromImmutable(self::activityGraceStart($now)));
+    }
+
     /** @return list<City> */
     public function findActiveCities(): array
     {
@@ -180,15 +214,10 @@ class CityRepository extends ServiceEntityRepository
         $builder
             ->select('c')
             ->where($builder->expr()->eq('c.enabled', ':enabled'))
-            ->andWhere(
-                $builder->expr()->orX(
-                    $builder->expr()->gte('c.activityScore', ':threshold'),
-                    $builder->expr()->isNull('c.activityScore')
-                )
-            )
             ->orderBy('c.city', 'ASC')
-            ->setParameter('enabled', true)
-            ->setParameter('threshold', self::ACTIVITY_SCORE_THRESHOLD);
+            ->setParameter('enabled', true);
+
+        self::addActiveCityCondition($builder, 'c');
 
         $query = $builder->getQuery();
 
@@ -297,6 +326,10 @@ class CityRepository extends ServiceEntityRepository
         return $query->getResult();
     }
 
+    /**
+     * Die Staedteliste im Footer, auf jeder Seite. Nach Einwohnerzahl allein
+     * standen dort New York, Brooklyn und Houston — alle drei mit Score 0.
+     */
     public function findPopularCities(int $limit = 10): array
     {
         $builder = $this->createQueryBuilder('c');
@@ -307,6 +340,8 @@ class CityRepository extends ServiceEntityRepository
             ->orderBy('c.cityPopulation', 'DESC')
             ->setParameter('enabled', true)
             ->setMaxResults($limit);
+
+        self::addActiveCityCondition($builder, 'c');
 
         $query = $builder->getQuery();
 

--- a/src/Repository/RideRepository.php
+++ b/src/Repository/RideRepository.php
@@ -233,18 +233,13 @@ class RideRepository extends ServiceEntityRepository
             ->where($builder->expr()->lte('r.dateTime', ':startDateTime'))
             ->andWhere($builder->expr()->gte('r.dateTime', ':endDateTime'))
             ->andWhere($builder->expr()->eq('city.enabled', ':enabled'))
-            ->andWhere(
-                $builder->expr()->orX(
-                    $builder->expr()->gte('city.activityScore', ':threshold'),
-                    $builder->expr()->isNull('city.activityScore')
-                )
-            )
             ->addOrderBy('r.dateTime', 'ASC')
             ->addOrderBy('r.city', 'ASC')
             ->setParameter('startDateTime', $startDateTime)
             ->setParameter('endDateTime', $endDateTime)
-            ->setParameter('enabled', true)
-            ->setParameter('threshold', CityRepository::ACTIVITY_SCORE_THRESHOLD);
+            ->setParameter('enabled', true);
+
+        CityRepository::addActiveCityCondition($builder, 'city');
 
         $query = $builder->getQuery();
 

--- a/templates/Calendar/index.html.twig
+++ b/templates/Calendar/index.html.twig
@@ -15,6 +15,21 @@
     }) -}}
 {% endmacro %}
 
+{% macro eintrag(ride, ruhend) %}
+    <li class="calendar-day__entry{{ not ride.enabled ? ' calendar-day__entry--off' }}{{ ruhend ? ' calendar-day__entry--inactive' }}">
+        <span class="calendar-day__time">
+            {{ ride.dateTime ? ride.dateTime|date('H:i', ride.city ? ride.city.timezone : null) : '—' }}
+        </span>
+
+        {% set ridePath = object_path(ride) %}
+        {% if ridePath %}
+            <a href="{{ ridePath }}">{{ ride.city ? ride.city.city : ride.title }}</a>
+        {% else %}
+            {{ ride.city ? ride.city.city : ride.title }}
+        {% endif %}
+    </li>
+{% endmacro %}
+
 {% block content %}
     {% import _self as kalender %}
 
@@ -112,22 +127,31 @@
                             {{ touren|length }} {{ touren|length == 1 ? 'Tour' : 'Touren' }}
                         </p>
 
-                        <ol class="calendar-day__list">
-                            {% for ride in touren %}
-                                <li class="calendar-day__entry{{ not ride.enabled ? ' calendar-day__entry--off' }}">
-                                    <span class="calendar-day__time">
-                                        {{ ride.dateTime ? ride.dateTime|date('H:i', ride.city ? ride.city.timezone : null) : '—' }}
-                                    </span>
+                        {# Touren eingeschlafener Staedte bleiben im Kalender — sie sind
+                           eingetragen und fahren vielleicht doch —, stehen aber
+                           abgesetzt unter denen, in denen zuletzt etwas los war. #}
+                        {% set aktiveTouren = touren|filter(ride => not (ride.city and ride.city.isInactive)) %}
+                        {% set ruhendeTouren = touren|filter(ride => ride.city and ride.city.isInactive) %}
 
-                                    {% set ridePath = object_path(ride) %}
-                                    {% if ridePath %}
-                                        <a href="{{ ridePath }}">{{ ride.city ? ride.city.city : ride.title }}</a>
-                                    {% else %}
-                                        {{ ride.city ? ride.city.city : ride.title }}
-                                    {% endif %}
-                                </li>
-                            {% endfor %}
-                        </ol>
+                        {% if aktiveTouren is not empty %}
+                            <ol class="calendar-day__list">
+                                {% for ride in aktiveTouren %}
+                                    {{ kalender.eintrag(ride, false) }}
+                                {% endfor %}
+                            </ol>
+                        {% endif %}
+
+                        {% if ruhendeTouren is not empty %}
+                            <h3 class="calendar-day__subheading">
+                                Außerdem eingetragen, in Städten ohne Lebenszeichen seit sechs Monaten
+                            </h3>
+
+                            <ol class="calendar-day__list calendar-day__list--inactive">
+                                {% for ride in ruhendeTouren %}
+                                    {{ kalender.eintrag(ride, true) }}
+                                {% endfor %}
+                            </ol>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/templates/City/show.html.twig
+++ b/templates/City/show.html.twig
@@ -145,6 +145,15 @@
             </div>
         {% endif %}
 
+        {% if city.isInactive %}
+            <div class="alert alert-warning border-0 d-flex align-items-center mb-4" role="alert" id="inactive-city-hint">
+                <i class="far fa-exclamation-triangle fa-lg me-3"></i>
+                <div>
+                    Aus {{ city.city }} ist seit einem halben Jahr keine Teilnahme, kein Foto, kein Track und kein Beitrag in sozialen Netzwerken mehr bei uns angekommen. Vielleicht fährt hier derzeit keine Critical Mass. Wenn du es besser weißt, freuen wir uns über aktuelle Fotos, Tracks oder eingetragene Termine.
+                </div>
+            </div>
+        {% endif %}
+
         <div class="row">
             {# Hauptinhalt #}
             <div class="col-lg-8">

--- a/templates/CityList/list.html.twig
+++ b/templates/CityList/list.html.twig
@@ -7,7 +7,58 @@
     {{ breadcrumb.active('Städteliste') }}
 {% endblock %}
 
+{% macro cityTable(cityList, id) %}
+    <div class="table-responsive">
+        <table id="{{ id }}" class="table table-hover tablesorter mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th>Stadt</th>
+                    <th>aktuelle Tour</th>
+                    <th>Turnus</th>
+                    <th>Touren</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for city in cityList %}
+                    <tr data-city-slug="{{ city.city.getMainSlugString() }}">
+                        <td>
+                            <a href="{{ object_path(city.city) }}">
+                                {{ city.city.city }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if city.currentRide %}
+                                <a href="{{ object_path(city.currentRide) }}">
+                                    {{ city.currentRide.dateTime|format_datetime(dateFormat='long', timeFormat='short', locale='de', timezone=city.city.timezone) }}
+                                    &nbsp;Uhr
+                                </a>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <ul class="list-unstyled mb-0">
+                                {% for cycle in city.cycles %}
+                                    <li>
+                                        am {{ ('cycle.event_date.month_week.' ~ cycle.weekOfMonth)|trans }} {{ ('cycle.event_date.day.' ~ cycle.dayOfWeek)|trans }}
+                                        um {{ cycle.time|date('H:i', 'UTC') }} Uhr
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        <td>
+                            <a href="{{ object_path(city.city, 'caldera_criticalmass_city_listrides') }}">
+                                {{ city.countRides }}
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endmacro %}
+
 {% block content %}
+    {% import _self as liste %}
+
     <div class="container">
         <h1 class="mb-2">
             Die nächste Masse ist ganz nah
@@ -18,7 +69,7 @@
         </p>
 
         <p class="mb-4">
-            Auf den Sattel, fertig, los: Die folgende Liste enthält mittlerweile {{ cityList|length }} Städte.
+            Auf den Sattel, fertig, los: Die folgende Liste enthält {{ cityList|length }} Städte, in denen zuletzt etwas los war.
             Bitte bedenke, dass die folgenden Informationen aus verschiedenen Quellen im Internet stammen und
             womöglich veraltet oder schlichtweg falsch sein können. Überprüfe bitte vorher weitere Quellen,
             bevor du dich auf den Weg machst.
@@ -26,53 +77,29 @@
 
         <div class="card border-0 shadow-sm">
             <div class="card-body p-0">
-                <div class="table-responsive">
-                    <table id="city-list-table" class="table table-hover tablesorter mb-0">
-                        <thead class="table-light">
-                            <tr>
-                                <th>Stadt</th>
-                                <th>aktuelle Tour</th>
-                                <th>Turnus</th>
-                                <th>Touren</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for city in cityList %}
-                                <tr data-city-slug="{{ city.city.getMainSlugString() }}">
-                                    <td>
-                                        <a href="{{ object_path(city.city) }}">
-                                            {{ city.city.city }}
-                                        </a>
-                                    </td>
-                                    <td>
-                                        {% if city.currentRide %}
-                                            <a href="{{ object_path(city.currentRide) }}">
-                                                {{ city.currentRide.dateTime|format_datetime(dateFormat='long', timeFormat='short', locale='de', timezone=city.city.timezone) }}
-                                                &nbsp;Uhr
-                                            </a>
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        <ul class="list-unstyled mb-0">
-                                            {% for cycle in city.cycles %}
-                                                <li>
-                                                    am {{ ('cycle.event_date.month_week.' ~ cycle.weekOfMonth)|trans }} {{ ('cycle.event_date.day.' ~ cycle.dayOfWeek)|trans }}
-                                                    um {{ cycle.time|date('H:i', 'UTC') }} Uhr
-                                                </li>
-                                            {% endfor %}
-                                        </ul>
-                                    </td>
-                                    <td>
-                                        <a href="{{ object_path(city.city, 'caldera_criticalmass_city_listrides') }}">
-                                            {{ city.countRides }}
-                                        </a>
-                                    </td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                {{ liste.cityTable(cityList, 'city-list-table') }}
             </div>
         </div>
+
+        {% if inactiveCityList is not empty %}
+            <details class="mt-5" id="inactive-city-list">
+                <summary class="h5 mb-3">
+                    {{ inactiveCityList|length }} weitere Städte ohne Lebenszeichen in den letzten sechs Monaten
+                </summary>
+
+                <p class="text-muted">
+                    Aus diesen Städten sind seit einem halben Jahr keine Teilnahmen, Fotos, Tracks oder Beiträge
+                    in sozialen Netzwerken mehr bei uns angekommen. Womöglich fährt dort keine Critical Mass mehr —
+                    oder es hat nur noch niemand davon erzählt. Wenn du es besser weißt, freuen wir uns über
+                    aktuelle Fotos, Tracks oder eingetragene Termine.
+                </p>
+
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body p-0">
+                        {{ liste.cityTable(inactiveCityList, 'inactive-city-list-table') }}
+                    </div>
+                </div>
+            </details>
+        {% endif %}
     </div>
 {% endblock %}

--- a/templates/Ride/Includes/_inactiveCityHint.html.twig
+++ b/templates/Ride/Includes/_inactiveCityHint.html.twig
@@ -1,0 +1,9 @@
+{# Warnt bei kommenden Touren einer Stadt, aus der seit Monaten nichts mehr ankommt. #}
+{% if ride.dateTime and ride.dateTime > date() and city.isInactive %}
+    <div class="alert alert-warning border-0 d-flex align-items-center mb-4" role="alert" id="inactive-city-hint">
+        <i class="far fa-exclamation-triangle fa-lg me-3"></i>
+        <div>
+            Diese Tour ist eingetragen, aber aus {{ city.city }} ist seit einem halben Jahr nichts mehr bei uns angekommen. Ob sie tatsächlich stattfindet, ist ungewiss – frag im Zweifel lokal nach, bevor du dich auf den Weg machst.
+        </div>
+    </div>
+{% endif %}

--- a/templates/Ride/show.html.twig
+++ b/templates/Ride/show.html.twig
@@ -16,6 +16,8 @@
 
         {% include('Ride/Includes/_registrationHint.html.twig') %}
 
+        {% include('Ride/Includes/_inactiveCityHint.html.twig') %}
+
         {% include('Ride/Ride.html.twig') with { 'ride': ride, 'tracks': tracks, 'participation': participation, 'location': location, 'weatherForecast': weatherForecast, 'estimateForm': estimateForm } %}
 
         {% include('Ride/Includes/_pagination.html.twig') with { 'ride': ride } %}

--- a/tests/Controller/CalendarControllerTest.php
+++ b/tests/Controller/CalendarControllerTest.php
@@ -259,4 +259,50 @@ class CalendarControllerTest extends AbstractControllerTestCase
         self::assertStringContainsString('5 Touren', $text);
         self::assertStringContainsString('2 Tagen', $text);
     }
+
+    /**
+     * Touren eingeschlafener Staedte bleiben im Kalender, stehen aber
+     * abgesetzt unter einer eigenen Zwischenzeile.
+     */
+    public function testRidesOfInactiveCitiesAreSetApart(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $this->tourenAnlegen($entityManager, 20, 2);
+
+        $stadt = $this->probestadt($entityManager);
+        $stadt->setActivityScore(0.0);
+        $stadt->setCreatedAt(new \DateTime('-2 years'));
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', $this->adresse(20));
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(2, $crawler->filter('.calendar-day__entry')->count(), 'Keine Tour verschwindet.');
+        self::assertSame(2, $crawler->filter('.calendar-day__list--inactive .calendar-day__entry--inactive')->count());
+        self::assertSame(1, $crawler->filter('.calendar-day__subheading')->count());
+    }
+
+    /**
+     * Eine neue Stadt ohne Signale gilt nicht als eingeschlafen.
+     */
+    public function testRidesOfNewCitiesWithoutSignalsStayUpFront(): void
+    {
+        $client = static::createClient();
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+
+        $this->tourenAnlegen($entityManager, 21, 2);
+
+        $stadt = $this->probestadt($entityManager);
+        $stadt->setActivityScore(0.0);
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', $this->adresse(21));
+
+        self::assertResponseIsSuccessful();
+        self::assertSame(2, $crawler->filter('.calendar-day__entry')->count());
+        self::assertSame(0, $crawler->filter('.calendar-day__entry--inactive')->count());
+        self::assertSame(0, $crawler->filter('.calendar-day__subheading')->count());
+    }
 }

--- a/tests/Controller/CityControllerTest.php
+++ b/tests/Controller/CityControllerTest.php
@@ -82,6 +82,43 @@ class CityControllerTest extends AbstractControllerTestCase
         $this->assertSelectorTextContains('html', 'Berlin');
     }
 
+    public function testCityListMovesInactiveCitiesIntoTheirOwnSection(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/citylist');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+
+        $active = $crawler->filter('#city-list-table')->text();
+        $inactive = $crawler->filter('#inactive-city-list')->text();
+
+        $this->assertStringNotContainsString('Ghosttown', $active);
+        $this->assertStringContainsString('Ghosttown', $inactive);
+        $this->assertStringContainsString('Hamburg', $active);
+        $this->assertStringNotContainsString('Hamburg', $inactive);
+    }
+
+    public function testInactiveCityPageShowsAHint(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/ghosttown');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertCount(1, $crawler->filter('#inactive-city-hint'));
+    }
+
+    public function testActiveCityPageShowsNoHint(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hamburg');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertCount(0, $crawler->filter('#inactive-city-hint'));
+    }
+
     public function testCityPageContainsNavigationTabs(): void
     {
         $client = static::createClient();

--- a/tests/Controller/InactiveCityRideHintTest.php
+++ b/tests/Controller/InactiveCityRideHintTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Controller;
+
+use App\Entity\City;
+use App\Entity\Ride;
+
+/**
+ * Eine kommende Tour in einer eingeschlafenen Stadt warnt, dass sie
+ * vielleicht nicht stattfindet.
+ */
+class InactiveCityRideHintTest extends AbstractControllerTestCase
+{
+    private const TITEL = 'Hinweisprobe';
+
+    protected function tearDown(): void
+    {
+        if (static::$booted) {
+            static::getContainer()->get('doctrine')->getManager()
+                ->createQuery('DELETE FROM App\\Entity\\Ride r WHERE r.title = :titel')
+                ->setParameter('titel', self::TITEL)
+                ->execute();
+        }
+
+        parent::tearDown();
+    }
+
+    private function rideIn(string $cityName, string $when): string
+    {
+        $entityManager = static::getContainer()->get('doctrine')->getManager();
+        $city = $entityManager->getRepository(City::class)->findOneBy(['city' => $cityName]);
+
+        $ride = new Ride();
+        $ride->setCity($city);
+        $ride->setTitle(self::TITEL);
+        $ride->setDateTime(new \DateTime($when));
+        $ride->setCreatedAt(new \DateTime());
+        $ride->setUpdatedAt(new \DateTime());
+        $ride->setEnabled(true);
+
+        $entityManager->persist($ride);
+        $entityManager->flush();
+
+        return sprintf('/%s/%s', $city->getMainSlugString(), $ride->getDateTime()->format('Y-m-d'));
+    }
+
+    public function testUpcomingRideInInactiveCityWarns(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->rideIn('Ghosttown', '+3 years 19:00'));
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(1, $crawler->filter('#inactive-city-hint'));
+    }
+
+    public function testPastRideInInactiveCityDoesNotWarn(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->rideIn('Ghosttown', '-3 years 19:00'));
+
+        self::assertResponseIsSuccessful();
+        self::assertCount(0, $crawler->filter('#inactive-city-hint'));
+    }
+}

--- a/tests/Entity/CityInactiveTest.php
+++ b/tests/Entity/CityInactiveTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Entity;
+
+use App\Entity\City;
+use App\Repository\CityRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wann eine Stadt als eingeschlafen gilt und nicht mehr beworben wird.
+ *
+ * Der Score allein reicht nicht: Eine neu angelegte Stadt hat zwangslaeufig
+ * keine Signale und stuende sonst ab dem ersten Tag auf der Liste der Toten.
+ */
+class CityInactiveTest extends TestCase
+{
+    private const NOW = '2026-09-11 12:00:00';
+
+    private function city(?float $score, ?string $createdAt): City
+    {
+        $city = (new City())->setActivityScore($score);
+
+        if (null !== $createdAt) {
+            $city->setCreatedAt(new \DateTime($createdAt));
+        } else {
+            (new \ReflectionProperty(City::class, 'createdAt'))->setValue($city, null);
+        }
+
+        return $city;
+    }
+
+    /** @return iterable<string, array{?float, ?string, bool}> */
+    public static function cases(): iterable
+    {
+        yield 'kein Score: noch nie gemessen, bleibt sichtbar' => [null, '2020-01-01', false];
+        yield 'Score am Schwellwert' => [CityRepository::ACTIVITY_SCORE_THRESHOLD, '2020-01-01', false];
+        yield 'Score deutlich darueber' => [0.64, '2020-01-01', false];
+        yield 'Score 0, alte Stadt' => [0.0, '2020-01-01', true];
+        yield 'Score knapp unter dem Schwellwert, alte Stadt' => [0.005, '2020-01-01', true];
+        yield 'Score 0, vor zwei Tagen angelegt' => [0.0, '2026-09-09 10:00:00', false];
+        yield 'Score 0, vor fuenf Monaten angelegt' => [0.0, '2026-04-11 12:00:00', false];
+        yield 'Score 0, genau sechs Monate alt' => [0.0, '2026-03-11 12:00:00', true];
+        yield 'Score 0, ohne Anlagedatum' => [0.0, null, true];
+    }
+
+    #[DataProvider('cases')]
+    public function testIsInactive(?float $score, ?string $createdAt, bool $expected): void
+    {
+        $city = $this->city($score, $createdAt);
+
+        self::assertSame($expected, $city->isInactive(new \DateTimeImmutable(self::NOW)));
+    }
+
+    public function testDefaultsToTheCurrentTime(): void
+    {
+        self::assertFalse($this->city(0.0, 'now')->isInactive(), 'Eine eben angelegte Stadt ist nicht inaktiv.');
+        self::assertTrue($this->city(0.0, '-7 months')->isInactive());
+    }
+}

--- a/tests/Repository/CityRepositoryTest.php
+++ b/tests/Repository/CityRepositoryTest.php
@@ -59,6 +59,42 @@ class CityRepositoryTest extends KernelTestCase
         $this->assertContains('Berlin', $cityNames);
     }
 
+    /**
+     * Eine neu angelegte Stadt hat noch keine Signale und damit Score 0 —
+     * sie darf deshalb nicht sofort verschwinden.
+     */
+    public function testFindActiveCitiesKeepsNewCitiesWithoutSignals(): void
+    {
+        $city = new City();
+        $city->setCity('Neugruendung');
+        $city->setTitle('Critical Mass Neugruendung');
+        $city->setEnabled(true);
+        $city->setTimezone('Europe/Berlin');
+        $city->setActivityScore(0.0);
+
+        $this->entityManager->persist($city);
+        $this->entityManager->flush();
+
+        try {
+            $cityNames = array_map(fn(City $city) => $city->getCity(), $this->repository->findActiveCities());
+
+            $this->assertContains('Neugruendung', $cityNames, 'A city younger than the grace period counts as active');
+            $this->assertNotContains('Ghosttown', $cityNames);
+        } finally {
+            $this->entityManager->remove($city);
+            $this->entityManager->flush();
+        }
+    }
+
+    public function testFindPopularCitiesSkipsInactiveCities(): void
+    {
+        $cityNames = array_map(fn(City $city) => $city->getCity(), $this->repository->findPopularCities());
+
+        $this->assertNotContains('Ghosttown', $cityNames, 'The footer must not promote inactive cities');
+        $this->assertContains('Hamburg', $cityNames);
+        $this->assertContains('Kiel', $cityNames, 'An unscored city stays in the footer');
+    }
+
     public function testActivityScoreThreshold(): void
     {
         $this->assertEquals(0.01, CityRepository::ACTIVITY_SCORE_THRESHOLD);


### PR DESCRIPTION
## Summary

Jetzt, wo der Aktivitätslauf jede Nacht alle Städte vollständig liefert (seit 07.09.), werden eingeschlafene Städte nicht mehr prominent beworben.

- **Eine Regel für „inaktiv“:** `City::isInactive()` und `CityRepository::addActiveCityCondition()` verwenden dieselbe Definition: Score unter 0,01 **und** älter als sechs Monate.
- **Karenzzeit für neue Städte:** Der Score zählt nur Signale der letzten sechs Monate. Eine neu angelegte Stadt steht deshalb immer bei 0. Die zehn indonesischen Städte vom 09.09. waren dadurch zwei Tage nach dem Anlegen schon von der Startseite verschwunden.
- **Footer (jede Seite):** `findPopularCities()` sortierte nur nach Einwohnerzahl, dort standen New York, Brooklyn und Houston, alle mit Score 0. Der Footer filtert jetzt mit derselben Regel.
- **`/citylist`:** Die aktiven Städte stehen oben, die inaktiven in einem eingeklappten Abschnitt darunter. Sie bleiben also erreichbar.
- **`/calendar`:** Keine Tour verschwindet. Touren inaktiver Städte stehen ausgegraut unter einer eigenen Zwischenzeile.
- **Stadt- und Tourseite:** Warnhinweis bei inaktiven Städten (bei Touren nur, wenn sie noch bevorstehen). Übernommen vom nie gemergten Branch `feature/city-activity-bonus-signals-and-hints`.
- Die Tourenliste auf der Startseite nutzt die gemeinsame Bedingung und bekommt damit die Karenzzeit.

**Wirkung auf die Produktion (Stand 11.09., lesend nachgerechnet):** Von 732 Städten gelten 564 als inaktiv, 168 bleiben vorn. Die Karenzzeit rettet genau die zehn indonesischen Städte.

## Deploy

Die SCSS für den Kalender hat sich geändert, deshalb muss gebaut werden (`npm ci` + Build, nicht `deploy.sh npm`). Es gibt keine Migration.

## Test Plan

- [x] Neuer Unit-Test `CityInactiveTest` (Schwellwert, Karenzzeit, Grenzfall genau sechs Monate, fehlendes Anlagedatum)
- [x] Repository-Tests: neue Stadt ohne Signale bleibt aktiv, Footer lässt Ghosttown weg
- [x] Controller-Tests: Städteliste, Kalender (inaktiv abgesetzt, neue Stadt vorn), Hinweis auf Stadt- und Tourseite
- [x] Komplette Suite lokal gegen PostgreSQL 17/PostGIS auf frischer DB: 1662 Tests grün, 14 übersprungen
- [x] PHPStan auf den geänderten Dateien ohne Fehler, `lint:twig` sauber
- [ ] Nach dem Deploy: Footer, `/citylist`, `/calendar` am letzten Freitag und `/ghosttown`-artige Stadtseite im Browser ansehen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr6RUqahuPZFVC8kS1Tdxv
