### PR TITLE
Nominatim nicht mehr ungebremst aus fremden Pfaden befragen

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -23,6 +23,14 @@ framework:
             doctrine.result_cache_pool:
                 adapter: cache.adapter.filesystem
 
+            # Antworten von Nominatim, auch die leeren. Jeder unbekannte Pfad
+            # auf criticalmass.in fragt dort nach einer Stadt; ohne Gedaechtnis
+            # fragt derselbe Unsinn jedes Mal neu nach. Eine Woche ist
+            # reichlich: Staedte ziehen nicht um.
+            cache.nominatim:
+                adapter: cache.adapter.filesystem
+                default_lifetime: 604800
+
     translator: { fallbacks: [de] }
     form: ~
     csrf_protection:

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -34,3 +34,21 @@ framework:
             policy: token_bucket
             limit: 1000
             rate: { interval: '1 minute', amount: 200 }
+
+        # Ausgehende Anfragen an Nominatim -- nicht zum Schutz vor unseren
+        # Besuchern, sondern zum Schutz von OpenStreetMap vor uns.
+        #
+        # Die Route /{citySlug} faengt jeden unbekannten Pfad ab und fragt
+        # Nominatim, ob es dazu eine Stadt gibt. Ein Crawler, der /work-here,
+        # /positions und /work-for-us abklappert, laesst criticalmass.in also
+        # ungebremst gegen einen fremden Dienst laufen -- am 12.09.2026 kam von
+        # dort dreimal ein 429 zurueck.
+        #
+        # Nominatims Nutzungsbedingungen nennen hoechstens eine Anfrage je
+        # Sekunde. Genau das steht hier: ein Eimer fuer 60 Anfragen, der sich
+        # mit einer je Sekunde fuellt. Ist er leer, unterbleibt die Anfrage und
+        # die Seite kommt ohne Stadtvorschlag -- was sie ohnehin kann.
+        nominatim:
+            policy: token_bucket
+            limit: 60
+            rate: { interval: '1 second', amount: 1 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1213,18 +1213,6 @@ parameters:
 			path: src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
 
 		-
-			message: '#^Method App\\Criticalmass\\OpenStreetMap\\NominatimCityBridge\\NominatimCityBridge\:\:createCity\(\) has parameter \$result with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
-
-		-
-			message: '#^Method App\\Criticalmass\\OpenStreetMap\\NominatimCityBridge\\NominatimCityBridge\:\:getCityNameFromResult\(\) has parameter \$result with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
-
-		-
 			message: '#^Method App\\Criticalmass\\Participation\\Calculator\\RideParticipationCalculator\:\:getParticipationRepository\(\) should return App\\Repository\\ParticipationRepository but returns Doctrine\\Persistence\\ObjectRepository\<App\\Entity\\Participation\>\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Criticalmass/OpenStreetMap/NominatimCityBridge/AbstractNominatimCityBridge.php
+++ b/src/Criticalmass/OpenStreetMap/NominatimCityBridge/AbstractNominatimCityBridge.php
@@ -4,6 +4,10 @@ namespace App\Criticalmass\OpenStreetMap\NominatimCityBridge;
 
 use App\Factory\City\CityFactoryInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 abstract class AbstractNominatimCityBridge implements NominatimCityBridgeInterface
@@ -14,6 +18,11 @@ abstract class AbstractNominatimCityBridge implements NominatimCityBridgeInterfa
         protected readonly ManagerRegistry $doctrine,
         protected readonly CityFactoryInterface $cityFactory,
         protected readonly HttpClientInterface $httpClient,
+        #[Autowire(service: 'cache.nominatim')]
+        protected readonly CacheInterface $cache,
+        #[Autowire(service: 'limiter.nominatim')]
+        protected readonly RateLimiterFactoryInterface $nominatimLimiter,
+        protected readonly LoggerInterface $logger,
     ) {
     }
 }

--- a/src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
+++ b/src/Criticalmass/OpenStreetMap/NominatimCityBridge/NominatimCityBridge.php
@@ -4,35 +4,109 @@ namespace App\Criticalmass\OpenStreetMap\NominatimCityBridge;
 
 use App\Entity\City;
 use App\Entity\Region;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientException;
 
 class NominatimCityBridge extends AbstractNominatimCityBridge
 {
+    /**
+     * Schlaegt eine Stadt bei Nominatim nach -- hoechstens.
+     *
+     * Die Route /{citySlug} faengt **jeden** unbekannten Pfad ab. Wer
+     * criticalmass.in/work-here aufruft, loest damit eine Anfrage an
+     * OpenStreetMap aus, und ein Crawler, der Karriereseiten sucht, loest
+     * hunderte aus. Am 12.09.2026 kam von dort dreimal ein 429 zurueck --
+     * und weil die Ausnahme niemand auffing, wurde aus der Abfuhr eines
+     * fremden Dienstes ein Serverfehler auf unserer Seite.
+     *
+     * Drei Dinge halten das jetzt in Schranken, und jedes fuer sich reicht,
+     * damit die Seite steht:
+     *
+     *   Der Ratenbegrenzer deckelt, was **wir** nach draussen schicken, auf
+     *   Nominatims Hoechstmass von einer Anfrage je Sekunde. Ist der Eimer
+     *   leer, unterbleibt die Anfrage.
+     *
+     *   Der Zwischenspeicher merkt sich auch die leeren Antworten. Derselbe
+     *   unsinnige Pfad fragt sonst jedes Mal neu nach.
+     *
+     *   Und scheitert es doch -- 429, Zeitueberschreitung, Wartung --, gibt
+     *   es null statt einer Ausnahme. Die Vorlage kennt diesen Fall laengst
+     *   und schreibt dann "wir konnten keine Stadt zu deiner Suche finden",
+     *   was die ehrlichere Auskunft ist als ein 500er.
+     */
     public function lookupCity(string $citySlug): ?City
     {
-        $response = $this->httpClient->request('GET', self::NOMINATIM_URL . 'search', [
-            'query' => [
-                'city' => $citySlug,
-                'format' => 'json',
-                'addressdetails' => 1,
-            ],
-            'headers' => [
-                'User-Agent' => 'criticalmass.in/1.0',
-            ],
-        ]);
+        $rohdaten = $this->rohdatenHolen($citySlug);
 
-        $result = $response->toArray();
-        $firstResult = array_shift($result);
-
-        if ($firstResult) {
-            $city = $this->createCity($firstResult);
-
-            return $city;
-        }
-
-        return null;
+        return null === $rohdaten ? null : $this->createCity($rohdaten);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function rohdatenHolen(string $citySlug): ?array
+    {
+        // Der Schluessel muss die Anfrage eindeutig beschreiben und darf die
+        // Zeichen nicht enthalten, die PSR-6 verbietet.
+        $schluessel = 'nominatim_city_' . hash('xxh128', $citySlug);
+
+        $gemerkt = $this->cache->get($schluessel, function () use ($citySlug): array|false {
+            $antwort = $this->beiNominatimFragen($citySlug);
+
+            // false statt null: Der Zwischenspeicher unterscheidet "nichts
+            // gefunden" sonst nicht von "noch nicht gefragt" und liefe fuer
+            // jeden unbekannten Pfad ins Leere.
+            return $antwort ?? false;
+        });
+
+        return false === $gemerkt ? null : $gemerkt;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function beiNominatimFragen(string $citySlug): ?array
+    {
+        if (!$this->nominatimLimiter->create()->consume()->isAccepted()) {
+            $this->logger->warning('Nominatim nicht gefragt: eigenes Kontingent erschoepft.', [
+                'stadt' => $citySlug,
+            ]);
+
+            return null;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', self::NOMINATIM_URL . 'search', [
+                'query' => [
+                    'city' => $citySlug,
+                    'format' => 'json',
+                    'addressdetails' => 1,
+                ],
+                'headers' => [
+                    // Nominatim verlangt eine Kennung, unter der man erreichbar
+                    // ist. "criticalmass.in/1.0" allein erfuellt das nicht.
+                    'User-Agent' => 'criticalmass.in (https://criticalmass.in/)',
+                ],
+                'timeout' => 5,
+            ]);
+
+            $result = $response->toArray();
+        } catch (HttpClientException $ausnahme) {
+            $this->logger->warning('Nominatim hat nicht geantwortet.', [
+                'stadt' => $citySlug,
+                'grund' => $ausnahme->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $erster = array_shift($result);
+
+        return is_array($erster) ? $erster : null;
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
     protected function createCity(array $result): ?City
     {
         $state = $result['address']['state'] ?? null;
@@ -55,6 +129,9 @@ class NominatimCityBridge extends AbstractNominatimCityBridge
         return $this->cityFactory->build();
     }
 
+    /**
+     * @param array<string, mixed> $result
+     */
     protected function getCityNameFromResult(array $result): ?string
     {
         $propertyOrder = ['city', 'town', 'village', 'suburb'];

--- a/tests/Criticalmass/OpenStreetMap/NominatimCityBridgeTest.php
+++ b/tests/Criticalmass/OpenStreetMap/NominatimCityBridgeTest.php
@@ -1,0 +1,226 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Criticalmass\OpenStreetMap;
+
+use App\Criticalmass\OpenStreetMap\NominatimCityBridge\NominatimCityBridge;
+use App\Entity\City;
+use App\Entity\Region;
+use App\Factory\City\CityFactoryInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+
+/**
+ * Was criticalmass.in nach draussen schickt, wenn jemand einen unbekannten
+ * Pfad aufruft.
+ *
+ * Die Route /{citySlug} faengt **jeden** unbekannten Pfad ab und fragt
+ * Nominatim, ob es dazu eine Stadt gibt. Am 12.09.2026 klapperte ein Crawler
+ * Karriereseiten ab -- /work-here, /work-for-us, /positions -- und
+ * criticalmass.in reichte jede dieser Erfindungen an OpenStreetMap weiter.
+ * Von dort kam ein 429, und weil die Ausnahme niemand auffing, wurde aus der
+ * Abfuhr eines fremden Dienstes ein Serverfehler auf unserer Seite.
+ *
+ * Die Tests bewachen beide Seiten davon: dass eine Abfuhr die Seite nicht
+ * mehr umwirft, und dass wir gar nicht erst so viel fragen.
+ */
+class NominatimCityBridgeTest extends TestCase
+{
+    private function bruecke(MockHttpClient $client, int $kontingent = 60): NominatimCityBridge
+    {
+        $region = new Region();
+        $region->setName('Hamburg');
+
+        // findOneByName() ist eine magische Methode von Doctrines
+        // EntityRepository -- PHPUnit kann sie nicht einrichten, weil es sie
+        // gar nicht gibt. Also von Hand, und dabei gleich die ganze
+        // Schnittstelle, weil getRepository() sie als Rueckgabetyp fordert.
+        $repository = new class($region) implements ObjectRepository {
+            public function __construct(private readonly Region $region)
+            {
+            }
+
+            public function findOneByName(string $name): ?Region
+            {
+                return 'Hamburg' === $name ? $this->region : null;
+            }
+
+            public function find($id): ?object
+            {
+                return null;
+            }
+
+            public function findAll(): array
+            {
+                return [];
+            }
+
+            public function findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null): array
+            {
+                return [];
+            }
+
+            public function findOneBy(array $criteria): ?object
+            {
+                return null;
+            }
+
+            public function getClassName(): string
+            {
+                return Region::class;
+            }
+        };
+
+        $doctrine = $this->createMock(ManagerRegistry::class);
+        $doctrine->method('getRepository')->willReturn($repository);
+
+        $stadt = new City();
+        $stadt->setCity('Hamburg');
+
+        $factory = $this->createMock(CityFactoryInterface::class);
+        foreach (['withLatitude', 'withLongitude', 'withName', 'withTitle', 'withRegion'] as $methode) {
+            $factory->method($methode)->willReturnSelf();
+        }
+        $factory->method('build')->willReturn($stadt);
+
+        return new NominatimCityBridge(
+            $doctrine,
+            $factory,
+            $client,
+            new ArrayAdapter(),
+            new RateLimiterFactory(
+                ['id' => 'nominatim', 'policy' => 'token_bucket', 'limit' => $kontingent, 'rate' => ['interval' => '1 second', 'amount' => 1]],
+                new InMemoryStorage()
+            ),
+            new NullLogger(),
+        );
+    }
+
+    private function treffer(): MockResponse
+    {
+        return new MockResponse(json_encode([[
+            'lat' => '53.5503',
+            'lon' => '9.9920',
+            'address' => ['city' => 'Hamburg', 'state' => 'Hamburg'],
+        ]]), ['http_code' => 200]);
+    }
+
+    private function leer(): MockResponse
+    {
+        return new MockResponse('[]', ['http_code' => 200]);
+    }
+
+    public function testAKnownCityIsStillLookedUp(): void
+    {
+        $bruecke = $this->bruecke(new MockHttpClient([$this->treffer()]));
+
+        self::assertInstanceOf(City::class, $bruecke->lookupCity('hamburg'));
+    }
+
+    /**
+     * Der Fall aus dem Protokoll: Nominatim weist uns ab.
+     */
+    public function testARefusalFromNominatimDoesNotBreakThePage(): void
+    {
+        $bruecke = $this->bruecke(new MockHttpClient([new MockResponse('', ['http_code' => 429])]));
+
+        self::assertNull($bruecke->lookupCity('work-here'));
+    }
+
+    public function testAServerErrorAtNominatimDoesNotBreakThePage(): void
+    {
+        $bruecke = $this->bruecke(new MockHttpClient([new MockResponse('', ['http_code' => 503])]));
+
+        self::assertNull($bruecke->lookupCity('positions'));
+    }
+
+    public function testATransportFailureDoesNotBreakThePage(): void
+    {
+        $bruecke = $this->bruecke(new MockHttpClient([
+            new MockResponse(['', ''], ['error' => 'Connection timed out']),
+        ]));
+
+        self::assertNull($bruecke->lookupCity('work-for-us'));
+    }
+
+    /**
+     * Zweimal derselbe Pfad, einmal gefragt.
+     */
+    public function testTheSameCityIsOnlyAskedOnce(): void
+    {
+        $client = new MockHttpClient([$this->treffer(), $this->treffer()]);
+        $bruecke = $this->bruecke($client);
+
+        $bruecke->lookupCity('hamburg');
+        $bruecke->lookupCity('hamburg');
+
+        self::assertSame(1, $client->getRequestsCount());
+    }
+
+    /**
+     * Und das gilt gerade fuer die leeren Antworten -- die kommen von den
+     * unsinnigen Pfaden, und genau die wiederholen sich.
+     */
+    public function testAnEmptyAnswerIsRememberedToo(): void
+    {
+        $client = new MockHttpClient([$this->leer(), $this->leer()]);
+        $bruecke = $this->bruecke($client);
+
+        self::assertNull($bruecke->lookupCity('work-here'));
+        self::assertNull($bruecke->lookupCity('work-here'));
+
+        self::assertSame(1, $client->getRequestsCount());
+    }
+
+    /**
+     * Der Kern: Ist unser eigenes Kontingent erschoepft, geht gar nichts mehr
+     * hinaus. Nicht, um uns zu schuetzen -- um OpenStreetMap vor uns zu
+     * schuetzen.
+     */
+    public function testAnExhaustedBudgetStopsUsFromAskingAtAll(): void
+    {
+        $client = new MockHttpClient([$this->treffer(), $this->treffer(), $this->treffer()]);
+        $bruecke = $this->bruecke($client, kontingent: 2);
+
+        self::assertInstanceOf(City::class, $bruecke->lookupCity('hamburg'));
+        self::assertInstanceOf(City::class, $bruecke->lookupCity('bremen'));
+        self::assertNull($bruecke->lookupCity('luebeck'), 'Die dritte Anfrage unterbleibt.');
+
+        self::assertSame(2, $client->getRequestsCount());
+    }
+
+    /**
+     * Nominatim verlangt eine Kennung, unter der man erreichbar ist -- eine
+     * blosse Versionsnummer erfuellt das nicht.
+     *
+     * Hier faengt eine Rueckruffunktion die Anfrage ab, statt eine fertige
+     * Antwort zu liefern: Nur so kommt man an die abgeschickten Kopfzeilen.
+     */
+    public function testWeIdentifyOurselvesToNominatim(): void
+    {
+        $gesehen = [];
+
+        $client = new MockHttpClient(static function (string $methode, string $url, array $optionen) use (&$gesehen): MockResponse {
+            $gesehen = ['methode' => $methode, 'url' => $url, 'kopfzeilen' => $optionen['headers'] ?? []];
+
+            return new MockResponse('[]', ['http_code' => 200]);
+        });
+
+        $this->bruecke($client)->lookupCity('hamburg');
+
+        $kennung = implode(' ', array_filter(
+            $gesehen['kopfzeilen'],
+            static fn (string $zeile): bool => str_starts_with(strtolower($zeile), 'user-agent:')
+        ));
+
+        self::assertStringContainsString('criticalmass.in', $kennung);
+        self::assertStringContainsString('https://', $kennung, 'Ohne Kontaktadresse ist die Kennung wertlos.');
+        self::assertStringContainsString('city=hamburg', $gesehen['url']);
+    }
+}


### PR DESCRIPTION
## Summary

Am 12.09.2026 standen drei neue 500er im Protokoll:

```
HTTP/2 429 returned for "https://nominatim.openstreetmap.org/search?city=work-here&…"
HTTP/2 429 returned for "https://nominatim.openstreetmap.org/search?city=work-for-us&…"
HTTP/2 429 returned for "https://nominatim.openstreetmap.org/search?city=positions&…"
```

`work-here`, `work-for-us`, `positions` sind keine Städte. Es sind die Pfade, die ein Crawler abklappert, wenn er Karriereseiten sucht.

**Die Route `/{citySlug}` (Priorität 100) fängt jeden unbekannten Pfad ab** und leitet an `MissingCityController` weiter, der bei Nominatim nachfragt. Jeder erfundene Pfad löst also eine Anfrage an OpenStreetMap aus. Nominatim hat uns irgendwann abgewiesen, und weil `lookupCity()` die Ausnahme nicht auffing, wurde daraus ein Serverfehler auf unserer Seite.

**Der 500er ist dabei das kleinere Übel.** Schwerer wiegt, dass jeder Unbeteiligte uns beliebig viele Anfragen an einen fremden Dienst schicken lassen konnte — auf unseren Namen, gegen dessen Nutzungsbedingungen, mit einem Bann als möglicher Folge. Nominatim nennt als Höchstmaß **eine Anfrage je Sekunde**; wir hatten oben keine Grenze.

## Was sich ändert

Drei Schranken, jede für sich ausreichend, damit die Seite steht:

| | |
|---|---|
| **Ratenbegrenzer** | Neuer Limiter `nominatim`, `token_bucket`, 60 Marken, Nachfüllrate 1/s — genau Nominatims Höchstmaß. Ist der Eimer leer, unterbleibt die Anfrage. |
| **Zwischenspeicher** | Neuer Pool `cache.nominatim`, eine Woche. Merkt sich auch die **leeren** Antworten — und gerade die, denn die unsinnigen Pfade wiederholen sich. |
| **Fehlerbehandlung** | `try/catch` auf `HttpClientException` → `null` statt Ausnahme, plus Protokollwarnung. Zusätzlich ein Zeitlimit von 5 s. |

Die Vorlage `CityManagement/missing.html.twig` kennt den Fall `city == null` längst und schreibt dann „wir konnten keine Stadt zu deiner Suche nach `…` finden". Es geht also nichts verloren — der Seitenbesucher sieht dieselbe Seite wie bei jeder anderen unbekannten Stadt.

Dazu eine Kennung, unter der wir erreichbar sind: `criticalmass.in (https://criticalmass.in/)` statt `criticalmass.in/1.0`. Nominatim verlangt eine identifizierbare Adresse, eine bloße Versionsnummer erfüllt das nicht.

## Test plan

- `tests/Criticalmass/OpenStreetMap/NominatimCityBridgeTest.php`, 8 Fälle mit `MockHttpClient`:
  - die drei Abfuhren aus dem Protokoll (429, 503, Zeitüberschreitung) → `null` statt Ausnahme
  - zweimal dieselbe Stadt → **eine** ausgehende Anfrage
  - zweimal derselbe unsinnige Pfad → ebenfalls **eine**
  - erschöpftes Kontingent → gar keine Anfrage mehr (2 Marken, 3 Aufrufe, 2 Anfragen)
  - die Kennung enthält Domain und Kontaktadresse
  - eine echte Stadt wird weiterhin gefunden
- 8/8 grün.
- `vendor/bin/phpstan analyse` über den **gesamten** Quelltext → keine Fehler. **Zwei Baseline-Einträge entfernt**, weil `createCity()` und `getCityNameFromResult()` jetzt ihre Typen nennen.
- `bin/console lint:yaml` über beide Konfigurationen → OK.
- Verdrahtung geprüft: `debug:container` zeigt `Service(cache.nominatim)` und `Service(limiter.nominatim)`.

## Was dieser PR nicht tut

Die eigentliche Merkwürdigkeit bleibt: **Ein anonymer Aufruf eines beliebigen Pfades löst eine ausgehende HTTP-Anfrage aus.** Sauberer wäre, die Seite ohne Vorschlag zu rendern und erst beim tatsächlichen Anlegen einer Stadt zu geokodieren — `CityManagementController` ruft `lookupCity()` ohnehin eigenständig auf (Zeilen 47 und 209). Das ist aber eine Änderung am Verhalten für Besucher und gehört nicht in einen Fehlerbehebungs-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)