### PR TITLE
Footer: Städte ohne Einwohnerzahl nicht mehr vorn

### DIFF
--- a/src/Repository/CityRepository.php
+++ b/src/Repository/CityRepository.php
@@ -327,8 +327,11 @@ class CityRepository extends ServiceEntityRepository
     }
 
     /**
-     * Die Staedteliste im Footer, auf jeder Seite. Nach Einwohnerzahl allein
-     * standen dort New York, Brooklyn und Houston — alle drei mit Score 0.
+     * Die Staedteliste im Footer, auf jeder Seite.
+     *
+     * Ohne Einwohnerzahl gehoert eine Stadt nicht hierher: PostgreSQL sortiert
+     * NULL bei DESC nach vorn (MySQL nach hinten). Seit dem Umzug standen im
+     * Footer deshalb Nice, Goiânia, Bratislava — 455 Staedte haben keine Zahl.
      */
     public function findPopularCities(int $limit = 10): array
     {
@@ -337,6 +340,7 @@ class CityRepository extends ServiceEntityRepository
         $builder
             ->select('c')
             ->where($builder->expr()->eq('c.enabled', ':enabled'))
+            ->andWhere($builder->expr()->gt('c.cityPopulation', 0))
             ->orderBy('c.cityPopulation', 'DESC')
             ->setParameter('enabled', true)
             ->setMaxResults($limit);

--- a/tests/Repository/CityRepositoryTest.php
+++ b/tests/Repository/CityRepositoryTest.php
@@ -95,6 +95,33 @@ class CityRepositoryTest extends KernelTestCase
         $this->assertContains('Kiel', $cityNames, 'An unscored city stays in the footer');
     }
 
+    /**
+     * PostgreSQL sortiert NULL bei DESC nach vorn — eine Stadt ohne
+     * Einwohnerzahl wuerde sonst die Liste anfuehren.
+     */
+    public function testFindPopularCitiesSkipsCitiesWithoutPopulation(): void
+    {
+        $city = new City();
+        $city->setCity('Ohnezahl');
+        $city->setTitle('Critical Mass Ohnezahl');
+        $city->setEnabled(true);
+        $city->setTimezone('Europe/Berlin');
+
+        $this->entityManager->persist($city);
+        $this->entityManager->flush();
+
+        try {
+            $popular = $this->repository->findPopularCities();
+            $cityNames = array_map(fn(City $city) => $city->getCity(), $popular);
+
+            $this->assertNotContains('Ohnezahl', $cityNames);
+            $this->assertSame('Berlin', $cityNames[0] ?? null, 'The largest fixture city leads the list');
+        } finally {
+            $this->entityManager->remove($city);
+            $this->entityManager->flush();
+        }
+    }
+
     public function testActivityScoreThreshold(): void
     {
         $this->assertEquals(0.01, CityRepository::ACTIVITY_SCORE_THRESHOLD);


### PR DESCRIPTION
## Summary

- PostgreSQL sortiert `NULL` bei `DESC` nach vorn, MySQL nach hinten. Seit dem Umzug auf PostgreSQL führten deshalb Städte **ohne** Einwohnerzahl die Städteliste im Footer an (Nice, Goiânia, Bratislava …). 455 Städte haben keine Einwohnerzahl.
- `findPopularCities()` berücksichtigt jetzt nur Städte mit bekannter Einwohnerzahl (> 0).
- Aufgefallen nach dem Deploy von #1542: Der Footer zeigte trotz Filter nicht London, Berlin, Chicago …

## Test Plan

- [x] Neuer Repository-Test: Stadt ohne Einwohnerzahl fehlt, Berlin führt die Liste an
- [x] `tests/Repository`, Navigation- und Frontpage-Tests lokal gegen PostgreSQL 17/PostGIS grün (59 Tests)
- [x] PHPStan ohne Fehler
- [ ] Nach dem Deploy: Footer auf criticalmass.in ansehen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr6RUqahuPZFVC8kS1Tdxv